### PR TITLE
Fix msvc build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,14 @@ jobs:
           persist-credentials: false
       - run: make CC=${{ matrix.cc }} PROFILE=release test
 
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - run: make -f Makefile.Windows
+
   ensure-header-updated:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile.Windows
+++ b/Makefile.Windows
@@ -4,13 +4,13 @@
 #
 export CL=
 
-CRUSTLS_LIB = target/i686-pc-windows-msvc/release/crustls.lib
+CRUSTLS_LIB = target/release/crustls.lib
 
 USE_CLANG_CL ?= 1
 
 CFLAGS     = -nologo -MD -Zi -W3 -O2 -I. -Dssize_t=int -D_CRT_SECURE_NO_WARNINGS
 LDFLAGS    = -nologo -incremental:no
-CARGOFLAGS = --color never --release --target i686-pc-windows-msvc
+CARGOFLAGS = --color never --release
 
 ifeq ($(USE_CLANG_CL),1)
   CC = clang-cl

--- a/README.md
+++ b/README.md
@@ -176,7 +176,3 @@ For this to work, your connection needs to buffer the initial data from the
 client, so these bytes can be replayed to the second connection you use. Do not
 write any data back to the client while your are in the initial connection. The
 client hellos are usually only a few hundred bytes.
-
-
-
-

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -159,8 +159,10 @@ typedef struct rustls_client_config_builder rustls_client_config_builder;
 typedef struct rustls_connection rustls_connection;
 
 /**
- * An alias for `struct iovec` from uio.h. You should cast `const struct rustls_iovec *` to
- * `const struct iovec *`.
+ * An alias for `struct iovec` from uio.h (on Unix) or `WSABUF` on Windows. You should cast
+ * `const struct rustls_iovec *` to `const struct iovec *` on Unix, or `const *LPWSABUF`
+ * on Windows. See [`std::io::IoSlice`] for details on interoperability with platform
+ * specific vectored IO.
  */
 typedef struct rustls_iovec rustls_iovec;
 


### PR DESCRIPTION
PR#112 broke the Windows build because `rustls_write_vectored_callback`
is hidden behind `#[cfg(unix)]`. Rust's `std::io::IoSlice` should be
compatible with `wsasend` and `WSABUF` just as it is with `write(2)` and
`struct iovec`, so it should be safe to include this functionality in
Windows builds.

Additionally, this commit configures GitHub Actions to at least build on
Windows.

Closes #119