### PR TITLE
Re-add Miri to CI.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -152,7 +152,6 @@ jobs:
           toolchain: nightly
           profile: minimal
           override: true
-      - run: MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
-      - run: rustup override set "$MIRI_NIGHTLY"
+      - run: rustup override set "nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)"
       - run: rustup component add miri
       - run: cargo miri test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -136,3 +136,23 @@ jobs:
         with:
           command: clippy
           args: --workspace
+
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install nightly Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - run: MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+      - run: rustup override set "$MIRI_NIGHTLY"
+      - run: rustup component add miri
+      - run: cargo miri test


### PR DESCRIPTION
Following instructions from https://github.com/rust-lang/miri#running-miri-on-ci.

Fixes #51