### PR TITLE
Include pthread.h only for non-WIN32 build

### DIFF
--- a/tests/server.c
+++ b/tests/server.c
@@ -12,6 +12,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <pthread.h>
 #endif /* _WIN32 */
 
 #include <sys/types.h>
@@ -20,7 +21,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <errno.h>
-#include <pthread.h>
 #include <time.h>
 
 #ifdef _WIN32


### PR DESCRIPTION
Thanks for spotting, @gvanem !