### PR TITLE
Fix client.c and server.c.

### DIFF
--- a/tests/common.c
+++ b/tests/common.c
@@ -206,6 +206,10 @@ bytevec_ensure_available(struct bytevec *vec, size_t n)
   return CRUSTLS_DEMO_OK;
 }
 
+/**
+ * Copy all available plaintext from rustls into our own buffer, growing
+ * our buffer as much as needed.
+ */
 int
 copy_plaintext_to_buffer(struct conndata *conn)
 {
@@ -234,6 +238,9 @@ copy_plaintext_to_buffer(struct conndata *conn)
       return CRUSTLS_DEMO_EOF;
     }
     bytevec_consume(&conn->data, n);
+    if(bytevec_ensure_available(&conn->data, 1024) != CRUSTLS_DEMO_OK) {
+      return CRUSTLS_DEMO_ERROR;
+    }
   }
 
   return CRUSTLS_DEMO_ERROR;

--- a/tests/server.c
+++ b/tests/server.c
@@ -144,7 +144,7 @@ send_response(struct conndata *conn)
   struct rustls_connection *rconn = conn->rconn;
   const char *prefix = "HTTP/1.1 200 OK\r\nContent-Length:";
   const int body_size = 10000;
-  const int response_size = strlen(prefix) + 10 + body_size;
+  const int response_size = strlen(prefix) + 15 + body_size;
   char *response = malloc(response_size);
   size_t n;
 

--- a/tests/server.c
+++ b/tests/server.c
@@ -142,8 +142,17 @@ enum crustls_demo_result
 send_response(struct conndata *conn)
 {
   struct rustls_connection *rconn = conn->rconn;
-  const char *response = "HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nhello\n";
+  const char *prefix = "HTTP/1.1 200 OK\r\nContent-Length:";
+  const int body_size = 10000;
+  const int response_size = strlen(prefix) + 20 + body_size;
+  char *response = malloc(response_size);
   size_t n;
+
+  n = sprintf(response, "%s %d\r\n\r\n", prefix, body_size);
+  memset(response + n, 'a', body_size);
+  *(response + n + body_size + 1) = '\0';
+  fprintf(stderr, "strlen response %ld\n", strlen(response));
+
   rustls_connection_write(
     rconn, (const uint8_t *)response, strlen(response), &n);
   if(n != strlen(response)) {
@@ -177,6 +186,12 @@ handle_conn(struct conndata *conn)
     if(rustls_connection_wants_write(rconn)) {
       FD_SET(sockfd, &write_fds);
     }
+
+    if(!rustls_connection_wants_read(rconn) && !rustls_connection_wants_write(rconn)) {
+      fprintf(stderr, "rustls wants neither read nor write. closing connection\n");
+      goto cleanup;
+    }
+
     tv.tv_sec = 1;
     tv.tv_usec = 0;
 
@@ -235,6 +250,7 @@ handle_conn(struct conndata *conn)
   fprintf(stderr, "handle_conn: loop fell through");
 
 cleanup:
+  fprintf(stderr, "closing socket %d\n", sockfd);
   if(sockfd > 0) {
     close(sockfd);
   }

--- a/tests/server.c
+++ b/tests/server.c
@@ -144,9 +144,14 @@ send_response(struct conndata *conn)
   struct rustls_connection *rconn = conn->rconn;
   const char *prefix = "HTTP/1.1 200 OK\r\nContent-Length:";
   const int body_size = 10000;
-  const int response_size = strlen(prefix) + 20 + body_size;
+  const int response_size = strlen(prefix) + 10 + body_size;
   char *response = malloc(response_size);
   size_t n;
+
+  if(response == NULL) {
+    fprintf(stderr, "failed malloc\n");
+    return CRUSTLS_DEMO_ERROR;
+  }
 
   n = sprintf(response, "%s %d\r\n\r\n", prefix, body_size);
   memset(response + n, 'a', body_size);


### PR DESCRIPTION
Some issues were introduced in v0.7.0.
If there was plaintext left in the buffers when the connection closed,
the client would call select with no FDs, and hang forever. In this
change, if we reach that state, we drain the remaining plaintext and
then write it stdout and exit.

Ensure copy_plaintext_to_buffer copies all available plaintext, even if
that requires growing the buffer multiple times.

On the server side, send larger responses, and exit the loop when
neither read nor write is wanted.

Remove unused copy_plaintext_to_stdout.