### PR TITLE
Initial cargo-c conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,3 @@ libc = "0.2"
 rustls-native-certs = "0.5.0"
 sct = "0.6.0"
 rustls-pemfile = "0.2.0"
-
-[dev_dependencies]
-cbindgen = "*"
-
-[lib]
-name = "crustls"
-crate-type = ["staticlib"]

--- a/README.md
+++ b/README.md
@@ -8,17 +8,16 @@ to make an HTTPS request.
 
 You'll need to [install the Rust toolchain](https://rustup.rs/) and a C
 compiler (gcc and clang should both work). Once you've got the Rust toolchain
-installed, run `cargo install cbindgen`. Then, to build in debug mode:
+installed, run `cargo install cargo-c`. Then, to build in debug mode:
 
-    make
+    cargo cbuild
 
 To install:
 
-    make install
+    cargo cinstall --destdir /tmp/staging
+    sudo cp -a /tmp/staging /
 
-To build and install in optimized mode:
-
-    make PROFILE=release install
+By default `cargo cinstall` builds a release build.
 
 # Conventions
 


### PR DESCRIPTION
- [x] Remove the now-unneeded entries in Cargo.toml
- [x] Update the documentation 
- [ ] Port the tests to use `cargo ctest`

Addresses #11 