### PR TITLE
lib: expose rustls_version as a rustls_str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
   - `rustls_version` returns a `rustls_str` that points to a static string in
-    memroy, and the function no longer accepts a character buffer or length.
+    memory, and the function no longer accepts a character buffer or length.
 
 ## 0.7.1 - 2021-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.8.0 (unreleased)
 
+### Changed
+
+  - `rustls_version` returns a `rustls_str` that points to a static string in
+    memroy, and the function no longer accepts a character buffer or length.
+
 ## 0.7.1 - 2021-06-29
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 links = "rustls_ffi"
 
 [dependencies]
-# Keep in sync with RUSTLS_CRATE_VERSION in lib.rs
+# Keep in sync with RUSTLS_CRATE_VERSION in build.rs
 rustls = { version = "=0.20", features = [ "dangerous_configuration" ] }
 webpki = "0.22"
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,10 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
 use std::{env, fs, path::PathBuf};
+
+// Keep in sync with Cargo.toml.
+const RUSTLS_CRATE_VERSION: &str = "0.19.0";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -8,4 +14,17 @@ fn main() {
     fs::copy("src/rustls.h", include_dir.join("rustls.h")).unwrap();
 
     println!("cargo:include={}", include_dir.to_str().unwrap());
+
+    let dest_path = Path::new("src/constants.rs");
+    let mut f = File::create(&dest_path).expect("Could not create file");
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    write!(
+        &mut f,
+        r#"pub const RUSTLS_FFI_VERSION: &'static str = "crustls/{}/rustls/{}";
+"#,
+        pkg_version, RUSTLS_CRATE_VERSION
+    )
+    .expect("Could not write file");
+
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,9 @@
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
 use std::{env, fs, path::PathBuf};
 
 // Keep in sync with Cargo.toml.
-const RUSTLS_CRATE_VERSION: &str = "0.19.0";
+const RUSTLS_CRATE_VERSION: &str = "0.20.0";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -15,12 +14,12 @@ fn main() {
 
     println!("cargo:include={}", include_dir.to_str().unwrap());
 
-    let dest_path = Path::new("src/constants.rs");
+    let dest_path = out_dir.join("version.rs");
     let mut f = File::create(&dest_path).expect("Could not create file");
     let pkg_version = env!("CARGO_PKG_VERSION");
     write!(
         &mut f,
-        r#"pub const RUSTLS_FFI_VERSION: &'static str = "crustls/{}/rustls/{}";
+        r#"const RUSTLS_FFI_VERSION: &'static str = "crustls/{}/rustls/{}";
 "#,
         pkg_version, RUSTLS_CRATE_VERSION
     )

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,1 +1,0 @@
-pub const RUSTLS_FFI_VERSION: &'static str = "crustls/0.7.1/rustls/0.19.0";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,1 @@
+pub const RUSTLS_FFI_VERSION: &'static str = "crustls/0.7.1/rustls/0.19.0";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ use std::thread::AccessError;
 pub mod cipher;
 pub mod client;
 pub mod connection;
-mod constants;
 pub mod enums;
 mod error;
 pub mod io;
@@ -24,6 +23,8 @@ pub use error::rustls_result;
 
 use crate::log::rustls_log_callback;
 use crate::panic::PanicOrDefault;
+
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
 // For C callbacks, we need to offer a `void *userdata` parameter, so the
 // application can associate callbacks with particular pieces of state. We
@@ -275,9 +276,6 @@ mod tests {
     }
 }
 
-// Keep in sync with Cargo.toml.
-const RUSTLS_CRATE_VERSION: &str = "0.20.0";
-
 /// CastPtr represents the relationship between a snake case type (like rustls_client_config)
 /// and the corresponding Rust type (like ClientConfig). For each matched pair of types, there
 /// should be an `impl CastPtr for foo_bar { RustTy = FooBar }`.
@@ -495,14 +493,14 @@ macro_rules! try_callback {
 /// and NUL terminated. Returns the number of bytes written before the NUL.
 #[no_mangle]
 pub extern "C" fn rustls_version() -> rustls_str<'static> {
-    return rustls_str::from_str_unchecked(crate::constants::RUSTLS_FFI_VERSION);
+    return rustls_str::from_str_unchecked(RUSTLS_FFI_VERSION);
 }
 
 #[test]
 fn test_rustls_version() {
     // very rough check that the version number is being interpolated into the
     // variable
-    assert!(crate::constants::RUSTLS_FFI_VERSION.contains("/0."));
+    assert!(RUSTLS_FFI_VERSION.contains("/0."));
     let vsn = rustls_version();
     assert!(vsn.len > 4)
 }

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -230,6 +230,24 @@ typedef struct rustls_slice_str rustls_slice_str;
 typedef struct rustls_supported_ciphersuite rustls_supported_ciphersuite;
 
 /**
+ * A read-only view on a Rust `&str`. The contents are guaranteed to be valid
+ * UTF-8. As an additional guarantee on top of Rust's normal UTF-8 guarantee,
+ * a `rustls_str` is guaranteed not to contain internal NUL bytes, so it is
+ * safe to interpolate into a C string or compare using strncmp. Keep in mind
+ * that it is not NUL-terminated.
+ *
+ * The memory exposed is available as specified by the function
+ * using this in its signature. For instance, when this is a parameter to a
+ * callback, the lifetime will usually be the duration of the callback.
+ * Functions that receive one of these must not dereference the data pointer
+ * beyond the allowed lifetime.
+ */
+typedef struct rustls_str {
+  const char *data;
+  size_t len;
+} rustls_str;
+
+/**
  * A read-only view on a Rust byte slice.
  *
  * This is used to pass data from crustls to callback functions provided
@@ -252,24 +270,6 @@ typedef struct rustls_slice_bytes {
  * rustls_client_config_builder_dangerous_set_certificate_verifier().
  */
 typedef void *rustls_verify_server_cert_user_data;
-
-/**
- * A read-only view on a Rust `&str`. The contents are guaranteed to be valid
- * UTF-8. As an additional guarantee on top of Rust's normal UTF-8 guarantee,
- * a `rustls_str` is guaranteed not to contain internal NUL bytes, so it is
- * safe to interpolate into a C string or compare using strncmp. Keep in mind
- * that it is not NUL-terminated.
- *
- * The memory exposed is available as specified by the function
- * using this in its signature. For instance, when this is a parameter to a
- * callback, the lifetime will usually be the duration of the callback.
- * Functions that receive one of these must not dereference the data pointer
- * beyond the allowed lifetime.
- */
-typedef struct rustls_str {
-  const char *data;
-  size_t len;
-} rustls_str;
 
 /**
  * Input to a custom certificate verifier callback. See
@@ -470,7 +470,7 @@ typedef enum rustls_result (*rustls_session_store_put_callback)(rustls_session_s
  * provided buffer, up to a max of `len` bytes. Output is UTF-8 encoded
  * and NUL terminated. Returns the number of bytes written before the NUL.
  */
-size_t rustls_version(char *buf, size_t len);
+struct rustls_str rustls_version(void);
 
 /**
  * Get the DER data of the certificate itself.


### PR DESCRIPTION
This simplifies the work of retrieving the rustls-ffi version in C
code, since you don't need to bring your own buffer and hope it is big
enough. Rust can return you a string that is compiled into the binary
and lives for the duration of the program.

To accomplish this, at build time, we write constants.rs with the
cargo version and the package version.

This also helps us achieve our goals of memory safety, by making
data available to C that is not vulnerable to use-after-free issues.

Fixes #148.