### PR TITLE
Fix enabling of ALPN and SNI in config builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.8.0 (unreleased)
+## 0.8.1 (unreleased)
+
+## Changed
+ - Setting of ALPN protocols for client configs was broken in the 0.8.0 release.
+   This release fixes it.
+
+## 0.8.0 (2021-11-08)
 
 The package name has changed to "rustls-ffi" (from "crustls").
 The header file (as installed by `make DESTDIR=/path/ install`)

--- a/src/server.rs
+++ b/src/server.rs
@@ -673,3 +673,25 @@ impl rustls_server_config_builder {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_builder() {
+        let builder: *mut rustls_server_config_builder =
+            rustls_server_config_builder::rustls_server_config_builder_new();
+        let h1 = "http/1.1".as_bytes();
+        let h2 = "h2".as_bytes();
+        let alpn: Vec<rustls_slice_bytes> = vec![h1.into(), h2.into()];
+        rustls_server_config_builder::rustls_server_config_builder_set_alpn_protocols(
+            builder,
+            alpn.as_ptr(),
+            alpn.len(),
+        );
+        let config = rustls_server_config_builder::rustls_server_config_builder_build(builder);
+        let config = try_ref_from_ptr!(config);
+        assert_eq!(config.alpn_protocols, vec![h1, h2]);
+    }
+}


### PR DESCRIPTION
We were collecting the ALPN and SNI information into our internal config builder object but not setting it on the actual rustls config builder object.

Add unittests for client and server builders that check this.

Fixes #204