### PR TITLE
Add valgrind to C tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,9 +47,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-    - run: apt install valgrind
-    - run: export VALGRIND="valgrind -q"
-    - run: make test
+      - run: apt install valgrind
+      - run: export VALGRIND="valgrind -q"
+      - run: make test
 
   test-windows:
     name: Windows

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,9 +30,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install valgrind
-        run: sudo apt-get install -y valgrind
-
       - name: Install ${{ matrix.rust }} toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -47,7 +44,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - run: apt install valgrind
+      - name: Install valgrind
+        run: sudo apt-get install -y valgrind
       - run: export VALGRIND="valgrind -q"
       - run: make test
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,19 @@ jobs:
           override: true
       - run: make CC=${{ matrix.cc }} PROFILE=release test
 
+  valgrind:
+    name: Valgrind
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+    - run: apt install valgrind
+    - run: export VALGRIND="valgrind -q"
+    - run: make test
+
   test-windows:
+    name: Windows
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install valgrind
+        run: apt install valgrind
+
       - name: Install ${{ matrix.rust }} toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Install valgrind
-        run: apt install valgrind
+        run: sudo apt-get install -y valgrind
 
       - name: Install ${{ matrix.rust }} toolchain
         uses: actions-rs/toolchain@v1

--- a/test.sh
+++ b/test.sh
@@ -34,7 +34,7 @@ kill_server() {
   kill "${SERVER_PID}"
 }
 
-VALGRIND="valgrind -q"
+VALGRIND=""
 
 run_client_tests() {
   CA_FILE=minica.pem $VALGRIND ./target/client localhost 8443 /

--- a/test.sh
+++ b/test.sh
@@ -34,10 +34,12 @@ kill_server() {
   kill "${SERVER_PID}"
 }
 
+VALGRIND="valgrind -q"
+
 run_client_tests() {
-  CA_FILE=minica.pem ./target/client localhost 8443 /
-  NO_CHECK_CERTIFICATE='' ./target/client localhost 8443 /
-  CA_FILE=minica.pem VECTORED_IO='' ./target/client localhost 8443 /
+  CA_FILE=minica.pem $VALGRIND ./target/client localhost 8443 /
+  NO_CHECK_CERTIFICATE='' $VALGRIND ./target/client localhost 8443 /
+  CA_FILE=minica.pem VECTORED_IO='' $VALGRIND ./target/client localhost 8443 /
 }
 
 if port_is_open localhost 8443 ; then
@@ -46,19 +48,19 @@ if port_is_open localhost 8443 ; then
 fi
 
 # Start server in default config.
-./target/server localhost/cert.pem localhost/key.pem &
+$VALGRIND ./target/server localhost/cert.pem localhost/key.pem &
 SERVER_PID=$!
 trap kill_server EXIT
 
 wait_tcp_port localhost 8443
-run_client_tests
+run_client_tests > /dev/null
 
 kill_server
 sleep 1
 
 # Start server with vectored I/O
-VECTORED_IO='' ./target/server localhost/cert.pem localhost/key.pem &
+VECTORED_IO='' $VALGRIND ./target/server localhost/cert.pem localhost/key.pem &
 SERVER_PID=$!
 wait_tcp_port localhost 8443
 
-run_client_tests
+run_client_tests > /dev/null

--- a/test.sh
+++ b/test.sh
@@ -34,7 +34,7 @@ kill_server() {
   kill "${SERVER_PID}"
 }
 
-VALGRIND=""
+VALGRIND="${VALGRIND:-}"
 
 run_client_tests() {
   CA_FILE=minica.pem $VALGRIND ./target/client localhost 8443 /

--- a/tests/common.c
+++ b/tests/common.c
@@ -25,12 +25,12 @@
 #include "common.h"
 
 void
-print_error(char *prefix, rustls_result result)
+print_error(const char *program_name, const char *prefix, rustls_result result)
 {
   char buf[256];
   size_t n;
   rustls_error(result, buf, sizeof(buf), &n);
-  fprintf(stderr, "%s: %.*s\n", prefix, (int)n, buf);
+  fprintf(stderr, "%s: %s: %.*s\n", program_name, prefix, (int)n, buf);
 }
 
 #ifdef _WIN32
@@ -139,7 +139,6 @@ write_tls(struct rustls_connection *rconn, struct conndata *conn, size_t *n)
   return rustls_connection_write_tls(rconn, write_cb, conn, n);
 #else
   if(getenv("VECTORED_IO")) {
-    fprintf(stderr, "(vectored)\n");
     return rustls_connection_write_tls_vectored(rconn, write_vectored_cb, conn, n);
   } else {
     return rustls_connection_write_tls(rconn, write_cb, conn, n);
@@ -230,7 +229,7 @@ copy_plaintext_to_buffer(struct conndata *conn)
       return CRUSTLS_DEMO_OK;
     }
     if(result != RUSTLS_RESULT_OK) {
-      print_error("Error in rustls_connection_read", result);
+      print_error(conn->program_name, "Error in rustls_connection_read", result);
       return CRUSTLS_DEMO_ERROR;
     }
     if(n == 0) {

--- a/tests/common.h
+++ b/tests/common.h
@@ -25,7 +25,7 @@ struct conndata {
 };
 
 void
-print_error(char *prefix, rustls_result result);
+print_error(const char *program_name, const char *prefix, rustls_result result);
 
 int
 write_all(int fd, const char *buf, int n);

--- a/tests/server.c
+++ b/tests/server.c
@@ -328,12 +328,14 @@ main(int argc, const char **argv)
   alpn_http11.data = (unsigned char*)"http/1.1";
   alpn_http11.len = 8;
 
+#ifndef _WIN32
   struct sigaction siga = { 0 };
   siga.sa_handler = handle_signal;
   if (sigaction(SIGTERM, &siga, NULL) == -1) {
     perror("setting a signal handler");
     return 1;
   }
+#endif /* _WIN32 */
 
   if(argc <= 2) {
     fprintf(stderr,


### PR DESCRIPTION
Fix some memory leaks.

Add clean shutdown to the server test so it can be tested under valgrind.

Send the stdout of client tests to /dev/null so they aren't so noisy.

Add a client or server prefix to all stderr messages to distinguish which side they came from.