### PR TITLE
Make rustdoc rendered output better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### Fixed
 
- - rustls_connect_get_peer_certificate was returning a dangling pointer.
+ - rustls_connection_get_peer_certificate was returning a dangling pointer.
    This is now fixed by having it return a reference that lives as long
    as the connection does. (#103)
 

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -29,38 +29,25 @@ impl CastPtr for rustls_certificate {
     type RustType = Certificate;
 }
 
-/// Get the DER data of the certificate itself.
-/// The data is owned by the certificate and has the same lifetime.
-#[no_mangle]
-pub extern "C" fn rustls_certificate_get_der(
-    cert: *const rustls_certificate,
-    out_der_data: *mut *const u8,
-    out_der_len: *mut size_t,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let cert = try_ref_from_ptr!(cert);
-        let out_der_data: &mut *const u8 = try_mut_from_ptr!(out_der_data);
-        let out_der_len: &mut size_t = try_mut_from_ptr!(out_der_len);
-        let der = cert.as_ref();
-        *out_der_data = der.as_ptr();
-        *out_der_len = der.len();
-        rustls_result::Ok
+impl rustls_certificate {
+    /// Get the DER data of the certificate itself.
+    /// The data is owned by the certificate and has the same lifetime.
+    #[no_mangle]
+    pub extern "C" fn rustls_certificate_get_der(
+        cert: *const rustls_certificate,
+        out_der_data: *mut *const u8,
+        out_der_len: *mut size_t,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let cert = try_ref_from_ptr!(cert);
+            let out_der_data: &mut *const u8 = try_mut_from_ptr!(out_der_data);
+            let out_der_len: &mut size_t = try_mut_from_ptr!(out_der_len);
+            let der = cert.as_ref();
+            *out_der_data = der.as_ptr();
+            *out_der_len = der.len();
+            rustls_result::Ok
+        }
     }
-}
-
-/// The complete chain of certificates to send during a TLS handshake,
-/// plus a private key that matches the end-entity (leaf) certificate.
-/// Corresponds to `CertifiedKey` in the Rust API.
-/// https://docs.rs/rustls/0.20.0/rustls/sign/struct.CertifiedKey.html
-pub struct rustls_certified_key {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
-    _private: [u8; 0],
-}
-
-impl CastPtr for rustls_certified_key {
-    type RustType = CertifiedKey;
 }
 
 /// A cipher suite supported by rustls.
@@ -72,20 +59,22 @@ impl CastPtr for rustls_supported_ciphersuite {
     type RustType = SupportedCipherSuite;
 }
 
-/// Return a 16-bit unsigned integer corresponding to this cipher suite's assignment from
-/// <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>.
-/// The bytes from the assignment are interpreted in network order.
-#[no_mangle]
-pub extern "C" fn rustls_supported_ciphersuite_get_suite(
-    supported_ciphersuite: *const rustls_supported_ciphersuite,
-) -> u16 {
-    let supported_ciphersuite = try_ref_from_ptr!(supported_ciphersuite);
-    match supported_ciphersuite {
-        rustls::SupportedCipherSuite::Tls12(sc) => &sc.common,
-        rustls::SupportedCipherSuite::Tls13(sc) => &sc.common,
+impl rustls_supported_ciphersuite {
+    /// Return a 16-bit unsigned integer corresponding to this cipher suite's assignment from
+    /// <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>.
+    /// The bytes from the assignment are interpreted in network order.
+    #[no_mangle]
+    pub extern "C" fn rustls_supported_ciphersuite_get_suite(
+        supported_ciphersuite: *const rustls_supported_ciphersuite,
+    ) -> u16 {
+        let supported_ciphersuite = try_ref_from_ptr!(supported_ciphersuite);
+        match supported_ciphersuite {
+            rustls::SupportedCipherSuite::Tls12(sc) => &sc.common,
+            rustls::SupportedCipherSuite::Tls13(sc) => &sc.common,
+        }
+        .suite
+        .get_u16()
     }
-    .suite
-    .get_u16()
 }
 
 /// Return the length of rustls' list of supported cipher suites.
@@ -108,162 +97,180 @@ pub extern "C" fn rustls_all_ciphersuites_get_entry(
     }
 }
 
-/// Build a `rustls_certified_key` from a certificate chain and a private key.
-/// `cert_chain` must point to a buffer of `cert_chain_len` bytes, containing
-/// a series of PEM-encoded certificates, with the end-entity (leaf)
-/// certificate first.
-///
-/// `private_key` must point to a buffer of `private_key_len` bytes, containing
-/// a PEM-encoded private key in either PKCS#1 or PKCS#8 format.
-///
-/// On success, this writes a pointer to the newly created
-/// `rustls_certified_key` in `certified_key_out`. That pointer must later
-/// be freed with `rustls_certified_key_free` to avoid memory leaks. Note that
-/// internally, this is an atomically reference-counted pointer, so even after
-/// the original caller has called `rustls_certified_key_free`, other objects
-/// may retain a pointer to the object. The memory will be freed when all
-/// references are gone.
-#[no_mangle]
-pub extern "C" fn rustls_certified_key_build(
-    cert_chain: *const u8,
-    cert_chain_len: size_t,
-    private_key: *const u8,
-    private_key_len: size_t,
-    certified_key_out: *mut *const rustls_certified_key,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let certified_key_out: &mut *const rustls_certified_key = unsafe {
-            match certified_key_out.as_mut() {
-                Some(c) => c,
-                None => return NullParameter,
+/// The complete chain of certificates to send during a TLS handshake,
+/// plus a private key that matches the end-entity (leaf) certificate.
+/// Corresponds to `CertifiedKey` in the Rust API.
+/// https://docs.rs/rustls/0.20.0/rustls/sign/struct.CertifiedKey.html
+pub struct rustls_certified_key {
+    // We use the opaque struct pattern to tell C about our types without
+    // telling them what's inside.
+    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
+    _private: [u8; 0],
+}
+
+impl CastPtr for rustls_certified_key {
+    type RustType = CertifiedKey;
+}
+
+impl rustls_certified_key {
+    /// Build a `rustls_certified_key` from a certificate chain and a private key.
+    /// `cert_chain` must point to a buffer of `cert_chain_len` bytes, containing
+    /// a series of PEM-encoded certificates, with the end-entity (leaf)
+    /// certificate first.
+    ///
+    /// `private_key` must point to a buffer of `private_key_len` bytes, containing
+    /// a PEM-encoded private key in either PKCS#1 or PKCS#8 format.
+    ///
+    /// On success, this writes a pointer to the newly created
+    /// `rustls_certified_key` in `certified_key_out`. That pointer must later
+    /// be freed with `rustls_certified_key_free` to avoid memory leaks. Note that
+    /// internally, this is an atomically reference-counted pointer, so even after
+    /// the original caller has called `rustls_certified_key_free`, other objects
+    /// may retain a pointer to the object. The memory will be freed when all
+    /// references are gone.
+    #[no_mangle]
+    pub extern "C" fn rustls_certified_key_build(
+        cert_chain: *const u8,
+        cert_chain_len: size_t,
+        private_key: *const u8,
+        private_key_len: size_t,
+        certified_key_out: *mut *const rustls_certified_key,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let certified_key_out: &mut *const rustls_certified_key = unsafe {
+                match certified_key_out.as_mut() {
+                    Some(c) => c,
+                    None => return NullParameter,
+                }
+            };
+            let certified_key = match rustls_certified_key::certified_key_build(
+                cert_chain, cert_chain_len, private_key, private_key_len) {
+                Ok(key) => Box::new(key),
+                Err(rr) => return rr,
+            };
+            let certified_key = Arc::into_raw(Arc::new(*certified_key)) as *const _;
+            *certified_key_out = certified_key;
+            return rustls_result::Ok
+        }
+    }
+
+    /// Return the i-th rustls_certificate in the rustls_certified_key. 0 gives the
+    /// end-entity certificate. 1 and higher give certificates from the chain.
+    /// Indexes higher the the last available certificate return NULL.
+    ///
+    /// The returned certificate is valid until the rustls_certified_key is freed.
+    #[no_mangle]
+    pub extern "C" fn rustls_certified_key_get_certificate(
+        certified_key: *const rustls_certified_key,
+        i: size_t,
+    ) -> *const rustls_certificate {
+        ffi_panic_boundary! {
+            let certified_key: &CertifiedKey = try_ref_from_ptr!(certified_key);
+            match certified_key.cert.get(i) {
+                Some(cert) => cert as *const Certificate as *const _,
+                None => null()
+            }
+        }
+    }
+
+    /// Create a copy of the rustls_certified_key with the given OCSP response data
+    /// as DER encoded bytes. The OCSP response may be given as NULL to clear any
+    /// possibly present OCSP data from the cloned key.
+    /// The cloned key is independent from its original and needs to be freed
+    /// by the application.
+    #[no_mangle]
+    pub extern "C" fn rustls_certified_key_clone_with_ocsp(
+        certified_key: *const rustls_certified_key,
+        ocsp_response: *const rustls_slice_bytes,
+        cloned_key_out: *mut *const rustls_certified_key,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let cloned_key_out: &mut *const rustls_certified_key = unsafe {
+                match cloned_key_out.as_mut() {
+                    Some(c) => c,
+                    None => return NullParameter,
+                }
+            };
+            let certified_key: &CertifiedKey = try_ref_from_ptr!(certified_key);
+            let mut new_key = certified_key.deref().clone();
+            if !ocsp_response.is_null() {
+                let ocsp_slice = unsafe{ &*ocsp_response };
+                new_key.ocsp = Some(Vec::from(try_slice!(ocsp_slice.data, ocsp_slice.len)));
+            } else {
+                new_key.ocsp = None;
+            }
+            *cloned_key_out = Arc::into_raw(Arc::new(new_key)) as *const _;
+            return rustls_result::Ok
+        }
+    }
+
+    /// "Free" a certified_key previously returned from
+    /// rustls_certified_key_build. Since certified_key is actually an
+    /// atomically reference-counted pointer, extant certified_key may still
+    /// hold an internal reference to the Rust object. However, C code must
+    /// consider this pointer unusable after "free"ing it.
+    /// Calling with NULL is fine. Must not be called twice with the same value.
+    #[no_mangle]
+    pub extern "C" fn rustls_certified_key_free(key: *const rustls_certified_key) {
+        ffi_panic_boundary! {
+            if key.is_null() {
+                return;
+            }
+            // To free the certified_key, we reconstruct the Arc. It should have a refcount of 1,
+            // representing the C code's copy. When it drops, that refcount will go down to 0
+            // and the inner ServerConfig will be dropped.
+            unsafe { drop(Arc::from_raw(key)) };
+        }
+    }
+
+    fn certified_key_build(
+        cert_chain: *const u8,
+        cert_chain_len: size_t,
+        private_key: *const u8,
+        private_key_len: size_t,
+    ) -> Result<CertifiedKey, rustls_result> {
+        let mut cert_chain: &[u8] = unsafe {
+            if cert_chain.is_null() {
+                return Err(NullParameter);
+            }
+            slice::from_raw_parts(cert_chain, cert_chain_len as usize)
+        };
+        let private_key: &[u8] = unsafe {
+            if private_key.is_null() {
+                return Err(NullParameter);
+            }
+            slice::from_raw_parts(private_key, private_key_len as usize)
+        };
+        let mut private_keys: Vec<Vec<u8>> = match pkcs8_private_keys(&mut Cursor::new(private_key))
+        {
+            Ok(v) => v,
+            Err(_) => return Err(rustls_result::PrivateKeyParseError),
+        };
+        let private_key: PrivateKey = match private_keys.pop() {
+            Some(p) => PrivateKey(p),
+            None => {
+                private_keys = match rsa_private_keys(&mut Cursor::new(private_key)) {
+                    Ok(v) => v,
+                    Err(_) => return Err(rustls_result::PrivateKeyParseError),
+                };
+                let rsa_private_key: PrivateKey = match private_keys.pop() {
+                    Some(p) => PrivateKey(p),
+                    None => return Err(rustls_result::PrivateKeyParseError),
+                };
+                rsa_private_key
             }
         };
-        let certified_key = match certified_key_build(
-            cert_chain, cert_chain_len, private_key, private_key_len) {
-            Ok(key) => Box::new(key),
-            Err(rr) => return rr,
+        let signing_key = match rustls::sign::any_supported_type(&private_key) {
+            Ok(key) => key,
+            Err(_) => return Err(rustls_result::PrivateKeyParseError),
         };
-        let certified_key = Arc::into_raw(Arc::new(*certified_key)) as *const _;
-        *certified_key_out = certified_key;
-        return rustls_result::Ok
-    }
-}
-
-/// Return the i-th rustls_certificate in the rustls_certified_key. 0 gives the
-/// end-entity certificate. 1 and higher give certificates from the chain.
-/// Indexes higher the the last available certificate return NULL.
-///
-/// The returned certificate is valid until the rustls_certified_key is freed.
-#[no_mangle]
-pub extern "C" fn rustls_certified_key_get_certificate(
-    certified_key: *const rustls_certified_key,
-    i: size_t,
-) -> *const rustls_certificate {
-    ffi_panic_boundary! {
-        let certified_key: &CertifiedKey = try_ref_from_ptr!(certified_key);
-        match certified_key.cert.get(i) {
-            Some(cert) => cert as *const Certificate as *const _,
-            None => null()
-        }
-    }
-}
-
-/// Create a copy of the rustls_certified_key with the given OCSP response data
-/// as DER encoded bytes. The OCSP response may be given as NULL to clear any
-/// possibly present OCSP data from the cloned key.
-/// The cloned key is independent from its original and needs to be freed
-/// by the application.
-#[no_mangle]
-pub extern "C" fn rustls_certified_key_clone_with_ocsp(
-    certified_key: *const rustls_certified_key,
-    ocsp_response: *const rustls_slice_bytes,
-    cloned_key_out: *mut *const rustls_certified_key,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let cloned_key_out: &mut *const rustls_certified_key = unsafe {
-            match cloned_key_out.as_mut() {
-                Some(c) => c,
-                None => return NullParameter,
-            }
+        let parsed_chain: Vec<Certificate> = match certs(&mut cert_chain) {
+            Ok(v) => v.into_iter().map(Certificate).collect(),
+            Err(_) => return Err(rustls_result::CertificateParseError),
         };
-        let certified_key: &CertifiedKey = try_ref_from_ptr!(certified_key);
-        let mut new_key = certified_key.deref().clone();
-        if !ocsp_response.is_null() {
-            let ocsp_slice = unsafe{ &*ocsp_response };
-            new_key.ocsp = Some(Vec::from(try_slice!(ocsp_slice.data, ocsp_slice.len)));
-        } else {
-            new_key.ocsp = None;
-        }
-        *cloned_key_out = Arc::into_raw(Arc::new(new_key)) as *const _;
-        return rustls_result::Ok
+
+        Ok(rustls::sign::CertifiedKey::new(parsed_chain, signing_key))
     }
-}
-
-/// "Free" a certified_key previously returned from
-/// rustls_certified_key_build. Since certified_key is actually an
-/// atomically reference-counted pointer, extant certified_key may still
-/// hold an internal reference to the Rust object. However, C code must
-/// consider this pointer unusable after "free"ing it.
-/// Calling with NULL is fine. Must not be called twice with the same value.
-#[no_mangle]
-pub extern "C" fn rustls_certified_key_free(key: *const rustls_certified_key) {
-    ffi_panic_boundary! {
-        if key.is_null() {
-            return;
-        }
-        // To free the certified_key, we reconstruct the Arc. It should have a refcount of 1,
-        // representing the C code's copy. When it drops, that refcount will go down to 0
-        // and the inner ServerConfig will be dropped.
-        unsafe { drop(Arc::from_raw(key)) };
-    }
-}
-
-fn certified_key_build(
-    cert_chain: *const u8,
-    cert_chain_len: size_t,
-    private_key: *const u8,
-    private_key_len: size_t,
-) -> Result<CertifiedKey, rustls_result> {
-    let mut cert_chain: &[u8] = unsafe {
-        if cert_chain.is_null() {
-            return Err(NullParameter);
-        }
-        slice::from_raw_parts(cert_chain, cert_chain_len as usize)
-    };
-    let private_key: &[u8] = unsafe {
-        if private_key.is_null() {
-            return Err(NullParameter);
-        }
-        slice::from_raw_parts(private_key, private_key_len as usize)
-    };
-    let mut private_keys: Vec<Vec<u8>> = match pkcs8_private_keys(&mut Cursor::new(private_key)) {
-        Ok(v) => v,
-        Err(_) => return Err(rustls_result::PrivateKeyParseError),
-    };
-    let private_key: PrivateKey = match private_keys.pop() {
-        Some(p) => PrivateKey(p),
-        None => {
-            private_keys = match rsa_private_keys(&mut Cursor::new(private_key)) {
-                Ok(v) => v,
-                Err(_) => return Err(rustls_result::PrivateKeyParseError),
-            };
-            let rsa_private_key: PrivateKey = match private_keys.pop() {
-                Some(p) => PrivateKey(p),
-                None => return Err(rustls_result::PrivateKeyParseError),
-            };
-            rsa_private_key
-        }
-    };
-    let signing_key = match rustls::sign::any_supported_type(&private_key) {
-        Ok(key) => key,
-        Err(_) => return Err(rustls_result::PrivateKeyParseError),
-    };
-    let parsed_chain: Vec<Certificate> = match certs(&mut cert_chain) {
-        Ok(v) => v.into_iter().map(Certificate).collect(),
-        Err(_) => return Err(rustls_result::CertificateParseError),
-    };
-
-    Ok(rustls::sign::CertifiedKey::new(parsed_chain, signing_key))
 }
 
 /// A root cert store that is done being constructed and is now read-only.
@@ -280,68 +287,70 @@ impl CastPtr for rustls_root_cert_store {
     type RustType = RootCertStore;
 }
 
-/// Create a rustls_root_cert_store. Caller owns the memory and must
-/// eventually call rustls_root_cert_store_free. The store starts out empty.
-/// Caller must add root certificates with rustls_root_cert_store_add_pem.
-/// https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html#method.empty
-#[no_mangle]
-pub extern "C" fn rustls_root_cert_store_new() -> *mut rustls_root_cert_store {
-    ffi_panic_boundary! {
-        let store = rustls::RootCertStore::empty();
-        let s = Box::new(store);
-        Box::into_raw(s) as *mut _
-    }
-}
-
-/// Add one or more certificates to the root cert store using PEM encoded data.
-///
-/// When `strict` is true an error will return a `CertificateParseError`
-/// result. So will an attempt to parse data that has zero certificates.
-
-/// When `strict` is false, unparseable root certificates will be ignored.
-/// This may be useful on systems that have syntactically invalid root
-/// certificates.
-#[no_mangle]
-pub extern "C" fn rustls_root_cert_store_add_pem(
-    store: *mut rustls_root_cert_store,
-    pem: *const u8,
-    pem_len: size_t,
-    strict: bool,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let certs_pem: &[u8] = try_slice!(pem, pem_len);
-        let store: &mut RootCertStore = try_mut_from_ptr!(store);
-
-        let certs_der = match rustls_pemfile::certs(&mut Cursor::new(certs_pem)) {
-            Ok(vv) => vv,
-            Err(_) => return rustls_result::CertificateParseError,
-        };
-        // We first copy into a temporary root store so we can uphold our
-        // API guideline that there are no partial failures or partial
-        // successes.
-        let mut new_store = RootCertStore::empty();
-        let (parsed, rejected) = new_store.add_parsable_certificates(&certs_der);
-        if strict && (rejected > 0 || parsed == 0) {
-            return rustls_result::CertificateParseError;
+impl rustls_root_cert_store {
+    /// Create a rustls_root_cert_store. Caller owns the memory and must
+    /// eventually call rustls_root_cert_store_free. The store starts out empty.
+    /// Caller must add root certificates with rustls_root_cert_store_add_pem.
+    /// https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html#method.empty
+    #[no_mangle]
+    pub extern "C" fn rustls_root_cert_store_new() -> *mut rustls_root_cert_store {
+        ffi_panic_boundary! {
+            let store = rustls::RootCertStore::empty();
+            let s = Box::new(store);
+            Box::into_raw(s) as *mut _
         }
-
-        store.roots.append(&mut new_store.roots);
-        rustls_result::Ok
     }
-}
 
-/// "Free" a rustls_root_cert_store previously returned from
-/// rustls_root_cert_store_builder_build. Since rustls_root_cert_store is actually an
-/// atomically reference-counted pointer, extant rustls_root_cert_store may still
-/// hold an internal reference to the Rust object. However, C code must
-/// consider this pointer unusable after "free"ing it.
-/// Calling with NULL is fine. Must not be called twice with the same value.
-#[no_mangle]
-pub extern "C" fn rustls_root_cert_store_free(store: *mut rustls_root_cert_store) {
-    ffi_panic_boundary! {
-        let store: &mut RootCertStore = try_mut_from_ptr!(store);
-        // Convert the pointer to a Box and drop it.
-        unsafe { drop(Box::from_raw(store)) }
+    /// Add one or more certificates to the root cert store using PEM encoded data.
+    ///
+    /// When `strict` is true an error will return a `CertificateParseError`
+    /// result. So will an attempt to parse data that has zero certificates.
+
+    /// When `strict` is false, unparseable root certificates will be ignored.
+    /// This may be useful on systems that have syntactically invalid root
+    /// certificates.
+    #[no_mangle]
+    pub extern "C" fn rustls_root_cert_store_add_pem(
+        store: *mut rustls_root_cert_store,
+        pem: *const u8,
+        pem_len: size_t,
+        strict: bool,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let certs_pem: &[u8] = try_slice!(pem, pem_len);
+            let store: &mut RootCertStore = try_mut_from_ptr!(store);
+
+            let certs_der = match rustls_pemfile::certs(&mut Cursor::new(certs_pem)) {
+                Ok(vv) => vv,
+                Err(_) => return rustls_result::CertificateParseError,
+            };
+            // We first copy into a temporary root store so we can uphold our
+            // API guideline that there are no partial failures or partial
+            // successes.
+            let mut new_store = RootCertStore::empty();
+            let (parsed, rejected) = new_store.add_parsable_certificates(&certs_der);
+            if strict && (rejected > 0 || parsed == 0) {
+                return rustls_result::CertificateParseError;
+            }
+
+            store.roots.append(&mut new_store.roots);
+            rustls_result::Ok
+        }
+    }
+
+    /// "Free" a rustls_root_cert_store previously returned from
+    /// rustls_root_cert_store_builder_build. Since rustls_root_cert_store is actually an
+    /// atomically reference-counted pointer, extant rustls_root_cert_store may still
+    /// hold an internal reference to the Rust object. However, C code must
+    /// consider this pointer unusable after "free"ing it.
+    /// Calling with NULL is fine. Must not be called twice with the same value.
+    #[no_mangle]
+    pub extern "C" fn rustls_root_cert_store_free(store: *mut rustls_root_cert_store) {
+        ffi_panic_boundary! {
+            let store: &mut RootCertStore = try_mut_from_ptr!(store);
+            // Convert the pointer to a Box and drop it.
+            unsafe { drop(Box::from_raw(store)) }
+        }
     }
 }
 
@@ -357,34 +366,38 @@ impl CastPtr for rustls_client_cert_verifier {
     type RustType = AllowAnyAuthenticatedClient;
 }
 
-/// Create a new client certificate verifier for the root store. The verifier
-/// can be used in several rustls_server_config instances. Must be freed by
-/// the application when no longer needed. See the documentation of
-/// rustls_client_cert_verifier_free for details about lifetime.
-#[no_mangle]
-pub extern "C" fn rustls_client_cert_verifier_new(
-    store: *mut rustls_root_cert_store,
-) -> *const rustls_client_cert_verifier {
-    let store: &mut RootCertStore = try_mut_from_ptr!(store);
-    return Arc::into_raw(AllowAnyAuthenticatedClient::new(store.clone())) as *const _;
-}
+impl rustls_client_cert_verifier {
+    /// Create a new client certificate verifier for the root store. The verifier
+    /// can be used in several rustls_server_config instances. Must be freed by
+    /// the application when no longer needed. See the documentation of
+    /// rustls_client_cert_verifier_free for details about lifetime.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_cert_verifier_new(
+        store: *mut rustls_root_cert_store,
+    ) -> *const rustls_client_cert_verifier {
+        let store: &mut RootCertStore = try_mut_from_ptr!(store);
+        return Arc::into_raw(AllowAnyAuthenticatedClient::new(store.clone())) as *const _;
+    }
 
-/// "Free" a verifier previously returned from
-/// rustls_client_cert_verifier_new. Since rustls_client_cert_verifier is actually an
-/// atomically reference-counted pointer, extant server_configs may still
-/// hold an internal reference to the Rust object. However, C code must
-/// consider this pointer unusable after "free"ing it.
-/// Calling with NULL is fine. Must not be called twice with the same value.
-#[no_mangle]
-pub extern "C" fn rustls_client_cert_verifier_free(verifier: *const rustls_client_cert_verifier) {
-    ffi_panic_boundary! {
-        if verifier.is_null() {
-            return;
+    /// "Free" a verifier previously returned from
+    /// rustls_client_cert_verifier_new. Since rustls_client_cert_verifier is actually an
+    /// atomically reference-counted pointer, extant server_configs may still
+    /// hold an internal reference to the Rust object. However, C code must
+    /// consider this pointer unusable after "free"ing it.
+    /// Calling with NULL is fine. Must not be called twice with the same value.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_cert_verifier_free(
+        verifier: *const rustls_client_cert_verifier,
+    ) {
+        ffi_panic_boundary! {
+            if verifier.is_null() {
+                return;
+            }
+            // To free the verifier, we reconstruct the Arc. It should have a refcount of 1,
+            // representing the C code's copy. When it drops, that refcount will go down to 0
+            // and the inner object will be dropped.
+            unsafe { drop(Arc::from_raw(verifier)) };
         }
-        // To free the verifier, we reconstruct the Arc. It should have a refcount of 1,
-        // representing the C code's copy. When it drops, that refcount will go down to 0
-        // and the inner object will be dropped.
-        unsafe { drop(Arc::from_raw(verifier)) };
     }
 }
 
@@ -394,7 +407,7 @@ pub extern "C" fn rustls_client_cert_verifier_free(verifier: *const rustls_clien
 /// does not offer a certificate, the connection will succeed.
 ///
 /// The application can retrieve the certificate, if any, with
-/// rustls_server_session_get_peer_certificate.
+/// rustls_connection_peer_certificate.
 pub struct rustls_client_cert_verifier_optional {
     _private: [u8; 0],
 }
@@ -403,35 +416,38 @@ impl CastPtr for rustls_client_cert_verifier_optional {
     type RustType = AllowAnyAnonymousOrAuthenticatedClient;
 }
 
-/// Create a new rustls_client_cert_verifier_optional for the root store. The
-/// verifier can be used in several rustls_server_config instances. Must be
-/// freed by the application when no longer needed. See the documentation of
-/// rustls_client_cert_verifier_optional_free for details about lifetime.
-#[no_mangle]
-pub extern "C" fn rustls_client_cert_verifier_optional_new(
-    store: *mut rustls_root_cert_store,
-) -> *const rustls_client_cert_verifier_optional {
-    let store: &mut RootCertStore = try_mut_from_ptr!(store);
-    return Arc::into_raw(AllowAnyAnonymousOrAuthenticatedClient::new(store.clone())) as *const _;
-}
+impl rustls_client_cert_verifier_optional {
+    /// Create a new rustls_client_cert_verifier_optional for the root store. The
+    /// verifier can be used in several rustls_server_config instances. Must be
+    /// freed by the application when no longer needed. See the documentation of
+    /// rustls_client_cert_verifier_optional_free for details about lifetime.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_cert_verifier_optional_new(
+        store: *mut rustls_root_cert_store,
+    ) -> *const rustls_client_cert_verifier_optional {
+        let store: &mut RootCertStore = try_mut_from_ptr!(store);
+        return Arc::into_raw(AllowAnyAnonymousOrAuthenticatedClient::new(store.clone()))
+            as *const _;
+    }
 
-/// "Free" a verifier previously returned from
-/// rustls_client_cert_verifier_optional_new. Since rustls_client_cert_verifier_optional
-/// is actually an atomically reference-counted pointer, extant server_configs may still
-/// hold an internal reference to the Rust object. However, C code must
-/// consider this pointer unusable after "free"ing it.
-/// Calling with NULL is fine. Must not be called twice with the same value.
-#[no_mangle]
-pub extern "C" fn rustls_client_cert_verifier_optional_free(
-    verifier: *const rustls_client_cert_verifier_optional,
-) {
-    ffi_panic_boundary! {
-        if verifier.is_null() {
-            return;
+    /// "Free" a verifier previously returned from
+    /// rustls_client_cert_verifier_optional_new. Since rustls_client_cert_verifier_optional
+    /// is actually an atomically reference-counted pointer, extant server_configs may still
+    /// hold an internal reference to the Rust object. However, C code must
+    /// consider this pointer unusable after "free"ing it.
+    /// Calling with NULL is fine. Must not be called twice with the same value.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_cert_verifier_optional_free(
+        verifier: *const rustls_client_cert_verifier_optional,
+    ) {
+        ffi_panic_boundary! {
+            if verifier.is_null() {
+                return;
+            }
+            // To free the verifier, we reconstruct the Arc. It should have a refcount of 1,
+            // representing the C code's copy. When it drops, that refcount will go down to 0
+            // and the inner object will be dropped.
+            unsafe { drop(Arc::from_raw(verifier)) };
         }
-        // To free the verifier, we reconstruct the Arc. It should have a refcount of 1,
-        // representing the C code's copy. When it drops, that refcount will go down to 0
-        // and the inner object will be dropped.
-        unsafe { drop(Arc::from_raw(verifier)) };
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -68,75 +68,77 @@ impl CastPtr for rustls_client_config {
     type RustType = ClientConfig;
 }
 
-/// Create a rustls_client_config_builder. Caller owns the memory and must
-/// eventually call rustls_client_config_builder_build, then free the
-/// resulting rustls_client_config.
-/// This uses rustls safe default values
-/// for the cipher suites, key exchange groups and protocol versions.
-/// This starts out with no trusted roots.
-/// Caller must add roots with rustls_client_config_builder_load_roots_from_file
-/// or provide a custom verifier.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_new_with_safe_defaults(
-) -> *mut rustls_client_config_builder_wants_verifier {
-    ffi_panic_boundary! {
-        let builder = rustls::ClientConfig::builder().with_safe_defaults();
-        BoxCastPtr::to_mut_ptr(builder)
+impl rustls_client_config_builder {
+    /// Create a rustls_client_config_builder. Caller owns the memory and must
+    /// eventually call rustls_client_config_builder_build, then free the
+    /// resulting rustls_client_config.
+    /// This uses rustls safe default values
+    /// for the cipher suites, key exchange groups and protocol versions.
+    /// This starts out with no trusted roots.
+    /// Caller must add roots with rustls_client_config_builder_load_roots_from_file
+    /// or provide a custom verifier.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_new_with_safe_defaults(
+    ) -> *mut rustls_client_config_builder_wants_verifier {
+        ffi_panic_boundary! {
+            let builder = rustls::ClientConfig::builder().with_safe_defaults();
+            BoxCastPtr::to_mut_ptr(builder)
+        }
     }
-}
 
-/// Create a rustls_client_config_builder. Caller owns the memory and must
-/// eventually call rustls_client_config_builder_build, then free the
-/// resulting rustls_client_config. Specify cipher suites in preference order;
-/// the `cipher_suites` parameter must point to an array containing `len`
-/// pointers to `rustls_supported_ciphersuite` previously obtained from
-/// `rustls_all_ciphersuites_get()`. Set the TLS protocol versions to use
-/// when negotiating a TLS session.
-///
-/// `tls_version` is the version of the protocol, as defined in rfc8446,
-/// ch. 4.2.1 and end of ch. 5.1. Some values are defined in
-/// `rustls_tls_version` for convenience.
-///
-/// `versions` will only be used during the call and the application retains
-/// ownership. `len` is the number of consecutive `ui16` pointed to by `versions`.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_new(
-    cipher_suites: *const *const rustls_supported_ciphersuite,
-    cipher_suites_len: size_t,
-    tls_versions: *const u16,
-    tls_versions_len: size_t,
-    builder: *mut *mut rustls_client_config_builder_wants_verifier,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let cipher_suites: &[*const rustls_supported_ciphersuite] = try_slice!(cipher_suites, cipher_suites_len);
-        let mut cs_vec: Vec<SupportedCipherSuite> = Vec::new();
-        for &cs in cipher_suites.into_iter() {
-            let cs = try_ref_from_ptr!(cs);
-            match ALL_CIPHER_SUITES.iter().find(|&acs| cs.eq(acs)) {
-                Some(scs) => cs_vec.push(scs.clone()),
-                None => return InvalidParameter,
+    /// Create a rustls_client_config_builder. Caller owns the memory and must
+    /// eventually call rustls_client_config_builder_build, then free the
+    /// resulting rustls_client_config. Specify cipher suites in preference order;
+    /// the `cipher_suites` parameter must point to an array containing `len`
+    /// pointers to `rustls_supported_ciphersuite` previously obtained from
+    /// `rustls_all_ciphersuites_get()`. Set the TLS protocol versions to use
+    /// when negotiating a TLS session.
+    ///
+    /// `tls_version` is the version of the protocol, as defined in rfc8446,
+    /// ch. 4.2.1 and end of ch. 5.1. Some values are defined in
+    /// `rustls_tls_version` for convenience.
+    ///
+    /// `versions` will only be used during the call and the application retains
+    /// ownership. `len` is the number of consecutive `ui16` pointed to by `versions`.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_new(
+        cipher_suites: *const *const rustls_supported_ciphersuite,
+        cipher_suites_len: size_t,
+        tls_versions: *const u16,
+        tls_versions_len: size_t,
+        builder: *mut *mut rustls_client_config_builder_wants_verifier,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let cipher_suites: &[*const rustls_supported_ciphersuite] = try_slice!(cipher_suites, cipher_suites_len);
+            let mut cs_vec: Vec<SupportedCipherSuite> = Vec::new();
+            for &cs in cipher_suites.into_iter() {
+                let cs = try_ref_from_ptr!(cs);
+                match ALL_CIPHER_SUITES.iter().find(|&acs| cs.eq(acs)) {
+                    Some(scs) => cs_vec.push(scs.clone()),
+                    None => return InvalidParameter,
+                }
             }
-        }
 
-        let tls_versions: &[u16] = try_slice!(tls_versions, tls_versions_len);
-        let mut versions = vec![];
-        for version_number in tls_versions {
-            let proto = ProtocolVersion::from(*version_number);
-            if proto == rustls::version::TLS12.version {
-                versions.push(&rustls::version::TLS12);
-            } else if proto == rustls::version::TLS13.version {
-                versions.push(&rustls::version::TLS13);
+            let tls_versions: &[u16] = try_slice!(tls_versions, tls_versions_len);
+            let mut versions = vec![];
+            for version_number in tls_versions {
+                let proto = ProtocolVersion::from(*version_number);
+                if proto == rustls::version::TLS12.version {
+                    versions.push(&rustls::version::TLS12);
+                } else if proto == rustls::version::TLS13.version {
+                    versions.push(&rustls::version::TLS13);
+                }
             }
+
+            let result = rustls::ClientConfig::builder().with_cipher_suites(&cs_vec).with_safe_default_kx_groups().with_protocol_versions(&versions);
+            let new = match result {
+                Ok(new) => new,
+                Err(_) => return rustls_result::InvalidParameter,
+            };
+
+            BoxCastPtr::set_mut_ptr(builder, new);
+            rustls_result::Ok
         }
-
-        let result = rustls::ClientConfig::builder().with_cipher_suites(&cs_vec).with_safe_default_kx_groups().with_protocol_versions(&versions);
-        let new = match result {
-            Ok(new) => new,
-            Err(_) => return rustls_result::InvalidParameter,
-        };
-
-        BoxCastPtr::set_mut_ptr(builder, new);
-        rustls_result::Ok
     }
 }
 
@@ -154,14 +156,14 @@ pub struct rustls_verify_server_cert_params<'a> {
 /// User-provided input to a custom certificate verifier callback. See
 /// rustls_client_config_builder_dangerous_set_certificate_verifier().
 #[allow(non_camel_case_types)]
-type rustls_verify_server_cert_user_data = *mut libc::c_void;
+pub type rustls_verify_server_cert_user_data = *mut libc::c_void;
 
 // According to the nomicon https://doc.rust-lang.org/nomicon/ffi.html#the-nullable-pointer-optimization):
 // > Option<extern "C" fn(c_int) -> c_int> is a correct way to represent a
 // > nullable function pointer using the C ABI (corresponding to the C type int (*)(int)).
 // So we use Option<...> here. This is the type that is passed from C code.
 #[allow(non_camel_case_types)]
-type rustls_verify_server_cert_callback = Option<
+pub type rustls_verify_server_cert_callback = Option<
     unsafe extern "C" fn(
         userdata: rustls_verify_server_cert_user_data,
         params: *const rustls_verify_server_cert_params,
@@ -237,220 +239,222 @@ impl rustls::client::ServerCertVerifier for Verifier {
     }
 }
 
-/// Set a custom server certificate verifier.
-///
-/// The callback must not capture any of the pointers in its
-/// rustls_verify_server_cert_params.
-/// If `userdata` has been set with rustls_connection_set_userdata, it
-/// will be passed to the callback. Otherwise the userdata param passed to
-/// the callback will be NULL.
-///
-/// The callback must be safe to call on any thread at any time, including
-/// multiple concurrent calls. So, for instance, if the callback mutates
-/// userdata (or other shared state), it must use synchronization primitives
-/// to make such mutation safe.
-///
-/// The callback receives certificate chain information as raw bytes.
-/// Currently this library offers no functions for C code to parse the
-/// certificates, so you'll need to bring your own certificate parsing library
-/// if you need to parse them.
-///
-/// If you intend to write a verifier that accepts all certificates, be aware
-/// that special measures are required for IP addresses. Rustls currently
-/// (0.20.0) doesn't support building a ClientSession with an IP address
-/// (because it's not a valid DnsNameRef). One workaround is to detect IP
-/// addresses and rewrite them to `example.invalid`, and _also_ to disable
-/// SNI via rustls_client_config_builder_set_enable_sni (IP addresses don't
-/// need SNI).
-///
-/// If the custom verifier accepts the certificate, it should return
-/// RUSTLS_RESULT_OK. Otherwise, it may return any other rustls_result error.
-/// Feel free to use an appropriate error from the RUSTLS_RESULT_CERT_*
-/// section.
-///
-/// https://docs.rs/rustls/0.20.0/rustls/client/struct.DangerousClientConfig.html#method.set_certificate_verifier
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_dangerous_set_certificate_verifier(
-    wants_verifier: *mut rustls_client_config_builder_wants_verifier,
-    callback: rustls_verify_server_cert_callback,
-    builder: *mut *mut rustls_client_config_builder,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let callback: VerifyCallback = match callback {
-            Some(cb) => cb,
-            None => return rustls_result::InvalidParameter,
-        };
-
-        let new = *BoxCastPtr::to_box(wants_verifier);
-        let verifier: Verifier = Verifier{callback: callback};
-        // TODO: no client authentication support for now
-        let config = new.with_custom_certificate_verifier(Arc::new(verifier)).with_no_client_auth();
-        BoxCastPtr::set_mut_ptr(builder, config);
-        rustls_result::Ok
-    }
-}
-
-/// Use the trusted root certificates from the provided store.
-///
-/// This replaces any trusted roots already configured with copies
-/// from `roots`. This adds 1 to the refcount for `roots`. When you
-/// call rustls_client_config_free or rustls_client_config_builder_free,
-/// those will subtract 1 from the refcount for `roots`.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_use_roots(
-    wants_verifier: *mut rustls_client_config_builder_wants_verifier,
-    roots: *const rustls_root_cert_store,
-    builder: *mut *mut rustls_client_config_builder,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let root_store: &RootCertStore = try_ref_from_ptr!(roots);
-        let prev = *BoxCastPtr::to_box(wants_verifier);
-        let config = prev.with_root_certificates(root_store.clone()).with_no_client_auth();
-        BoxCastPtr::set_mut_ptr(builder, config);
-        rustls_result::Ok
-    }
-}
-
-/// Add trusted root certificates from the named file, which should contain
-/// PEM-formatted certificates.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_load_roots_from_file(
-    wants_verifier: *mut rustls_client_config_builder_wants_verifier,
-    filename: *const c_char,
-    builder: *mut *mut rustls_client_config_builder,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let filename: &CStr = unsafe {
-            if filename.is_null() {
-                return rustls_result::NullParameter;
-            }
-            CStr::from_ptr(filename)
-        };
-
-        let filename: &[u8] = filename.to_bytes();
-        let filename: &str = match std::str::from_utf8(filename) {
-            Ok(s) => s,
-            Err(_) => return rustls_result::Io,
-        };
-        let filename: &OsStr = OsStr::new(filename);
-        let mut cafile = match File::open(filename) {
-            Ok(f) => f,
-            Err(_) => return rustls_result::Io,
-        };
-
-        let mut bufreader = BufReader::new(&mut cafile);
-        let certs = match rustls_pemfile::certs(&mut bufreader) {
-            Ok(certs) => certs,
-            Err(_) => return rustls_result::Io,
-        };
-
-        let mut roots = RootCertStore::empty();
-        let (_, failed) = roots.add_parsable_certificates(&certs);
-        if failed > 0 {
-            return rustls_result::CertificateParseError;
-        }
-
-        let prev = *BoxCastPtr::to_box(wants_verifier);
-        // TODO: no client authentication support for now
-        let config = prev.with_root_certificates(roots).with_no_client_auth();
-        BoxCastPtr::set_mut_ptr(builder, config);
-
-        rustls_result::Ok
-    }
-}
-
-/// Set the ALPN protocol list to the given protocols. `protocols` must point
-/// to a buffer of `rustls_slice_bytes` (built by the caller) with `len`
-/// elements. Each element of the buffer must be a rustls_slice_bytes whose
-/// data field points to a single ALPN protocol ID. Standard ALPN protocol
-/// IDs are defined at
-/// https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids.
-///
-/// This function makes a copy of the data in `protocols` and does not retain
-/// any pointers, so the caller can free the pointed-to memory after calling.
-///
-/// https://docs.rs/rustls/0.20.0/rustls/client/struct.ClientConfig.html#structfield.alpn_protocols
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_set_alpn_protocols(
-    builder: *mut rustls_client_config_builder,
-    protocols: *const rustls_slice_bytes,
-    len: size_t,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let config: &mut ClientConfig = try_mut_from_ptr!(builder);
-        let protocols: &[rustls_slice_bytes] = try_slice!(protocols, len);
-
-        let mut vv: Vec<Vec<u8>> = Vec::with_capacity(protocols.len());
-        for p in protocols {
-            let v: &[u8] = try_slice!(p.data, p.len);
-            vv.push(v.to_vec());
-        }
-        config.alpn_protocols = vv;
-        rustls_result::Ok
-    }
-}
-
-/// Enable or disable SNI.
-/// https://docs.rs/rustls/0.20.0/rustls/struct.ClientConfig.html#structfield.enable_sni
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_set_enable_sni(
-    config: *mut rustls_client_config_builder,
-    enable: bool,
-) {
-    ffi_panic_boundary! {
-        let config: &mut ClientConfig = try_mut_from_ptr!(config);
-        config.enable_sni = enable;
-    }
-}
-
-/// "Free" a client_config_builder_wants_verifier before transmogrifying it into a client_config.
-/// Normally builders are consumed to client_configs via `rustls_client_config_builder_build`
-/// and may not be free'd or otherwise used afterwards.
-/// Use free only when the building of a config has to be aborted before a config
-/// was created.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_wants_verifier_free(
-    builder: *mut rustls_client_config_builder_wants_verifier,
-) {
-    ffi_panic_boundary! {
-        BoxCastPtr::to_box(builder);
-    }
-}
-
-/// Provide the configuration a list of certificates where the session
-/// will select the first one that is compatible with the server's signature
-/// verification capabilities. Clients that want to support both ECDSA and
-/// RSA certificates will want the ECSDA to go first in the list.
-///
-/// The built configuration will keep a reference to all certified keys
-/// provided. The client may `rustls_certified_key_free()` afterwards
-/// without the configuration losing them. The same certified key may also
-/// be used in multiple configs.
-///
-/// EXPERIMENTAL: installing a client authentication callback will replace any
-/// configured certified keys and vice versa.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_set_certified_key(
-    builder: *mut rustls_client_config_builder,
-    certified_keys: *const *const rustls_certified_key,
-    certified_keys_len: size_t,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let config: &mut ClientConfig = try_mut_from_ptr!(builder);
-        let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
-        let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
-        for &key_ptr in keys_ptrs {
-            let key_ptr: &CertifiedKey = try_ref_from_ptr!(key_ptr);
-            let certified_key: Arc<CertifiedKey> = unsafe {
-                match (key_ptr as *const CertifiedKey).as_ref() {
-                    Some(c) => arc_with_incref_from_raw(c),
-                    None => return NullParameter,
-                }
+impl rustls_client_config_builder {
+    /// Set a custom server certificate verifier.
+    ///
+    /// The callback must not capture any of the pointers in its
+    /// rustls_verify_server_cert_params.
+    /// If `userdata` has been set with rustls_connection_set_userdata, it
+    /// will be passed to the callback. Otherwise the userdata param passed to
+    /// the callback will be NULL.
+    ///
+    /// The callback must be safe to call on any thread at any time, including
+    /// multiple concurrent calls. So, for instance, if the callback mutates
+    /// userdata (or other shared state), it must use synchronization primitives
+    /// to make such mutation safe.
+    ///
+    /// The callback receives certificate chain information as raw bytes.
+    /// Currently this library offers no functions for C code to parse the
+    /// certificates, so you'll need to bring your own certificate parsing library
+    /// if you need to parse them.
+    ///
+    /// If you intend to write a verifier that accepts all certificates, be aware
+    /// that special measures are required for IP addresses. Rustls currently
+    /// (0.20.0) doesn't support building a ClientSession with an IP address
+    /// (because it's not a valid DnsNameRef). One workaround is to detect IP
+    /// addresses and rewrite them to `example.invalid`, and _also_ to disable
+    /// SNI via rustls_client_config_builder_set_enable_sni (IP addresses don't
+    /// need SNI).
+    ///
+    /// If the custom verifier accepts the certificate, it should return
+    /// RUSTLS_RESULT_OK. Otherwise, it may return any other rustls_result error.
+    /// Feel free to use an appropriate error from the RUSTLS_RESULT_CERT_*
+    /// section.
+    ///
+    /// https://docs.rs/rustls/0.20.0/rustls/client/struct.DangerousClientConfig.html#method.set_certificate_verifier
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_dangerous_set_certificate_verifier(
+        wants_verifier: *mut rustls_client_config_builder_wants_verifier,
+        callback: rustls_verify_server_cert_callback,
+        builder: *mut *mut rustls_client_config_builder,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let callback: VerifyCallback = match callback {
+                Some(cb) => cb,
+                None => return rustls_result::InvalidParameter,
             };
-            keys.push(certified_key);
+
+            let new = *BoxCastPtr::to_box(wants_verifier);
+            let verifier: Verifier = Verifier{callback: callback};
+            // TODO: no client authentication support for now
+            let config = new.with_custom_certificate_verifier(Arc::new(verifier)).with_no_client_auth();
+            BoxCastPtr::set_mut_ptr(builder, config);
+            rustls_result::Ok
         }
-        config.client_auth_cert_resolver = Arc::new(ResolvesClientCertFromChoices { keys });
-        rustls_result::Ok
+    }
+
+    /// Use the trusted root certificates from the provided store.
+    ///
+    /// This replaces any trusted roots already configured with copies
+    /// from `roots`. This adds 1 to the refcount for `roots`. When you
+    /// call rustls_client_config_free or rustls_client_config_builder_free,
+    /// those will subtract 1 from the refcount for `roots`.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_use_roots(
+        wants_verifier: *mut rustls_client_config_builder_wants_verifier,
+        roots: *const rustls_root_cert_store,
+        builder: *mut *mut rustls_client_config_builder,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let root_store: &RootCertStore = try_ref_from_ptr!(roots);
+            let prev = *BoxCastPtr::to_box(wants_verifier);
+            let config = prev.with_root_certificates(root_store.clone()).with_no_client_auth();
+            BoxCastPtr::set_mut_ptr(builder, config);
+            rustls_result::Ok
+        }
+    }
+
+    /// Add trusted root certificates from the named file, which should contain
+    /// PEM-formatted certificates.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_load_roots_from_file(
+        wants_verifier: *mut rustls_client_config_builder_wants_verifier,
+        filename: *const c_char,
+        builder: *mut *mut rustls_client_config_builder,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let filename: &CStr = unsafe {
+                if filename.is_null() {
+                    return rustls_result::NullParameter;
+                }
+                CStr::from_ptr(filename)
+            };
+
+            let filename: &[u8] = filename.to_bytes();
+            let filename: &str = match std::str::from_utf8(filename) {
+                Ok(s) => s,
+                Err(_) => return rustls_result::Io,
+            };
+            let filename: &OsStr = OsStr::new(filename);
+            let mut cafile = match File::open(filename) {
+                Ok(f) => f,
+                Err(_) => return rustls_result::Io,
+            };
+
+            let mut bufreader = BufReader::new(&mut cafile);
+            let certs = match rustls_pemfile::certs(&mut bufreader) {
+                Ok(certs) => certs,
+                Err(_) => return rustls_result::Io,
+            };
+
+            let mut roots = RootCertStore::empty();
+            let (_, failed) = roots.add_parsable_certificates(&certs);
+            if failed > 0 {
+                return rustls_result::CertificateParseError;
+            }
+
+            let prev = *BoxCastPtr::to_box(wants_verifier);
+            // TODO: no client authentication support for now
+            let config = prev.with_root_certificates(roots).with_no_client_auth();
+            BoxCastPtr::set_mut_ptr(builder, config);
+
+            rustls_result::Ok
+        }
+    }
+
+    /// Set the ALPN protocol list to the given protocols. `protocols` must point
+    /// to a buffer of `rustls_slice_bytes` (built by the caller) with `len`
+    /// elements. Each element of the buffer must be a rustls_slice_bytes whose
+    /// data field points to a single ALPN protocol ID. Standard ALPN protocol
+    /// IDs are defined at
+    /// https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids.
+    ///
+    /// This function makes a copy of the data in `protocols` and does not retain
+    /// any pointers, so the caller can free the pointed-to memory after calling.
+    ///
+    /// https://docs.rs/rustls/0.20.0/rustls/client/struct.ClientConfig.html#structfield.alpn_protocols
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_set_alpn_protocols(
+        builder: *mut rustls_client_config_builder,
+        protocols: *const rustls_slice_bytes,
+        len: size_t,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let config: &mut ClientConfig = try_mut_from_ptr!(builder);
+            let protocols: &[rustls_slice_bytes] = try_slice!(protocols, len);
+
+            let mut vv: Vec<Vec<u8>> = Vec::with_capacity(protocols.len());
+            for p in protocols {
+                let v: &[u8] = try_slice!(p.data, p.len);
+                vv.push(v.to_vec());
+            }
+            config.alpn_protocols = vv;
+            rustls_result::Ok
+        }
+    }
+
+    /// Enable or disable SNI.
+    /// https://docs.rs/rustls/0.20.0/rustls/struct.ClientConfig.html#structfield.enable_sni
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_set_enable_sni(
+        config: *mut rustls_client_config_builder,
+        enable: bool,
+    ) {
+        ffi_panic_boundary! {
+            let config: &mut ClientConfig = try_mut_from_ptr!(config);
+            config.enable_sni = enable;
+        }
+    }
+
+    /// "Free" a client_config_builder_wants_verifier before transmogrifying it into a client_config.
+    /// Normally builders are consumed to client_configs via `rustls_client_config_builder_build`
+    /// and may not be free'd or otherwise used afterwards.
+    /// Use free only when the building of a config has to be aborted before a config
+    /// was created.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_wants_verifier_free(
+        builder: *mut rustls_client_config_builder_wants_verifier,
+    ) {
+        ffi_panic_boundary! {
+            BoxCastPtr::to_box(builder);
+        }
+    }
+
+    /// Provide the configuration a list of certificates where the session
+    /// will select the first one that is compatible with the server's signature
+    /// verification capabilities. Clients that want to support both ECDSA and
+    /// RSA certificates will want the ECSDA to go first in the list.
+    ///
+    /// The built configuration will keep a reference to all certified keys
+    /// provided. The client may `rustls_certified_key_free()` afterwards
+    /// without the configuration losing them. The same certified key may also
+    /// be used in multiple configs.
+    ///
+    /// EXPERIMENTAL: installing a client authentication callback will replace any
+    /// configured certified keys and vice versa.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_set_certified_key(
+        builder: *mut rustls_client_config_builder,
+        certified_keys: *const *const rustls_certified_key,
+        certified_keys_len: size_t,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let config: &mut ClientConfig = try_mut_from_ptr!(builder);
+            let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
+            let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
+            for &key_ptr in keys_ptrs {
+                let key_ptr: &CertifiedKey = try_ref_from_ptr!(key_ptr);
+                let certified_key: Arc<CertifiedKey> = unsafe {
+                    match (key_ptr as *const CertifiedKey).as_ref() {
+                        Some(c) => arc_with_incref_from_raw(c),
+                        None => return NullParameter,
+                    }
+                };
+                keys.push(certified_key);
+            }
+            config.client_auth_cert_resolver = Arc::new(ResolvesClientCertFromChoices { keys });
+            rustls_result::Ok
+        }
     }
 }
 
