### PR TITLE
Add feature to inhibit log capture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,14 @@ description = "C-to-rustls bindings"
 edition = "2018"
 links = "rustls_ffi"
 
+[features]
+# Enable this feature when building as Rust dependency. It inhibits the
+# default behavior of capturing the global logger, which only works when
+# built using the Makefile, which passes -C metadata=rustls-ffi to avoid
+# interfering with copies of the global logger brought in by other Rust
+# libraries.
+no_log_capture = []
+
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
 rustls = { version = "=0.20", features = [ "dangerous_configuration" ] }

--- a/src/log.rs
+++ b/src/log.rs
@@ -30,6 +30,10 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
+#[cfg(feature = "no_log_capture")]
+pub(crate) fn ensure_log_registered() {}
+
+#[cfg(not(feature = "no_log_capture"))]
 pub(crate) fn ensure_log_registered() {
     log::set_logger(&Logger {}).ok();
     log::set_max_level(log::LevelFilter::Debug)


### PR DESCRIPTION
This is necessary to work properly when built as a Rust dependency (a
rare use case).

Fixes #212.

/cc @sagebind for review. I think this is the last thing we need before uploading rustls-ffi and making it usable as a backend for curl-rust.