### PR TITLE
Introduce ArcCastPtr; add try macros for BoxCastPtr

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -20,8 +20,8 @@ use crate::error::{self, result_to_error, rustls_result};
 use crate::rslice::NulByte;
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_str};
 use crate::{
-    arc_with_incref_from_raw, ffi_panic_boundary, try_mut_from_ptr, try_ref_from_ptr, try_slice,
-    userdata_get, BoxCastPtr, CastPtr,
+    ffi_panic_boundary, try_mut_from_ptr, try_ref_from_ptr, try_slice, userdata_get, ArcCastPtr,
+    BoxCastPtr, CastConstPtr, CastPtr,
 };
 
 /// A client config being constructed. A builder can be modified by,
@@ -64,9 +64,11 @@ pub struct rustls_client_config {
     _private: [u8; 0],
 }
 
-impl CastPtr for rustls_client_config {
+impl CastConstPtr for rustls_client_config {
     type RustType = ClientConfig;
 }
+
+impl ArcCastPtr for rustls_client_config {}
 
 /// Create a rustls_client_config_builder. Caller owns the memory and must
 /// eventually call rustls_client_config_builder_build, then free the
@@ -440,13 +442,7 @@ pub extern "C" fn rustls_client_config_builder_set_certified_key(
         let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
         let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
         for &key_ptr in keys_ptrs {
-            let key_ptr: &CertifiedKey = try_ref_from_ptr!(key_ptr);
-            let certified_key: Arc<CertifiedKey> = unsafe {
-                match (key_ptr as *const CertifiedKey).as_ref() {
-                    Some(c) => arc_with_incref_from_raw(c),
-                    None => return NullParameter,
-                }
-            };
+            let certified_key: Arc<CertifiedKey> = ArcCastPtr::to_arc(key_ptr);
             keys.push(certified_key);
         }
         config.client_auth_cert_resolver = Arc::new(ResolvesClientCertFromChoices { keys });
@@ -486,7 +482,7 @@ pub extern "C" fn rustls_client_config_builder_build(
 ) -> *const rustls_client_config {
     ffi_panic_boundary! {
         let b = BoxCastPtr::to_box(builder);
-        Arc::into_raw(Arc::new(*b)) as *const _
+        ArcCastPtr::to_const_ptr(*b)
     }
 }
 
@@ -538,12 +534,7 @@ pub extern "C" fn rustls_client_connection_new(
             }
             CStr::from_ptr(hostname)
         };
-        let config: Arc<ClientConfig> = unsafe {
-            match (config as *const ClientConfig).as_ref() {
-                Some(c) => arc_with_incref_from_raw(c),
-                None => return NullParameter,
-            }
-        };
+        let config: Arc<ClientConfig> = ArcCastPtr::to_arc(config);
         let hostname: &str = match hostname.to_str() {
             Ok(s) => s,
             Err(std::str::Utf8Error { .. }) => return rustls_result::InvalidDnsNameError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,9 @@ pub(crate) trait CastConstPtr {
     }
 }
 
+/// Anything that qualifies for CastPtr also automatically qualifies for
+/// CastConstPtr. Splitting out CastPtr vs CastConstPtr allows us to ensure
+/// that Arcs are never cast to a mutable pointer.
 impl<T, R> CastConstPtr for T
 where
     T: CastPtr<RustType = R>,
@@ -410,18 +413,14 @@ pub(crate) fn try_box_from<'a, F, T>(from: *mut F) -> Option<Box<T>>
 where
     F: BoxCastPtr<RustType = T>,
 {
-    {
-        F::to_box(from)
-    }
+    F::to_box(from)
 }
 
 pub(crate) fn try_arc_from<'a, F, T>(from: *const F) -> Option<Arc<T>>
 where
     F: ArcCastPtr<RustType = T>,
 {
-    {
-        F::to_arc(from)
-    }
+    F::to_arc(from)
 }
 
 impl CastPtr for size_t {

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,8 +27,8 @@ use crate::session::{
     SessionStoreGetCallback, SessionStorePutCallback,
 };
 use crate::{
-    ffi_panic_boundary, try_mut_from_ptr, try_mut_slice, try_ref_from_ptr, try_slice, userdata_get,
-    ArcCastPtr, BoxCastPtr, CastConstPtr, CastPtr,
+    ffi_panic_boundary, try_arc_from_ptr, try_box_from_ptr, try_mut_from_ptr, try_mut_slice,
+    try_ref_from_ptr, try_slice, userdata_get, ArcCastPtr, BoxCastPtr, CastConstPtr, CastPtr,
 };
 
 /// A server config being constructed. A builder can be modified by,
@@ -167,7 +167,7 @@ pub extern "C" fn rustls_server_config_builder_with_no_client_auth(
     wants_verifier: *mut rustls_server_config_builder_wants_verifier,
 ) -> *mut rustls_server_config_builder {
     ffi_panic_boundary! {
-        let prev = *BoxCastPtr::to_box(wants_verifier);
+        let prev = *try_box_from_ptr!(wants_verifier);
         let config: ServerConfig = prev.with_no_client_auth().with_cert_resolver(Arc::new(rustls::server::ResolvesServerCertUsingSni::new()));
         BoxCastPtr::to_mut_ptr(config)
     }
@@ -185,9 +185,9 @@ pub extern "C" fn rustls_server_config_builder_with_client_verifier(
     builder: *mut *mut rustls_server_config_builder_wants_server_cert,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let verifier: Arc<AllowAnyAuthenticatedClient> = ArcCastPtr::to_arc(verifier);
+        let verifier: Arc<AllowAnyAuthenticatedClient> = try_arc_from_ptr!(verifier);
 
-        let prev = *BoxCastPtr::to_box(wants_verifier);
+        let prev = *try_box_from_ptr!(wants_verifier);
         let new = prev.with_client_cert_verifier(verifier);
         BoxCastPtr::set_mut_ptr(builder, new);
         rustls_result::Ok
@@ -204,7 +204,7 @@ pub extern "C" fn rustls_server_config_builder_with_client_verifier_optional(
     verifier: *const rustls_client_cert_verifier_optional,
 ) -> *mut rustls_server_config_builder {
     ffi_panic_boundary! {
-        let verifier: Arc<AllowAnyAnonymousOrAuthenticatedClient> = ArcCastPtr::to_arc(verifier);
+        let verifier: Arc<AllowAnyAnonymousOrAuthenticatedClient> = try_arc_from_ptr!(verifier);
 
         let builder = rustls::ServerConfig::builder().with_safe_defaults();
         let config: ServerConfig = builder.with_client_cert_verifier(verifier).with_cert_resolver(Arc::new(rustls::server::ResolvesServerCertUsingSni::new()));
@@ -306,7 +306,7 @@ pub extern "C" fn rustls_server_config_builder_set_certified_keys(
         let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
         let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
         for &key_ptr in keys_ptrs {
-            let certified_key: Arc<CertifiedKey> = ArcCastPtr::to_arc(key_ptr);
+            let certified_key: Arc<CertifiedKey> = try_arc_from_ptr!(key_ptr);
             keys.push(certified_key);
         }
         config.cert_resolver = Arc::new(ResolvesServerCertFromChoices::new(&keys));
@@ -321,7 +321,7 @@ pub extern "C" fn rustls_server_config_builder_build(
     builder: *mut rustls_server_config_builder,
 ) -> *const rustls_server_config {
     ffi_panic_boundary! {
-        let b = BoxCastPtr::to_box(builder);
+        let b = try_box_from_ptr!(builder);
         ArcCastPtr::to_const_ptr(*b)
     }
 }
@@ -355,7 +355,7 @@ pub extern "C" fn rustls_server_connection_new(
     conn_out: *mut *mut rustls_connection,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let config: Arc<ServerConfig> = ArcCastPtr::to_arc(config);
+        let config: Arc<ServerConfig> = try_arc_from_ptr!(config);
 
         let server_connection = match ServerConnection::new(config) {
             Ok(sc) => sc,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
 use std::ffi::c_void;
-use std::ptr::null_mut;
 use std::slice;
 use std::sync::Arc;
 
@@ -28,8 +27,8 @@ use crate::session::{
     SessionStoreGetCallback, SessionStorePutCallback,
 };
 use crate::{
-    arc_with_incref_from_raw, ffi_panic_boundary, try_mut_from_ptr, try_mut_slice,
-    try_ref_from_ptr, try_slice, userdata_get, BoxCastPtr, CastPtr,
+    ffi_panic_boundary, try_mut_from_ptr, try_mut_slice, try_ref_from_ptr, try_slice, userdata_get,
+    ArcCastPtr, BoxCastPtr, CastConstPtr, CastPtr,
 };
 
 /// A server config being constructed. A builder can be modified by,
@@ -88,9 +87,11 @@ pub struct rustls_server_config {
     _private: [u8; 0],
 }
 
-impl CastPtr for rustls_server_config {
+impl CastConstPtr for rustls_server_config {
     type RustType = ServerConfig;
 }
+
+impl ArcCastPtr for rustls_server_config {}
 
 /// Create a rustls_server_config_builder. Caller owns the memory and must
 /// eventually call rustls_server_config_builder_build, then free the
@@ -184,12 +185,7 @@ pub extern "C" fn rustls_server_config_builder_with_client_verifier(
     builder: *mut *mut rustls_server_config_builder_wants_server_cert,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let verifier: Arc<AllowAnyAuthenticatedClient> = unsafe {
-            match (verifier as *const AllowAnyAuthenticatedClient).as_ref() {
-                Some(c) => arc_with_incref_from_raw(c),
-                None => return rustls_result::InvalidParameter,
-            }
-        };
+        let verifier: Arc<AllowAnyAuthenticatedClient> = ArcCastPtr::to_arc(verifier);
 
         let prev = *BoxCastPtr::to_box(wants_verifier);
         let new = prev.with_client_cert_verifier(verifier);
@@ -208,12 +204,7 @@ pub extern "C" fn rustls_server_config_builder_with_client_verifier_optional(
     verifier: *const rustls_client_cert_verifier_optional,
 ) -> *mut rustls_server_config_builder {
     ffi_panic_boundary! {
-        let verifier: Arc<AllowAnyAnonymousOrAuthenticatedClient> = unsafe {
-            match (verifier as *const AllowAnyAnonymousOrAuthenticatedClient).as_ref() {
-                Some(c) => arc_with_incref_from_raw(c),
-                None => return null_mut(),
-            }
-        };
+        let verifier: Arc<AllowAnyAnonymousOrAuthenticatedClient> = ArcCastPtr::to_arc(verifier);
 
         let builder = rustls::ServerConfig::builder().with_safe_defaults();
         let config: ServerConfig = builder.with_client_cert_verifier(verifier).with_cert_resolver(Arc::new(rustls::server::ResolvesServerCertUsingSni::new()));
@@ -315,13 +306,7 @@ pub extern "C" fn rustls_server_config_builder_set_certified_keys(
         let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
         let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
         for &key_ptr in keys_ptrs {
-            let key_ptr: &CertifiedKey = try_ref_from_ptr!(key_ptr);
-            let certified_key: Arc<CertifiedKey> = unsafe {
-                match (key_ptr as *const CertifiedKey).as_ref() {
-                    Some(c) => arc_with_incref_from_raw(c),
-                    None => return NullParameter,
-                }
-            };
+            let certified_key: Arc<CertifiedKey> = ArcCastPtr::to_arc(key_ptr);
             keys.push(certified_key);
         }
         config.cert_resolver = Arc::new(ResolvesServerCertFromChoices::new(&keys));
@@ -337,7 +322,7 @@ pub extern "C" fn rustls_server_config_builder_build(
 ) -> *const rustls_server_config {
     ffi_panic_boundary! {
         let b = BoxCastPtr::to_box(builder);
-        Arc::into_raw(Arc::new(*b)) as *const _
+        ArcCastPtr::to_const_ptr(*b)
     }
 }
 
@@ -370,12 +355,7 @@ pub extern "C" fn rustls_server_connection_new(
     conn_out: *mut *mut rustls_connection,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let config: Arc<ServerConfig> = unsafe {
-            match (config as *const ServerConfig).as_ref() {
-                Some(c) => arc_with_incref_from_raw(c),
-                None => return NullParameter,
-            }
-        };
+        let config: Arc<ServerConfig> = ArcCastPtr::to_arc(config);
 
         let server_connection = match ServerConnection::new(config) {
             Ok(sc) => sc,


### PR DESCRIPTION
Building on @djc's excellent addition of BoxCastPtr in #88, this introduces ArcCastPtr, which fills the same role for Arcs. Also, this introduces null checking for both BoxCastPtr and ArcCastPtr, and adds try macros for both of them.