### PR TITLE
Plug server mem-leaks

### DIFF
--- a/tests/client.c
+++ b/tests/client.c
@@ -12,10 +12,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/uio.h>
 #endif
 
 #include <sys/types.h>
-#include <sys/uio.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/tests/server.c
+++ b/tests/server.c
@@ -156,14 +156,13 @@ send_response(struct conndata *conn)
   n = sprintf(response, "%s %d\r\n\r\n", prefix, body_size);
   memset(response + n, 'a', body_size);
   *(response + n + body_size + 1) = '\0';
-  fprintf(stderr, "strlen response %ld\n", strlen(response));
+  response_size = strlen(response);
+  fprintf(stderr, "strlen response %ld\n", response_size);
 
   rustls_connection_write(
-    rconn, (const uint8_t *)response, strlen(response), &n);
+    rconn, (const uint8_t *)response, response_size, &n);
   
-  response_size = strlen(response);
-  free(response);
-  
+  free(response);  
   if(n != response_size) {
     fprintf(stderr, "failed to write all response bytes. wrote %ld\n", n);
     return CRUSTLS_DEMO_ERROR;

--- a/tests/server.c
+++ b/tests/server.c
@@ -144,7 +144,7 @@ send_response(struct conndata *conn)
   struct rustls_connection *rconn = conn->rconn;
   const char *prefix = "HTTP/1.1 200 OK\r\nContent-Length:";
   const int body_size = 10000;
-  int response_size = strlen(prefix) + 15 + body_size;
+  size_t response_size = strlen(prefix) + 15 + body_size;
   char *response = malloc(response_size);
   size_t n;
 

--- a/tests/server.c
+++ b/tests/server.c
@@ -144,7 +144,7 @@ send_response(struct conndata *conn)
   struct rustls_connection *rconn = conn->rconn;
   const char *prefix = "HTTP/1.1 200 OK\r\nContent-Length:";
   const int body_size = 10000;
-  const int response_size = strlen(prefix) + 15 + body_size;
+  int response_size = strlen(prefix) + 15 + body_size;
   char *response = malloc(response_size);
   size_t n;
 
@@ -160,7 +160,11 @@ send_response(struct conndata *conn)
 
   rustls_connection_write(
     rconn, (const uint8_t *)response, strlen(response), &n);
-  if(n != strlen(response)) {
+  
+  response_size = strlen(response);
+  free(response);
+  
+  if(n != response_size) {
     fprintf(stderr, "failed to write all response bytes. wrote %ld\n", n);
     return CRUSTLS_DEMO_ERROR;
   }
@@ -259,6 +263,8 @@ cleanup:
   if(sockfd > 0) {
     close(sockfd);
   }
+  if(conn->data.data)
+    free(conn->data.data);
   free(conn);
 }
 


### PR DESCRIPTION
Building server with MSVC and in `_DEBUG` mode, showed 2 memory leaks:
```
 tests/server.c(120) : {524} normal block at 0x0E3B5B48, 10047 bytes long.
   Data: <HTTP/1.1 200 OK > 48 54 54 50 2F 31 2E 31 20 32 30 30 20 4F 4B 0D
tests/common.c(189) : {523} normal block at 0x0E3B5318, 2048 bytes long.
   Data: <GET / HTTP/1.1  > 47 45 54 20 2F 20 48 54 54 50 2F 31 2E 31 0D 0A
```

This patch frees the `response` and the plain-text vector.