### PR TITLE
Fix documented lifetime on connection getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,85 @@
 
 ## 0.8.0 (unreleased)
 
-The package name has changed from "crustls" to "rustls-ffi". If you are
-importing it as a library from other Rust code, you should import `rustls_ffi`.
+The package name has changed to "rustls-ffi" (from "crustls").
+The header file (as installed by `make DESTDIR=/path/ install`)
+is now `rustls.h` and the library is `librustls.a`. The old library and header
+names are symlinked as part of the install process, to simplify upgrading to the
+new version.
 
-The header file is now named `rustls.h` instead of `crustls.h`, and the
-generated `.a` file is named `librustls_ffi.a` instead of `libcrustls.a`.
+If you are importing this as a library from other Rust code, you should import `rustls_ffi`.
+
+## New
+ - rustls_client_config_builder_new_custom and rustls_server_config_builder_new_custom:
+   start building a config, with ciphersuites and TLS versions set at initial construction.
+ - rustls_default_ciphersuites_get_entry() and
+   rustls_default_ciphersuites_len(): get default ciphersuites as opposed to
+   all ciphersuites (these happen to be the same today but might not always be).
+
+## Changed
+
+- `rustls-ffi` now imports `rustls` version 0.20, up from rustls 0.19. [View
+  the changelog](https://github.com/rustls/rustls#release-history).
+- Configuring ciphersuites and TLS versions. Previously these
+  could be set using setter methods on the builder object. Now they have
+  to be set at the beginning of the config builder process, by calling
+  rustls_client_config_builder_new_custom().
+- Reading of plaintext from a rustls_connection. When the
+  internal plaintext buffer is empty, rustls_connection_read will return
+  RUSTLS_RESULT_PLAINTEXT_EMPTY. That means no more plaintext can be read until
+  additional TLS bytes are ingested via rustls_connection_read_tls, and
+  rustls_connection_process_new_packets is called. Previously this condition was
+  indicated by returning RUSTLS_RESULT_OK with out_n set to 0.
+- Handling of unclean close and the close_notify TLS alert. Mirroring upstream changes,
+  a rustls_connection now tracks TCP closed state like so: rustls_connection_read_tls
+  considers a 0-length read from its callback to mean "TCP stream was closed by peer."
+  If that happens before the peer sent close_notify, rustls_connection_read will return
+  RUSTLS_RESULT_UNEXPECTED_EOF once the available plaintext bytes are exhausted. This is
+  useful to protect against truncation attacks. Note:
+  some TLS implementations don't send close_notify. If you are already getting length
+  information from your protocol (e.g. Content-Length in HTTP) you may choose to
+  ignore UNEXPECTED_EOF so long as the number of plaintext bytes was as
+  expected.
+- `rustls_version` returns a `rustls_str` that points to a static string in
+  memory, and the function no longer accepts a character buffer or length.
+- Some errors starting with RUSTLS_RESULT_CERT_ have been removed, and
+  some renamed.
+- rustls_client_config_builder_set_protocols is now rustls_client_config_builder_set_alpn_protocols.
+- rustls_server_config_builder_set_protocols is now rustls_server_config_builder_set_alpn_protocols.
+- rustls_server_config_builder_with_client_verifier and
+  rustls_server_config_builder_with_client_verifier_optional are replaced by
+  rustls_server_config_builder_set_client_verifier and
+  rustls_server_config_builder_set_client_verifier_optional, which are setters
+  rather than constructors.
+- The documented lifetime for pointers returned by rustls_connection_get_peer_certificate
+  and rustls_connection_get_alpn_protocol has been fixed - the pointers those
+  function provide are valid until the next mutating function call on that
+  connection.
+
+## Removed
+
+ - rustls_client_config_builder_from_config and
+   rustls_server_config_builder_from_config have been removed. These were
+   incompatible with the changes to config builders. Previously the notion of
+   "config builder" in this library simply meant "A ClientConfig that hasn't yet
+   been wrapped in an Arc," so we could use `Clone` to get a copy of one. Now
+   "config builder" corresponds to the underlying `ConfigBuilder` in rustls
+   (plus some rustls-ffi internal state), so we can't use `Clone` on a
+  `ClientConfig` to get one. And we can't manually copy fields from a ClientConfig,
+   since some of the necessary fields are private.
+ - rustls_client_config_builder_set_versions and
+   rustls_client_config_builder_set_ciphersuites are gone - for equivalent
+   functionality, use rustls_client_config_builder_new_custom and
+   rustls_server_config_builder_new_custom.
+
+
+## 0.7.2 - 2021-07-06
 
 ### Added
 
   - Adds support for TLS client certificates (servers authenticating clients),
     using the new `rustls_client_config_builder_set_certified_key` API.
     (https://github.com/rustls/rustls-ffi/pull/128)
-
-### Changed
-
-Software changes:
-
-  - `rustls-ffi` now imports `rustls` version 0.20, up from rustls 0.19. [View
-  the diff](https://github.com/rustls/rustls/compare/v/0.19.1...v/0.20.0)
-  - Client configurations can be initialized with safe defaults using the new
-    `rustls_client_config_builder_new` method, and then modified from there to
-    add defaults.
-  - `rustls_version` returns a `rustls_str` that points to a static string in
-    memory, and the function no longer accepts a character buffer or length.
-  - Rearrange exports so rustdoc should render documentation better.
 
 ## 0.7.1 - 2021-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ If you are importing this as a library from other Rust code, you should import `
   rather than constructors.
 - The documented lifetime for pointers returned by rustls_connection_get_peer_certificate
   and rustls_connection_get_alpn_protocol has been fixed - the pointers those
-  function provide are valid until the next mutating function call on that
+  functions provide are valid until the next mutating function call on that
   connection.
 
 ## Removed

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -499,7 +499,7 @@ size_t rustls_default_ciphersuites_len(void);
 
 /**
  * Get a pointer to a member of rustls' list of supported cipher suites. This will return non-NULL
- * for i < rustls_all_ciphersuites_len().
+ * for i < rustls_default_ciphersuites_len().
  * The returned pointer is valid for the lifetime of the program and may be used directly when
  * building a ClientConfig or ServerConfig.
  */
@@ -531,7 +531,7 @@ enum rustls_result rustls_certified_key_build(const uint8_t *cert_chain,
 /**
  * Return the i-th rustls_certificate in the rustls_certified_key. 0 gives the
  * end-entity certificate. 1 and higher give certificates from the chain.
- * Indexes higher the the last available certificate return NULL.
+ * Indexes higher than the last available certificate return NULL.
  *
  * The returned certificate is valid until the rustls_certified_key is freed.
  */
@@ -903,10 +903,13 @@ void rustls_connection_send_close_notify(struct rustls_connection *conn);
  * Index 0 is the end entity certificate. Higher indexes are certificates
  * in the chain. Requesting an index higher than what is available returns
  * NULL.
- * The returned pointer lives as long as the rustls_connection does.
+ * The returned pointer is valid until the next mutating function call
+ * affecting the connection. A mutating function call is one where the
+ * first argument has type `struct rustls_connection *` (as opposed to
+ *  `const struct rustls_connection *`).
  * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.peer_certificates>
  */
-const struct rustls_certificate *rustls_connection_get_peer_certificate(struct rustls_connection *conn,
+const struct rustls_certificate *rustls_connection_get_peer_certificate(const struct rustls_connection *conn,
                                                                         size_t i);
 
 /**
@@ -915,6 +918,10 @@ const struct rustls_certificate *rustls_connection_get_peer_certificate(struct r
  * The borrow lives as long as the connection.
  * If the connection is still handshaking, or no ALPN protocol was negotiated,
  * stores NULL and 0 in the output parameters.
+ * The provided pointer is valid until the next mutating function call
+ * affecting the connection. A mutating function call is one where the
+ * first argument has type `struct rustls_connection *` (as opposed to
+ *  `const struct rustls_connection *`).
  * <https://www.iana.org/assignments/tls-parameters/>
  * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.alpn_protocol>
  */


### PR DESCRIPTION
And change rustls_connection_get_peer_certificate to take a `*const rustls_connection`.

Fixes #178.