### PR TITLE
all: fix reference to function

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -90,11 +90,11 @@ impl rustls_client_config_builder {
 
     /// Create a rustls_client_config_builder. Caller owns the memory and must
     /// eventually call rustls_client_config_builder_build, then free the
-    /// resulting rustls_client_config. Specify cipher suites in preference order;
-    /// the `cipher_suites` parameter must point to an array containing `len`
-    /// pointers to `rustls_supported_ciphersuite` previously obtained from
-    /// `rustls_all_ciphersuites_get()`. Set the TLS protocol versions to use
-    /// when negotiating a TLS session.
+    /// resulting rustls_client_config. Specify cipher suites in preference
+    /// order; the `cipher_suites` parameter must point to an array containing
+    /// `len` pointers to `rustls_supported_ciphersuite` previously obtained
+    /// from `rustls_all_ciphersuites_get_entry()`. Set the TLS protocol
+    /// versions to use when negotiating a TLS session.
     ///
     /// `tls_version` is the version of the protocol, as defined in rfc8446,
     /// ch. 4.2.1 and end of ch. 5.1. Some values are defined in

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -637,11 +637,11 @@ struct rustls_client_config_builder_wants_verifier *rustls_client_config_builder
 /**
  * Create a rustls_client_config_builder. Caller owns the memory and must
  * eventually call rustls_client_config_builder_build, then free the
- * resulting rustls_client_config. Specify cipher suites in preference order;
- * the `cipher_suites` parameter must point to an array containing `len`
- * pointers to `rustls_supported_ciphersuite` previously obtained from
- * `rustls_all_ciphersuites_get()`. Set the TLS protocol versions to use
- * when negotiating a TLS session.
+ * resulting rustls_client_config. Specify cipher suites in preference
+ * order; the `cipher_suites` parameter must point to an array containing
+ * `len` pointers to `rustls_supported_ciphersuite` previously obtained
+ * from `rustls_all_ciphersuites_get_entry()`. Set the TLS protocol
+ * versions to use when negotiating a TLS session.
  *
  * `tls_version` is the version of the protocol, as defined in rfc8446,
  * ch. 4.2.1 and end of ch. 5.1. Some values are defined in
@@ -1019,11 +1019,11 @@ struct rustls_server_config_builder_wants_verifier *rustls_server_config_builder
 /**
  * Create a rustls_server_config_builder. Caller owns the memory and must
  * eventually call rustls_server_config_builder_build, then free the
- * resulting rustls_server_config. Specify cipher suites in preference order;
- * the `cipher_suites` parameter must point to an array containing `len`
- * pointers to `rustls_supported_ciphersuite` previously obtained from
- * `rustls_all_ciphersuites_get()`. Set the TLS protocol versions to use
- * when negotiating a TLS session.
+ * resulting rustls_server_config. Specify cipher suites in preference
+ * order; the `cipher_suites` parameter must point to an array containing
+ * `len` pointers to `rustls_supported_ciphersuite` previously obtained
+ * from `rustls_all_ciphersuites_get_entry()`. Set the TLS protocol
+ * versions to use when negotiating a TLS session.
  *
  * `tls_version` is the version of the protocol, as defined in rfc8446,
  * ch. 4.2.1 and end of ch. 5.1. Some values are defined in

--- a/src/server.rs
+++ b/src/server.rs
@@ -109,11 +109,11 @@ impl rustls_server_config_builder {
 
     /// Create a rustls_server_config_builder. Caller owns the memory and must
     /// eventually call rustls_server_config_builder_build, then free the
-    /// resulting rustls_server_config. Specify cipher suites in preference order;
-    /// the `cipher_suites` parameter must point to an array containing `len`
-    /// pointers to `rustls_supported_ciphersuite` previously obtained from
-    /// `rustls_all_ciphersuites_get()`. Set the TLS protocol versions to use
-    /// when negotiating a TLS session.
+    /// resulting rustls_server_config. Specify cipher suites in preference
+    /// order; the `cipher_suites` parameter must point to an array containing
+    /// `len` pointers to `rustls_supported_ciphersuite` previously obtained
+    /// from `rustls_all_ciphersuites_get_entry()`. Set the TLS protocol
+    /// versions to use when negotiating a TLS session.
     ///
     /// `tls_version` is the version of the protocol, as defined in rfc8446,
     /// ch. 4.2.1 and end of ch. 5.1. Some values are defined in


### PR DESCRIPTION
The docs reference rustls_all_ciphersuites_get() which does not exist.
Fix the references.