### PR TITLE
enums.rs: fix constant naming

### DIFF
--- a/src/crustls.h
+++ b/src/crustls.h
@@ -97,7 +97,7 @@ typedef enum rustls_result {
  */
 typedef enum rustls_tls_version {
   RUSTLS_TLS_VERSION_SSLV2 = 512,
-  RUSTLS_TLS_VERSION_SSSLV3 = 768,
+  RUSTLS_TLS_VERSION_SSLV3 = 768,
   RUSTLS_TLS_VERSION_TLSV1_0 = 769,
   RUSTLS_TLS_VERSION_TLSV1_1 = 770,
   RUSTLS_TLS_VERSION_TLSV1_2 = 771,
@@ -121,7 +121,7 @@ typedef struct rustls_certified_key rustls_certified_key;
 
 /**
  * A verifier of client certificates that requires all certificates to be
- * trusted based on a given `rustls_root_cert_store`. Usable in building server
+ * trusted based on a given`rustls_root_cert_store`. Usable in building server
  * configurations. Connections without such a client certificate will not
  * be accepted.
  */

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -3,7 +3,7 @@
 /// Definitions of known TLS protocol versions.
 pub enum rustls_tls_version {
     Sslv2 = 0x0200,
-    Ssslv3 = 0x0300,
+    Sslv3 = 0x0300,
     Tlsv1_0 = 0x0301,
     Tlsv1_1 = 0x0302,
     Tlsv1_2 = 0x0303,


### PR DESCRIPTION
You want "SSLv3", not "SSSLv3". I can do a search to see if the latter
is being used anywhere currently; we could maintain backward
compatibility fairly easily.