@@ -478,87 +482,91 @@ impl ResolvesClientCert for ResolvesClientCertFromChoices {
     }
 }
 
-/// Turn a *rustls_client_config_builder (mutable) into a const *rustls_client_config
-/// (read-only).
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_build(
-    builder: *mut rustls_client_config_builder,
-) -> *const rustls_client_config {
-    ffi_panic_boundary! {
-        let b = BoxCastPtr::to_box(builder);
-        Arc::into_raw(Arc::new(*b)) as *const _
+impl rustls_client_config_builder {
+    /// Turn a *rustls_client_config_builder (mutable) into a const *rustls_client_config
+    /// (read-only).
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_build(
+        builder: *mut rustls_client_config_builder,
+    ) -> *const rustls_client_config {
+        ffi_panic_boundary! {
+            let b = BoxCastPtr::to_box(builder);
+            Arc::into_raw(Arc::new(*b)) as *const _
+        }
+    }
+
+    /// "Free" a client_config_builder before transmogrifying it into a client_config.
+    /// Normally builders are consumed to client_configs via `rustls_client_config_builder_build`
+    /// and may not be free'd or otherwise used afterwards.
+    /// Use free only when the building of a config has to be aborted before a config
+    /// was created.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_builder_free(config: *mut rustls_client_config_builder) {
+        ffi_panic_boundary! {
+            BoxCastPtr::to_box(config);
+        }
     }
 }
 
-/// "Free" a client_config_builder before transmogrifying it into a client_config.
-/// Normally builders are consumed to client_configs via `rustls_client_config_builder_build`
-/// and may not be free'd or otherwise used afterwards.
-/// Use free only when the building of a config has to be aborted before a config
-/// was created.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_builder_free(config: *mut rustls_client_config_builder) {
-    ffi_panic_boundary! {
-        BoxCastPtr::to_box(config);
+impl rustls_client_config {
+    /// "Free" a client_config previously returned from
+    /// rustls_client_config_builder_build. Since client_config is actually an
+    /// atomically reference-counted pointer, extant client connections may still
+    /// hold an internal reference to the Rust object. However, C code must
+    /// consider this pointer unusable after "free"ing it.
+    /// Calling with NULL is fine. Must not be called twice with the same value.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config) {
+        ffi_panic_boundary! {
+            let config: &ClientConfig = try_ref_from_ptr!(config);
+            // To free the client_config, we reconstruct the Arc and then drop it. It should
+            // have a refcount of 1, representing the C code's copy. When it drops, that
+            // refcount will go down to 0 and the inner ClientConfig will be dropped.
+            unsafe { drop(Arc::from_raw(config)) };
+        }
     }
-}
 
-/// "Free" a client_config previously returned from
-/// rustls_client_config_builder_build. Since client_config is actually an
-/// atomically reference-counted pointer, extant client connections may still
-/// hold an internal reference to the Rust object. However, C code must
-/// consider this pointer unusable after "free"ing it.
-/// Calling with NULL is fine. Must not be called twice with the same value.
-#[no_mangle]
-pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config) {
-    ffi_panic_boundary! {
-        let config: &ClientConfig = try_ref_from_ptr!(config);
-        // To free the client_config, we reconstruct the Arc and then drop it. It should
-        // have a refcount of 1, representing the C code's copy. When it drops, that
-        // refcount will go down to 0 and the inner ClientConfig will be dropped.
-        unsafe { drop(Arc::from_raw(config)) };
-    }
-}
+    /// Create a new rustls_connection containing a client connection and return
+    /// it in the output parameter `out`. If this returns an error code, the
+    /// memory pointed to by `session_out` remains unchanged. If this returns a
+    /// non-error, the memory pointed to by `conn_out` is modified to point at a
+    /// valid rustls_connection. The caller now owns the rustls_connection and must
+    /// call `rustls_connection_free` when done with it.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_connection_new(
+        config: *const rustls_client_config,
+        hostname: *const c_char,
+        conn_out: *mut *mut rustls_connection,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let hostname: &CStr = unsafe {
+                if hostname.is_null() {
+                    return NullParameter;
+                }
+                CStr::from_ptr(hostname)
+            };
+            let config: Arc<ClientConfig> = unsafe {
+                match (config as *const ClientConfig).as_ref() {
+                    Some(c) => arc_with_incref_from_raw(c),
+                    None => return NullParameter,
+                }
+            };
+            let hostname: &str = match hostname.to_str() {
+                Ok(s) => s,
+                Err(std::str::Utf8Error { .. }) => return rustls_result::InvalidDnsNameError,
+            };
+            let server_name: rustls::ServerName = match hostname.try_into() {
+                Ok(sn) => sn,
+                Err(_) => return rustls_result::InvalidDnsNameError,
+            };
+            let client = ClientConnection::new(config, server_name).unwrap();
 
