### PR TITLE
Fix typo in actual source code

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -347,7 +347,7 @@ pub extern "C" fn rustls_root_cert_store_free(store: *mut rustls_root_cert_store
 }
 
 /// A verifier of client certificates that requires all certificates to be
-/// trusted based on a given`rustls_root_cert_store`. Usable in building server
+/// trusted based on a given `rustls_root_cert_store`. Usable in building server
 /// configurations. Connections without such a client certificate will not
 /// be accepted.
 pub struct rustls_client_cert_verifier {


### PR DESCRIPTION
I was a bit too fast in merging #136, which fixes a typo in generated header code. In my defense, the generated code lives in `src`, which seems like a choice to maybe reconsider. (Maybe we should not keep the header file in the repo at all -- I also got confused by `make clean` not doing what I expected in this regard.)