### PR TITLE
Fix config builder tests under miri

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -587,8 +587,11 @@ mod tests {
         );
         rustls_client_config_builder::rustls_client_config_builder_set_enable_sni(builder, false);
         let config = rustls_client_config_builder::rustls_client_config_builder_build(builder);
-        let config = try_ref_from_ptr!(config);
-        assert_eq!(config.enable_sni, false);
-        assert_eq!(config.alpn_protocols, vec![h1, h2]);
+        {
+            let config2 = try_ref_from_ptr!(config);
+            assert_eq!(config2.enable_sni, false);
+            assert_eq!(config2.alpn_protocols, vec![h1, h2]);
+        }
+        rustls_client_config::rustls_client_config_free(config)
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -691,7 +691,10 @@ mod tests {
             alpn.len(),
         );
         let config = rustls_server_config_builder::rustls_server_config_builder_build(builder);
-        let config = try_ref_from_ptr!(config);
-        assert_eq!(config.alpn_protocols, vec![h1, h2]);
+        {
+            let config2 = try_ref_from_ptr!(config);
+            assert_eq!(config2.alpn_protocols, vec![h1, h2]);
+        }
+        rustls_server_config::rustls_server_config_free(config);
     }
 }


### PR DESCRIPTION
Remember to manually free the memory.

This wasn't caught by CI because #199 and #205 were both inflight at once, and we don't have the "require branches to be up to date before merging" branch protection feature turned on. We could consider turning that feature on, but on the whole I think it adds more time waiting on CI than is worthwhile for the rare breakage like this one.