### PR TITLE
Quiet the "wait for port" code in test.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-set -xeu
+set -eu
 
 port_is_open() {
   local host="$1" port="$2"
-  if exec 6<>/dev/tcp/$host/$port; then
+  if { exec 6<>/dev/tcp/"${host}"/"${port}" ; } 2>/dev/null ; then
     exec 6>&-
     return 0
   fi
@@ -14,13 +14,13 @@ wait_tcp_port() {
     local host="$1" port="$2"
 
     # see https://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
-    local max_tries="120"
+    local max_tries="24"
     for n in `seq 1 $max_tries` ; do
       if port_is_open "${host}" "${port}"; then
         break
       else
         echo "$(date) - still trying to connect to $host:$port"
-        sleep .1
+        sleep .5
       fi
       if [ "$n" -eq "$max_tries" ]; then
         echo "unable to connect"

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,7 @@ wait_tcp_port() {
 
     # see https://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
     local max_tries="24"
-    for n in `seq 1 $max_tries` ; do
+    for n in $(seq 1 $max_tries) ; do
       if port_is_open "${host}" "${port}"; then
         break
       else
@@ -31,13 +31,13 @@ wait_tcp_port() {
 }
 
 kill_server() {
-  kill $SERVER_PID
+  kill "${SERVER_PID}"
 }
 
 run_client_tests() {
   CA_FILE=minica.pem ./target/client localhost 8443 /
-  NO_CHECK_CERTIFICATE= ./target/client localhost 8443 /
-  CA_FILE=minica.pem VECTORED_IO= ./target/client localhost 8443 /
+  NO_CHECK_CERTIFICATE='' ./target/client localhost 8443 /
+  CA_FILE=minica.pem VECTORED_IO='' ./target/client localhost 8443 /
 }
 
 if port_is_open localhost 8443 ; then
@@ -57,7 +57,7 @@ kill_server
 sleep 1
 
 # Start server with vectored I/O
-VECTORED_IO= ./target/server localhost/cert.pem localhost/key.pem &
+VECTORED_IO='' ./target/server localhost/cert.pem localhost/key.pem &
 SERVER_PID=$!
 wait_tcp_port localhost 8443
 


### PR DESCRIPTION
When the server fails to come up for some reason, we were emitting a lot
of logs, like:

./test.sh: connect: Connection refused
./test.sh: line 6: /dev/tcp/localhost/8443: Connection refused
+ return 1
++ date
+ echo 'Thu Nov  4 16:41:19 UTC 2021 - still trying to connect to localhost:8443'
Thu Nov  4 16:41:19 UTC 2021 - still trying to connect to localhost:8443
+ sleep .1
+ '[' 102 -eq 120 ']'
+ for n in '`seq 1 $max_tries`'
+ port_is_open localhost 8443
+ local host=localhost port=8443
+ exec

This turns off `-x`, which was responsible for much of the logs, and also
captures stdout and stderr when testing the port. So instead we see:

Thu Nov  4 16:41:19 UTC 2021 - still trying to connect to localhost:8443
Thu Nov  4 16:41:20 UTC 2021 - still trying to connect to localhost:8443
Thu Nov  4 16:41:20 UTC 2021 - still trying to connect to localhost:8443
Thu Nov  4 16:41:21 UTC 2021 - still trying to connect to localhost:8443

This also increases the sleep time somewhat and decreases the number of attempts.

Also, add some shellcheck fixes from #190.