-/// Create a new rustls_connection containing a client connection and return
-/// it in the output parameter `out`. If this returns an error code, the
-/// memory pointed to by `session_out` remains unchanged. If this returns a
-/// non-error, the memory pointed to by `conn_out` is modified to point at a
-/// valid rustls_connection. The caller now owns the rustls_connection and must
-/// call `rustls_connection_free` when done with it.
-#[no_mangle]
-pub extern "C" fn rustls_client_connection_new(
-    config: *const rustls_client_config,
-    hostname: *const c_char,
-    conn_out: *mut *mut rustls_connection,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let hostname: &CStr = unsafe {
-            if hostname.is_null() {
-                return NullParameter;
-            }
-            CStr::from_ptr(hostname)
-        };
-        let config: Arc<ClientConfig> = unsafe {
-            match (config as *const ClientConfig).as_ref() {
-                Some(c) => arc_with_incref_from_raw(c),
-                None => return NullParameter,
-            }
-        };
-        let hostname: &str = match hostname.to_str() {
-            Ok(s) => s,
-            Err(std::str::Utf8Error { .. }) => return rustls_result::InvalidDnsNameError,
-        };
-        let server_name: rustls::ServerName = match hostname.try_into() {
-            Ok(sn) => sn,
-            Err(_) => return rustls_result::InvalidDnsNameError,
-        };
-        let client = ClientConnection::new(config, server_name).unwrap();
-
-        // We've succeeded. Put the client on the heap, and transfer ownership
-        // to the caller. After this point, we must return CRUSTLS_OK so the
-        // caller knows it is responsible for this memory.
-        let c = Connection::from_client(client);
-        BoxCastPtr::set_mut_ptr(conn_out, c);
-        rustls_result::Ok
+            // We've succeeded. Put the client on the heap, and transfer ownership
+            // to the caller. After this point, we must return CRUSTLS_OK so the
+            // caller knows it is responsible for this memory.
+            let c = Connection::from_client(client);
+            BoxCastPtr::set_mut_ptr(conn_out, c);
+            rustls_result::Ok
+        }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -103,357 +103,359 @@ impl CastPtr for rustls_connection {
 
 impl BoxCastPtr for rustls_connection {}
 
-/// Set the userdata pointer associated with this connection. This will be passed
-/// to any callbacks invoked by the connection, if you've set up callbacks in the config.
-/// The pointed-to data must outlive the connection.
-#[no_mangle]
-pub extern "C" fn rustls_connection_set_userdata(
-    conn: *mut rustls_connection,
-    userdata: *mut c_void,
-) {
-    let conn: &mut Connection = try_mut_from_ptr!(conn);
-    conn.userdata = userdata;
-}
-
-/// Set the logging callback for this connection. The log callback will be invoked
-/// with the userdata parameter previously set by rustls_connection_set_userdata, or
-/// NULL if no userdata was set.
-#[no_mangle]
-pub extern "C" fn rustls_connection_set_log_callback(
-    conn: *mut rustls_connection,
-    cb: rustls_log_callback,
-) {
-    let conn: &mut Connection = try_mut_from_ptr!(conn);
-    ensure_log_registered();
-    conn.log_callback = cb;
-}
-
-/// Read some TLS bytes from the network into internal buffers. The actual network
-/// I/O is performed by `callback`, which you provide. Rustls will invoke your
-/// callback with a suitable buffer to store the read bytes into. You don't have
-/// to fill it up, just fill with as many bytes as you get in one syscall.
-/// The `userdata` parameter is passed through directly to `callback`. Note that
-/// this is distinct from the `userdata` parameter set with
-/// `rustls_connection_set_userdata`.
-/// Returns 0 for success, or an errno value on error. Passes through return values
-/// from callback. See rustls_read_callback for more details.
-/// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.read_tls
-#[no_mangle]
-pub extern "C" fn rustls_connection_read_tls(
-    conn: *mut rustls_connection,
-    callback: rustls_read_callback,
-    userdata: *mut c_void,
-    out_n: *mut size_t,
-) -> rustls_io_result {
-    ffi_panic_boundary! {
+impl rustls_connection {
+    /// Set the userdata pointer associated with this connection. This will be passed
+    /// to any callbacks invoked by the connection, if you've set up callbacks in the config.
+    /// The pointed-to data must outlive the connection.
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_set_userdata(
+        conn: *mut rustls_connection,
+        userdata: *mut c_void,
+    ) {
         let conn: &mut Connection = try_mut_from_ptr!(conn);
-        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
-        let callback: ReadCallback = try_callback!(callback);
-
-        let mut reader = CallbackReader { callback, userdata };
-        let n_read: usize = match conn.read_tls(&mut reader) {
-            Ok(n) => n,
-            Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
-        };
-        *out_n = n_read;
-
-        rustls_io_result(0)
+        conn.userdata = userdata;
     }
-}
 
-/// Write some TLS bytes to the network. The actual network I/O is performed by
-/// `callback`, which you provide. Rustls will invoke your callback with a
-/// suitable buffer containing TLS bytes to send. You don't have to write them
-/// all, just as many as you can in one syscall.
-/// The `userdata` parameter is passed through directly to `callback`. Note that
-/// this is distinct from the `userdata` parameter set with
-/// `rustls_connection_set_userdata`.
-/// Returns 0 for success, or an errno value on error. Passes through return values
-/// from callback. See rustls_write_callback for more details.
-/// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.write_tls
-#[no_mangle]
-pub extern "C" fn rustls_connection_write_tls(
-    conn: *mut rustls_connection,
-    callback: rustls_write_callback,
-    userdata: *mut c_void,
-    out_n: *mut size_t,
-) -> rustls_io_result {
-    ffi_panic_boundary! {
+    /// Set the logging callback for this connection. The log callback will be invoked
+    /// with the userdata parameter previously set by rustls_connection_set_userdata, or
+    /// NULL if no userdata was set.
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_set_log_callback(
+        conn: *mut rustls_connection,
+        cb: rustls_log_callback,
+    ) {
         let conn: &mut Connection = try_mut_from_ptr!(conn);
-        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
-        let callback: WriteCallback = try_callback!(callback);
-
-        let mut writer = CallbackWriter { callback, userdata };
-        let n_written: usize = match conn.write_tls(&mut writer) {
-            Ok(n) => n,
-            Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
-        };
-        *out_n = n_written;
-
-        rustls_io_result(0)
+        ensure_log_registered();
+        conn.log_callback = cb;
     }
-}
 
-/// Write all available TLS bytes to the network. The actual network I/O is performed by
-/// `callback`, which you provide. Rustls will invoke your callback with an array
-/// of rustls_slice_bytes, each containing a buffer with TLS bytes to send.
-/// You don't have to write them all, just as many as you are willing.
-/// The `userdata` parameter is passed through directly to `callback`. Note that
-/// this is distinct from the `userdata` parameter set with
-/// `rustls_connection_set_userdata`.
-/// Returns 0 for success, or an errno value on error. Passes through return values
-/// from callback. See rustls_write_callback for more details.
-/// https://docs.rs/rustls/0.20.0/rustls/trait.Session.html#tymethod.write_tls
-#[no_mangle]
-pub extern "C" fn rustls_connection_write_tls_vectored(
-    conn: *mut rustls_connection,
-    callback: rustls_write_vectored_callback,
-    userdata: *mut c_void,
-    out_n: *mut size_t,
-) -> rustls_io_result {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
-        let callback: VectoredWriteCallback = try_callback!(callback);
+    /// Read some TLS bytes from the network into internal buffers. The actual network
+    /// I/O is performed by `callback`, which you provide. Rustls will invoke your
+    /// callback with a suitable buffer to store the read bytes into. You don't have
+    /// to fill it up, just fill with as many bytes as you get in one syscall.
+    /// The `userdata` parameter is passed through directly to `callback`. Note that
+    /// this is distinct from the `userdata` parameter set with
+    /// `rustls_connection_set_userdata`.
+    /// Returns 0 for success, or an errno value on error. Passes through return values
+    /// from callback. See rustls_read_callback for more details.
+    /// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.read_tls
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_read_tls(
+        conn: *mut rustls_connection,
+        callback: rustls_read_callback,
+        userdata: *mut c_void,
+        out_n: *mut size_t,
+    ) -> rustls_io_result {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            let out_n: &mut size_t = try_mut_from_ptr!(out_n);
+            let callback: ReadCallback = try_callback!(callback);
 
-        let mut writer = VectoredCallbackWriter { callback, userdata };
-        let n_written: usize = match conn.write_tls(&mut writer) {
-            Ok(n) => n,
-            Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
-        };
-        *out_n = n_written;
+            let mut reader = CallbackReader { callback, userdata };
+            let n_read: usize = match conn.read_tls(&mut reader) {
+                Ok(n) => n,
+                Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
+            };
+            *out_n = n_read;
 
-        rustls_io_result(0)
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn rustls_connection_process_new_packets(
-    conn: *mut rustls_connection,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        let guard = match userdata_push(conn.userdata, conn.log_callback) {
-            Ok(g) => g,
-            Err(_) => return rustls_result::Panic,
-        };
-        let result = match conn.process_new_packets() {
-            Ok(_) => rustls_result::Ok,
-            Err(e) => map_error(e),
-        };
-        match guard.try_drop() {
-            Ok(()) => result,
-            Err(_) => return rustls_result::Panic,
+            rustls_io_result(0)
         }
     }
-}
 
-#[no_mangle]
-pub extern "C" fn rustls_connection_wants_read(conn: *const rustls_connection) -> bool {
-    ffi_panic_boundary! {
-        let conn: &Connection = try_ref_from_ptr!(conn);
-        conn.wants_read()
-    }
-}
+    /// Write some TLS bytes to the network. The actual network I/O is performed by
+    /// `callback`, which you provide. Rustls will invoke your callback with a
+    /// suitable buffer containing TLS bytes to send. You don't have to write them
+    /// all, just as many as you can in one syscall.
+    /// The `userdata` parameter is passed through directly to `callback`. Note that
+    /// this is distinct from the `userdata` parameter set with
+    /// `rustls_connection_set_userdata`.
+    /// Returns 0 for success, or an errno value on error. Passes through return values
+    /// from callback. See rustls_write_callback for more details.
+    /// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.write_tls
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_write_tls(
+        conn: *mut rustls_connection,
+        callback: rustls_write_callback,
+        userdata: *mut c_void,
+        out_n: *mut size_t,
+    ) -> rustls_io_result {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            let out_n: &mut size_t = try_mut_from_ptr!(out_n);
+            let callback: WriteCallback = try_callback!(callback);
 
-#[no_mangle]
-pub extern "C" fn rustls_connection_wants_write(conn: *const rustls_connection) -> bool {
-    ffi_panic_boundary! {
-        let conn: &Connection = try_ref_from_ptr!(conn);
-        conn.wants_write()
-    }
-}
+            let mut writer = CallbackWriter { callback, userdata };
+            let n_written: usize = match conn.write_tls(&mut writer) {
+                Ok(n) => n,
+                Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
+            };
+            *out_n = n_written;
 
-#[no_mangle]
-pub extern "C" fn rustls_connection_is_handshaking(conn: *const rustls_connection) -> bool {
-    ffi_panic_boundary! {
-        let conn: &Connection = try_ref_from_ptr!(conn);
-        conn.is_handshaking()
-    }
-}
-
-/// Sets a limit on the internal buffers used to buffer unsent plaintext (prior
-/// to completing the TLS handshake) and unsent TLS records. By default, there
-/// is no limit. The limit can be set at any time, even if the current buffer
-/// use is higher.
-/// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.set_buffer_limit
-#[no_mangle]
-pub extern "C" fn rustls_connection_set_buffer_limit(conn: *mut rustls_connection, n: usize) {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        conn.set_buffer_limit(Some(n));
-    }
-}
-
-/// Queues a close_notify fatal alert to be sent in the next write_tls call.
-/// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.send_close_notify
-#[no_mangle]
-pub extern "C" fn rustls_connection_send_close_notify(conn: *mut rustls_connection) {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        conn.send_close_notify();
-    }
-}
-
-/// Return the i-th certificate provided by the peer.
-/// Index 0 is the end entity certificate. Higher indexes are certificates
-/// in the chain. Requesting an index higher than what is available returns
-/// NULL.
-/// The returned pointer lives as long as the rustls_connection does.
-#[no_mangle]
-pub extern "C" fn rustls_connection_peer_certificate(
-    conn: *mut rustls_connection,
-    i: size_t,
-) -> *const rustls_certificate {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        match conn.peer_certificates().and_then(|c| c.get(i)) {
-            Some(cert) => cert as *const Certificate as *const _,
-            None => null()
+            rustls_io_result(0)
         }
     }
-}
 
-/// Get the ALPN protocol that was negotiated, if any. Stores a pointer to a
-/// borrowed buffer of bytes, and that buffer's len, in the output parameters.
-/// The borrow lives as long as the connection.
-/// If the connection is still handshaking, or no ALPN protocol was negotiated,
-/// stores NULL and 0 in the output parameters.
-/// https://www.iana.org/assignments/tls-parameters/
-/// https://docs.rs/rustls/0.19.1/rustls/trait.Connection.html#tymethod.get_alpn_protocol
-#[no_mangle]
-pub extern "C" fn rustls_connection_alpn_protocol(
-    conn: *const rustls_connection,
-    protocol_out: *mut *const u8,
-    protocol_out_len: *mut usize,
-) {
-    ffi_panic_boundary! {
-        let conn: &Connection = try_ref_from_ptr!(conn);
-        let protocol_out = try_mut_from_ptr!(protocol_out);
-        let protocol_out_len = try_mut_from_ptr!(protocol_out_len);
-        match conn.alpn_protocol() {
-            Some(p) => {
-                *protocol_out = p.as_ptr();
-                *protocol_out_len = p.len();
-            },
-            None => {
-                *protocol_out = null();
-                *protocol_out_len = 0;
+    /// Write all available TLS bytes to the network. The actual network I/O is performed by
+    /// `callback`, which you provide. Rustls will invoke your callback with an array
+    /// of rustls_slice_bytes, each containing a buffer with TLS bytes to send.
+    /// You don't have to write them all, just as many as you are willing.
+    /// The `userdata` parameter is passed through directly to `callback`. Note that
+    /// this is distinct from the `userdata` parameter set with
+    /// `rustls_connection_set_userdata`.
+    /// Returns 0 for success, or an errno value on error. Passes through return values
+    /// from callback. See rustls_write_callback for more details.
+    /// https://docs.rs/rustls/0.20.0/rustls/trait.Session.html#tymethod.write_tls
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_write_tls_vectored(
+        conn: *mut rustls_connection,
+        callback: rustls_write_vectored_callback,
+        userdata: *mut c_void,
+        out_n: *mut size_t,
+    ) -> rustls_io_result {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            let out_n: &mut size_t = try_mut_from_ptr!(out_n);
+            let callback: VectoredWriteCallback = try_callback!(callback);
+
+            let mut writer = VectoredCallbackWriter { callback, userdata };
+            let n_written: usize = match conn.write_tls(&mut writer) {
+                Ok(n) => n,
+                Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
+            };
+            *out_n = n_written;
+
+            rustls_io_result(0)
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_process_new_packets(
+        conn: *mut rustls_connection,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            let guard = match userdata_push(conn.userdata, conn.log_callback) {
+                Ok(g) => g,
+                Err(_) => return rustls_result::Panic,
+            };
+            let result = match conn.process_new_packets() {
+                Ok(_) => rustls_result::Ok,
+                Err(e) => map_error(e),
+            };
+            match guard.try_drop() {
+                Ok(()) => result,
+                Err(_) => return rustls_result::Panic,
             }
         }
     }
-}
 
-/// Return the TLS protocol version that has been negotiated. Before this
-/// has been decided during the handshake, this will return 0. Otherwise,
-/// the u16 version number as defined in the relevant RFC is returned.
-/// https://docs.rs/rustls/0.19.1/rustls/trait.Connection.html#tymethod.get_protocol_version
-/// https://docs.rs/rustls/0.19.1/rustls/internal/msgs/enums/enum.ProtocolVersion.html
-#[no_mangle]
-pub extern "C" fn rustls_connection_protocol_version(conn: *const rustls_connection) -> u16 {
-    ffi_panic_boundary! {
-        let conn: &Connection = try_ref_from_ptr!(conn);
-        match conn.protocol_version() {
-            Some(p) => p.get_u16(),
-            _ => 0,
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_wants_read(conn: *const rustls_connection) -> bool {
+        ffi_panic_boundary! {
+            let conn: &Connection = try_ref_from_ptr!(conn);
+            conn.wants_read()
         }
     }
-}
 
-/// Retrieves the cipher suite agreed with the peer.
-/// This returns NULL until the ciphersuite is agreed.
-/// The returned pointer lives as long as the program.
-/// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.get_negotiated_ciphersuite
-#[no_mangle]
-pub extern "C" fn rustls_connection_negotiated_ciphersuite(
-    conn: *const rustls_connection,
-) -> *const rustls_supported_ciphersuite {
-    ffi_panic_boundary! {
-        let conn: &Connection = try_ref_from_ptr!(conn);
-        let negotiated = match conn.negotiated_cipher_suite() {
-            Some(cs) => cs,
-            None => return null(),
-        };
-        for &cs in ALL_CIPHER_SUITES {
-            if negotiated == cs {
-                return &cs as *const SupportedCipherSuite as *const _;
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_wants_write(conn: *const rustls_connection) -> bool {
+        ffi_panic_boundary! {
+            let conn: &Connection = try_ref_from_ptr!(conn);
+            conn.wants_write()
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_is_handshaking(conn: *const rustls_connection) -> bool {
+        ffi_panic_boundary! {
+            let conn: &Connection = try_ref_from_ptr!(conn);
+            conn.is_handshaking()
+        }
+    }
+
+    /// Sets a limit on the internal buffers used to buffer unsent plaintext (prior
+    /// to completing the TLS handshake) and unsent TLS records. By default, there
+    /// is no limit. The limit can be set at any time, even if the current buffer
+    /// use is higher.
+    /// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.set_buffer_limit
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_set_buffer_limit(conn: *mut rustls_connection, n: usize) {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            conn.set_buffer_limit(Some(n));
+        }
+    }
+
+    /// Queues a close_notify fatal alert to be sent in the next write_tls call.
+    /// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.send_close_notify
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_send_close_notify(conn: *mut rustls_connection) {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            conn.send_close_notify();
+        }
+    }
+
+    /// Return the i-th certificate provided by the peer.
+    /// Index 0 is the end entity certificate. Higher indexes are certificates
+    /// in the chain. Requesting an index higher than what is available returns
+    /// NULL.
+    /// The returned pointer lives as long as the rustls_connection does.
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_peer_certificate(
+        conn: *mut rustls_connection,
+        i: size_t,
+    ) -> *const rustls_certificate {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            match conn.peer_certificates().and_then(|c| c.get(i)) {
+                Some(cert) => cert as *const Certificate as *const _,
+                None => null()
             }
         }
-        null()
     }
-}
 
-/// Write up to `count` plaintext bytes from `buf` into the `rustls_connection`.
-/// This will increase the number of output bytes available to
-/// `rustls_connection_write_tls`.
-/// On success, store the number of bytes actually written in *out_n
-/// (this may be less than `count`).
-#[no_mangle]
-pub extern "C" fn rustls_connection_write(
-    conn: *mut rustls_connection,
-    buf: *const u8,
-    count: size_t,
-    out_n: *mut size_t,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        let write_buf: &[u8] = try_slice!(buf, count);
-        let out_n: &mut size_t = unsafe {
-            match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
+    /// Get the ALPN protocol that was negotiated, if any. Stores a pointer to a
+    /// borrowed buffer of bytes, and that buffer's len, in the output parameters.
+    /// The borrow lives as long as the connection.
+    /// If the connection is still handshaking, or no ALPN protocol was negotiated,
+    /// stores NULL and 0 in the output parameters.
+    /// https://www.iana.org/assignments/tls-parameters/
+    /// https://docs.rs/rustls/0.19.1/rustls/trait.Connection.html#tymethod.get_alpn_protocol
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_alpn_protocol(
+        conn: *const rustls_connection,
+        protocol_out: *mut *const u8,
+        protocol_out_len: *mut usize,
+    ) {
+        ffi_panic_boundary! {
+            let conn: &Connection = try_ref_from_ptr!(conn);
+            let protocol_out = try_mut_from_ptr!(protocol_out);
+            let protocol_out_len = try_mut_from_ptr!(protocol_out_len);
+            match conn.alpn_protocol() {
+                Some(p) => {
+                    *protocol_out = p.as_ptr();
+                    *protocol_out_len = p.len();
+                },
+                None => {
+                    *protocol_out = null();
+                    *protocol_out_len = 0;
+                }
             }
-        };
-        let n_written: usize = match conn.writer().write(write_buf) {
-            Ok(n) => n,
-            Err(_) => return rustls_result::Io,
-        };
-        *out_n = n_written;
-        rustls_result::Ok
+        }
     }
-}
 
-/// Read up to `count` plaintext bytes from the `rustls_connection` into `buf`.
-/// On success, store the number of bytes read in *out_n (this may be less
-/// than `count`). A success with *out_n set to 0 means "all bytes currently
-/// available have been read, but more bytes may become available after
-/// subsequent calls to rustls_connection_read_tls and
-/// rustls_connection_process_new_packets."
-///
-/// Subtle note: Even though this function only writes to `buf` and does not
-/// read from it, the memory in `buf` must be initialized before the call (for
-/// Rust-internal reasons). Initializing a buffer once and then using it
-/// multiple times without zeroizing before each call is fine.
-#[no_mangle]
-pub extern "C" fn rustls_connection_read(
-    conn: *mut rustls_connection,
-    buf: *mut u8,
-    count: size_t,
-    out_n: *mut size_t,
-) -> rustls_result {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        let read_buf: &mut [u8] = try_mut_slice!(buf, count);
-        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
-
-        let n_read: usize = match conn.reader().read(read_buf) {
-            Ok(n) => n,
-            Err(e) if e.kind() == ErrorKind::UnexpectedEof => return rustls_result::UnexpectedEof,
-            Err(e) if e.kind() == ErrorKind::WouldBlock => return rustls_result::PlaintextEmpty,
-            Err(_) => return rustls_result::Io,
-        };
-        *out_n = n_read;
-        rustls_result::Ok
+    /// Return the TLS protocol version that has been negotiated. Before this
+    /// has been decided during the handshake, this will return 0. Otherwise,
+    /// the u16 version number as defined in the relevant RFC is returned.
+    /// https://docs.rs/rustls/0.19.1/rustls/trait.Connection.html#tymethod.get_protocol_version
+    /// https://docs.rs/rustls/0.19.1/rustls/internal/msgs/enums/enum.ProtocolVersion.html
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_protocol_version(conn: *const rustls_connection) -> u16 {
+        ffi_panic_boundary! {
+            let conn: &Connection = try_ref_from_ptr!(conn);
+            match conn.protocol_version() {
+                Some(p) => p.get_u16(),
+                _ => 0,
+            }
+        }
     }
-}
 
-/// Free a rustls_connection. Calling with NULL is fine.
-/// Must not be called twice with the same value.
-#[no_mangle]
-pub extern "C" fn rustls_connection_free(conn: *mut rustls_connection) {
-    ffi_panic_boundary! {
-        let conn: &mut Connection = try_mut_from_ptr!(conn);
-        // Convert the pointer to a Box and drop it.
-        unsafe { Box::from_raw(conn); }
+    /// Retrieves the cipher suite agreed with the peer.
+    /// This returns NULL until the ciphersuite is agreed.
+    /// The returned pointer lives as long as the program.
+    /// https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.get_negotiated_ciphersuite
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_negotiated_ciphersuite(
+        conn: *const rustls_connection,
+    ) -> *const rustls_supported_ciphersuite {
+        ffi_panic_boundary! {
+            let conn: &Connection = try_ref_from_ptr!(conn);
+            let negotiated = match conn.negotiated_cipher_suite() {
+                Some(cs) => cs,
+                None => return null(),
+            };
+            for &cs in ALL_CIPHER_SUITES {
+                if negotiated == cs {
+                    return &cs as *const SupportedCipherSuite as *const _;
+                }
+            }
+            null()
+        }
+    }
+
+    /// Write up to `count` plaintext bytes from `buf` into the `rustls_connection`.
+    /// This will increase the number of output bytes available to
+    /// `rustls_connection_write_tls`.
+    /// On success, store the number of bytes actually written in *out_n
+    /// (this may be less than `count`).
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_write(
+        conn: *mut rustls_connection,
+        buf: *const u8,
+        count: size_t,
+        out_n: *mut size_t,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            let write_buf: &[u8] = try_slice!(buf, count);
+            let out_n: &mut size_t = unsafe {
+                match out_n.as_mut() {
+                    Some(out_n) => out_n,
+                    None => return NullParameter,
+                }
+            };
+            let n_written: usize = match conn.writer().write(write_buf) {
+                Ok(n) => n,
+                Err(_) => return rustls_result::Io,
+            };
+            *out_n = n_written;
+            rustls_result::Ok
+        }
+    }
+
+    /// Read up to `count` plaintext bytes from the `rustls_connection` into `buf`.
+    /// On success, store the number of bytes read in *out_n (this may be less
+    /// than `count`). A success with *out_n set to 0 means "all bytes currently
+    /// available have been read, but more bytes may become available after
+    /// subsequent calls to rustls_connection_read_tls and
+    /// rustls_connection_process_new_packets."
+    ///
+    /// Subtle note: Even though this function only writes to `buf` and does not
+    /// read from it, the memory in `buf` must be initialized before the call (for
+    /// Rust-internal reasons). Initializing a buffer once and then using it
+    /// multiple times without zeroizing before each call is fine.
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_read(
+        conn: *mut rustls_connection,
+        buf: *mut u8,
+        count: size_t,
+        out_n: *mut size_t,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            let read_buf: &mut [u8] = try_mut_slice!(buf, count);
+            let out_n: &mut size_t = try_mut_from_ptr!(out_n);
+
+            let n_read: usize = match conn.reader().read(read_buf) {
+                Ok(n) => n,
+                Err(e) if e.kind() == ErrorKind::UnexpectedEof => return rustls_result::UnexpectedEof,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => return rustls_result::PlaintextEmpty,
+                Err(_) => return rustls_result::Io,
+            };
+            *out_n = n_read;
+            rustls_result::Ok
+        }
+    }
+
+    /// Free a rustls_connection. Calling with NULL is fine.
+    /// Must not be called twice with the same value.
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_free(conn: *mut rustls_connection) {
+        ffi_panic_boundary! {
+            let conn: &mut Connection = try_mut_from_ptr!(conn);
+            // Convert the pointer to a Box and drop it.
+            unsafe { Box::from_raw(conn); }
+        }
     }
 }

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -125,7 +125,7 @@ typedef struct rustls_client_cert_verifier rustls_client_cert_verifier;
  * does not offer a certificate, the connection will succeed.
  *
  * The application can retrieve the certificate, if any, with
- * rustls_server_session_get_peer_certificate.
+ * rustls_connection_peer_certificate.
  */
 typedef struct rustls_client_cert_verifier_optional rustls_client_cert_verifier_optional;
 
@@ -302,7 +302,7 @@ typedef void (*rustls_log_callback)(void *userdata, const struct rustls_log_para
 typedef int rustls_io_result;
 
 /**
- * A callback for rustls_server_session_read_tls or rustls_client_session_read_tls.
+ * A callback for rustls_connection_read_tls.
  * An implementation of this callback should attempt to read up to n bytes from the
  * network, storing them in `buf`. If any bytes were stored, the implementation should
  * set out_n to the number of bytes stored and return 0. If there was an error,
@@ -311,14 +311,14 @@ typedef int rustls_io_result;
  * On other systems, any appropriate error code works.
  * It's best to make one read attempt to the network per call. Additional reads will
  * be triggered by subsequent calls to one of the `_read_tls` methods.
- * `userdata` is set to the value provided to `rustls_*_session_set_userdata`. In most
+ * `userdata` is set to the value provided to `rustls_connection_set_userdata`. In most
  * cases that should be a struct that contains, at a minimum, a file descriptor.
  * The buf and out_n pointers are borrowed and should not be retained across calls.
  */
 typedef rustls_io_result (*rustls_read_callback)(void *userdata, uint8_t *buf, size_t n, size_t *out_n);
 
 /**
- * A callback for rustls_server_session_write_tls or rustls_client_session_write_tls.
+ * A callback for rustls_connection_write_tls.
  * An implementation of this callback should attempt to write the `n` bytes in buf
  * to the network. If any bytes were written, the implementation should
  * set out_n to the number of bytes stored and return 0. If there was an error,
@@ -326,8 +326,8 @@ typedef rustls_io_result (*rustls_read_callback)(void *userdata, uint8_t *buf, s
  * passed through to the caller. On POSIX systems, returning `errno` is convenient.
  * On other systems, any appropriate error code works.
  * It's best to make one write attempt to the network per call. Additional writes will
- * be triggered by subsequent calls to one of the `_write_tls` methods.
- * `userdata` is set to the value provided to `rustls_*_session_set_userdata`. In most
+ * be triggered by subsequent calls to rustls_connection_write_tls.
+ * `userdata` is set to the value provided to `rustls_connection_set_userdata`. In most
  * cases that should be a struct that contains, at a minimum, a file descriptor.
  * The buf and out_n pointers are borrowed and should not be retained across calls.
  */
@@ -967,8 +967,8 @@ enum rustls_result rustls_connection_read(struct rustls_connection *conn,
 void rustls_connection_free(struct rustls_connection *conn);
 
 /**
- * After a rustls_client_session method returns an error, you may call
- * this method to get a pointer to a buffer containing a detailed error
+ * After a rustls function returns an error, you may call
+ * this to get a pointer to a buffer containing a detailed error
  * message. The contents of the error buffer will be out_n bytes long,
  * UTF-8 encoded, and not NUL-terminated.
  */

--- a/src/io.rs
+++ b/src/io.rs
@@ -6,7 +6,7 @@ use crate::error::rustls_io_result;
 use crate::rslice::rustls_slice_bytes;
 use std::ops::Deref;
 
-/// A callback for rustls_server_session_read_tls or rustls_client_session_read_tls.
+/// A callback for rustls_connection_read_tls.
 /// An implementation of this callback should attempt to read up to n bytes from the
 /// network, storing them in `buf`. If any bytes were stored, the implementation should
 /// set out_n to the number of bytes stored and return 0. If there was an error,
@@ -15,7 +15,7 @@ use std::ops::Deref;
 /// On other systems, any appropriate error code works.
 /// It's best to make one read attempt to the network per call. Additional reads will
 /// be triggered by subsequent calls to one of the `_read_tls` methods.
-/// `userdata` is set to the value provided to `rustls_*_session_set_userdata`. In most
+/// `userdata` is set to the value provided to `rustls_connection_set_userdata`. In most
 /// cases that should be a struct that contains, at a minimum, a file descriptor.
 /// The buf and out_n pointers are borrowed and should not be retained across calls.
 pub type rustls_read_callback = Option<
@@ -51,7 +51,7 @@ impl Read for CallbackReader {
     }
 }
 
-/// A callback for rustls_server_session_write_tls or rustls_client_session_write_tls.
+/// A callback for rustls_connection_write_tls.
 /// An implementation of this callback should attempt to write the `n` bytes in buf
 /// to the network. If any bytes were written, the implementation should
 /// set out_n to the number of bytes stored and return 0. If there was an error,
@@ -59,8 +59,8 @@ impl Read for CallbackReader {
 /// passed through to the caller. On POSIX systems, returning `errno` is convenient.
 /// On other systems, any appropriate error code works.
 /// It's best to make one write attempt to the network per call. Additional writes will
-/// be triggered by subsequent calls to one of the `_write_tls` methods.
-/// `userdata` is set to the value provided to `rustls_*_session_set_userdata`. In most
+/// be triggered by subsequent calls to rustls_connection_write_tls.
+/// `userdata` is set to the value provided to `rustls_connection_set_userdata`. In most
 /// cases that should be a struct that contains, at a minimum, a file descriptor.
 /// The buf and out_n pointers are borrowed and should not be retained across calls.
 pub type rustls_write_callback = Option<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,17 +6,19 @@ use std::sync::Arc;
 use std::{cmp::min, thread::AccessError};
 use std::{mem, slice};
 
-mod cipher;
-mod client;
-mod connection;
-mod enums;
+pub mod cipher;
+pub mod client;
+pub mod connection;
+pub mod enums;
 mod error;
-mod io;
-mod log;
+pub mod io;
+pub mod log;
 mod panic;
-mod rslice;
-mod server;
-mod session;
+pub mod rslice;
+pub mod server;
+pub mod session;
+
+pub use error::rustls_result;
 
 use crate::log::rustls_log_callback;
 use crate::panic::PanicOrDefault;
@@ -32,10 +34,10 @@ use crate::panic::PanicOrDefault;
 // Rust code, we model these thread locals as a stack, so we can always
 // restore the previous version.
 thread_local! {
-    pub static USERDATA: RefCell<Vec<Userdata>> = RefCell::new(Vec::new());
+    pub(crate) static USERDATA: RefCell<Vec<Userdata>> = RefCell::new(Vec::new());
 }
 
-pub struct Userdata {
+pub(crate) struct Userdata {
     userdata: *mut c_void,
     log_callback: rustls_log_callback,
 }
@@ -47,7 +49,7 @@ pub struct Userdata {
 ///  - The top item on that stack must be the one this guard was built with.
 ///  - The `data` field must not be None.
 /// If any of these invariants fails, try_drop will return an error.
-pub struct UserdataGuard {
+pub(crate) struct UserdataGuard {
     // Keep a copy of the data we expect to be popping off the stack. This allows
     // us to check for consistency, and also serves to make this type !Send:
     // https://doc.rust-lang.org/nightly/std/primitive.pointer.html#impl-Send-1
@@ -104,7 +106,7 @@ impl Drop for UserdataGuard {
 }
 
 #[derive(Clone, Debug)]
-pub enum UserdataError {
+pub(crate) enum UserdataError {
     /// try_pop was called twice.
     AlreadyPopped,
     /// The RefCell is borrowed somewhere else.
@@ -119,7 +121,7 @@ pub enum UserdataError {
 }
 
 #[must_use = "If you drop the guard, userdata will be immediately cleared"]
-pub fn userdata_push(
+pub(crate) fn userdata_push(
     u: *mut c_void,
     cb: rustls_log_callback,
 ) -> Result<UserdataGuard, UserdataError> {
@@ -140,7 +142,7 @@ pub fn userdata_push(
     Ok(UserdataGuard::new(u))
 }
 
-pub fn userdata_get() -> Result<*mut c_void, UserdataError> {
+pub(crate) fn userdata_get() -> Result<*mut c_void, UserdataError> {
     USERDATA
         .try_with(|userdata| {
             userdata.try_borrow_mut().map_or_else(
@@ -154,7 +156,7 @@ pub fn userdata_get() -> Result<*mut c_void, UserdataError> {
         .unwrap_or(Err(UserdataError::AccessError))
 }
 
-pub fn log_callback_get() -> Result<(rustls_log_callback, *mut c_void), UserdataError> {
+pub(crate) fn log_callback_get() -> Result<(rustls_log_callback, *mut c_void), UserdataError> {
     USERDATA
         .try_with(|userdata| {
             userdata.try_borrow_mut().map_or_else(
@@ -274,8 +276,8 @@ mod tests {
 // Keep in sync with Cargo.toml.
 const RUSTLS_CRATE_VERSION: &str = "0.20.0";
 
-/// CastPtr represents the relationship between a snake case type (like rustls_client_session)
-/// and the corresponding Rust type (like ClientSession). For each matched pair of types, there
+/// CastPtr represents the relationship between a snake case type (like rustls_client_config)
+/// and the corresponding Rust type (like ClientConfig). For each matched pair of types, there
 /// should be an `impl CastPtr for foo_bar { RustTy = FooBar }`.
 ///
 /// This allows us to avoid using `as` in most places, and ensure that when we cast, we're
@@ -311,6 +313,7 @@ pub(crate) trait BoxCastPtr: CastPtr + Sized {
     }
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! try_slice {
     ( $ptr:expr, $count:expr ) => {
@@ -322,6 +325,7 @@ macro_rules! try_slice {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! try_mut_slice {
     ( $ptr:expr, $count:expr ) => {
@@ -365,6 +369,7 @@ impl CastPtr for *const u8 {
 /// based on the context;
 /// Example:
 ///   let config: &mut ClientConfig = try_ref_from_ptr!(builder);
+#[doc(hidden)]
 #[macro_export]
 macro_rules! try_ref_from_ptr {
     ( $var:ident ) => {
@@ -375,6 +380,7 @@ macro_rules! try_ref_from_ptr {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! try_mut_from_ptr {
     ( $var:ident ) => {
@@ -385,6 +391,7 @@ macro_rules! try_mut_from_ptr {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! try_callback {
     ( $var:ident ) => {
@@ -419,10 +426,9 @@ pub extern "C" fn rustls_version(buf: *mut c_char, len: size_t) -> size_t {
     }
 }
 
-/// In rustls_server_config_builder_build, and rustls_client_config_builder_build,
-/// we create an Arc, then call `into_raw` and return the resulting raw pointer
-/// to C. C can then call rustls_server_session_new multiple times using that
-/// same raw pointer. On each call, we need to reconstruct the Arc. But once we reconstruct the Arc,
+/// Sometimes we create an Arc, then call `into_raw` and return the resulting raw pointer
+/// to C. C can then call back into rustls multiple times using that same raw pointer.
+/// On each call, we need to reconstruct the Arc. But once we reconstruct the Arc,
 /// its reference count will be decremented on drop. We need to reference count to stay at 1,
 /// because the C code is holding a copy. This function turns the raw pointer back into an Arc,
 /// clones it to increment the reference count (which will make it 2 in this particular case), and

--- a/src/log.rs
+++ b/src/log.rs
@@ -35,7 +35,7 @@ pub(crate) fn ensure_log_registered() {
     log::set_max_level(log::LevelFilter::Debug)
 }
 
-type rustls_log_level = usize;
+pub type rustls_log_level = usize;
 
 /// Return a rustls_str containing the stringified version of a log level.
 #[no_mangle]
@@ -53,8 +53,8 @@ pub extern "C" fn rustls_log_level_str(level: rustls_log_level) -> rustls_str<'s
 
 #[repr(C)]
 pub struct rustls_log_params<'a> {
-    level: rustls_log_level,
-    message: rustls_str<'a>,
+    pub level: rustls_log_level,
+    pub message: rustls_str<'a>,
 }
 
 #[allow(non_camel_case_types)]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -92,6 +92,7 @@ impl NullParameterOrDefault for rustls_io_result {
     }
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! ffi_panic_boundary {
     ( $($tt:tt)* ) => {


### PR DESCRIPTION
Previously, rustdoc didn't render most of our types and functions,
because they weren't brought in with `pub mod` or `pub use`. This change
makes everything public that should be. Also, some internal-only things
were accidentally public; made those pub(crate).

Wrapped most method-like functions in an `impl` block, so they become
associated functions and are listed on their struct's page rather than
on separate pages by themselves.

Hide all macros, because they are internal implementation details.

Fix some leftover places where comments referred to
`rustls_client_session` or `rustls_server_session`.

This change doesn't affect visibility or naming of symbols in the
built C library, just how rustdoc renders things.

Note: rustdoc probably isn't the best overall tool for documenting
this library, since it presents function signatures with Rust syntax and
types rather than C syntax and types. However, it's handy for navigation
and seeing how things fit together.

Demo at https://jacob.hoffman-andrews.com/rust/rustls-ffi/crustls/index.html.