### PR TITLE
Update rustls.h

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - run: touch src/lib.rs
       - run: make src/rustls.h
       - run: git diff --exit-code
 

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -499,7 +499,7 @@ size_t rustls_default_ciphersuites_len(void);
 
 /**
  * Get a pointer to a member of rustls' list of supported cipher suites. This will return non-NULL
- * for i < rustls_all_ciphersuites_len().
+ * for i < rustls_default_ciphersuites_len().
  * The returned pointer is valid for the lifetime of the program and may be used directly when
  * building a ClientConfig or ServerConfig.
  */
@@ -531,7 +531,7 @@ enum rustls_result rustls_certified_key_build(const uint8_t *cert_chain,
 /**
  * Return the i-th rustls_certificate in the rustls_certified_key. 0 gives the
  * end-entity certificate. 1 and higher give certificates from the chain.
- * Indexes higher the the last available certificate return NULL.
+ * Indexes higher than the last available certificate return NULL.
  *
  * The returned certificate is valid until the rustls_certified_key is freed.
  */


### PR DESCRIPTION
And make the ensure-header-updated test in CI touch a .rs file to ensure
the target actually gets regenerated, regardless of the timestamps in
git.