### PR TITLE
lib.rs: correct rustls_version docs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
     let pkg_version = env!("CARGO_PKG_VERSION");
     write!(
         &mut f,
-        r#"const RUSTLS_FFI_VERSION: &'static str = "crustls/{}/rustls/{}";
+        r#"const RUSTLS_FFI_VERSION: &'static str = "rustls-ffi/{}/rustls/{}";
 "#,
         pkg_version, RUSTLS_CRATE_VERSION
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use error::rustls_result;
 use crate::log::rustls_log_callback;
 use crate::panic::PanicOrDefault;
 
+// version.rs gets written at compile time by build.rs
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
 // For C callbacks, we need to offer a `void *userdata` parameter, so the
@@ -488,9 +489,9 @@ macro_rules! try_callback {
         }
     };
 }
-/// Write the version of the crustls C bindings and rustls itself into the
-/// provided buffer, up to a max of `len` bytes. Output is UTF-8 encoded
-/// and NUL terminated. Returns the number of bytes written before the NUL.
+/// Returns a static string containing the rustls-ffi version as well as the
+/// rustls version. The string is alive for the lifetime of the program and does
+/// not need to be freed.
 #[no_mangle]
 pub extern "C" fn rustls_version() -> rustls_str<'static> {
     return rustls_str::from_str_unchecked(RUSTLS_FFI_VERSION);

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -460,9 +460,9 @@ typedef enum rustls_result (*rustls_session_store_get_callback)(rustls_session_s
 typedef enum rustls_result (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
 
 /**
- * Write the version of the crustls C bindings and rustls itself into the
- * provided buffer, up to a max of `len` bytes. Output is UTF-8 encoded
- * and NUL terminated. Returns the number of bytes written before the NUL.
+ * Returns a static string containing the rustls-ffi version as well as the
+ * rustls version. The string is alive for the lifetime of the program and does
+ * not need to be freed.
  */
 struct rustls_str rustls_version(void);
 

--- a/tests/client.c
+++ b/tests/client.c
@@ -188,18 +188,21 @@ send_request_and_read_response(struct conndata *conn,
   const char *content_length_end;
   unsigned long content_length = 0;
   size_t headers_len = 0;
+  struct rustls_str version;
 
+  version = rustls_version();
   bzero(buf, sizeof(buf));
   snprintf(buf,
            sizeof(buf),
            "GET %s HTTP/1.1\r\n"
            "Host: %s\r\n"
-           "User-Agent: crustls-demo\r\n"
+           "User-Agent: %s\r\n"
            "Accept: carcinization/inevitable, text/html\r\n"
            "Connection: close\r\n"
            "\r\n",
            path,
-           hostname);
+           hostname,
+           version.data);
   /* First we write the plaintext - the data that we want rustls to encrypt for
    * us- to the rustls connection. */
   result = rustls_connection_write(rconn, (uint8_t *)buf, strlen(buf), &n);


### PR DESCRIPTION
We changed the behavior of this function to return a static str, but
the docs still referred to the old behavior (write to a buffer). Fix
the documentation, and provide an example of how to use it in
tests/client.c.

Update the version to reflect the new name of the package
("rustls-ffi").

Fixes #168.