### PR TITLE
Improve handling of errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.9.0 (unreleased)
+
+### Changed
+
+ - rustls_is_cert_error now returns true for invalid certificate data
+   (this was broken by v0.8.0). It also takes unsigned int as its input
+   parameter instead of rustls_result (#227).
+ - rustls_verify_server_cert_callback now returns uint32_t instead of
+   rustls_result (#227).
+ - rustls_session_store_get_callback and rustls_session_store_put_callback now
+   return uint32_t (#227).
+
 ## 0.8.2 (2021-11-13)
 
 ### Changed

--- a/src/error.rs
+++ b/src/error.rs
@@ -313,7 +313,7 @@ impl Display for rustls_result {
         CorruptMessagePayload => write!(f, "received corrupt message"),
 
         PeerIncompatibleError => write!(f, "peer is incompatible"),
-        PeerMisbehavedError => write!(f, "peer is incompatible"),
+        PeerMisbehavedError => write!(f, "peer misbehaved"),
 
         General => write!(f, "general error"),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,7 @@ impl rustls_result {
     }
 }
 
-/// For cert-related resutl_results, turn them into a rustls::Error. For other
+/// For cert-related rustls_results, turn them into a rustls::Error. For other
 /// inputs, including Ok, return rustls::Error::General.
 pub(crate) fn cert_result_to_error(result: rustls_result) -> rustls::Error {
     use rustls::Error::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod server;
 pub mod session;
 
 pub use error::rustls_result;
+pub use error::*;
 
 use crate::log::rustls_log_callback;
 use crate::panic::PanicOrDefault;

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -276,7 +276,7 @@ typedef struct rustls_verify_server_cert_params {
   struct rustls_slice_bytes ocsp_response;
 } rustls_verify_server_cert_params;
 
-typedef rustls_result (*rustls_verify_server_cert_callback)(rustls_verify_server_cert_user_data userdata, const struct rustls_verify_server_cert_params *params);
+typedef uint32_t (*rustls_verify_server_cert_callback)(rustls_verify_server_cert_user_data userdata, const struct rustls_verify_server_cert_params *params);
 
 typedef size_t rustls_log_level;
 
@@ -428,8 +428,9 @@ typedef void *rustls_session_store_userdata;
  * do a partial copy but instead remove the value from its store and
  * act as if it was never found.
  *
- * The callback should return != 0 to indicate that a value was retrieved
- * and written in its entirety into `buf`.
+ * The callback should return RUSTLS_RESULT_OK to indicate that a value was
+ * retrieved and written in its entirety into `buf`, or RUSTLS_RESULT_NOT_FOUND
+ * if no session was retrieved.
  *
  * When `remove_after` is != 0, the returned data needs to be removed
  * from the store.
@@ -439,7 +440,7 @@ typedef void *rustls_session_store_userdata;
  * NOTE: callbacks used in several sessions via a common config
  * must be implemented thread-safe.
  */
-typedef rustls_result (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, int remove_after, uint8_t *buf, size_t count, size_t *out_n);
+typedef uint32_t (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, int remove_after, uint8_t *buf, size_t count, size_t *out_n);
 
 /**
  * Prototype of a callback that can be installed by the application at the
@@ -448,8 +449,8 @@ typedef rustls_result (*rustls_session_store_get_callback)(rustls_session_store_
  * for later use is handed to the client/has been received from the server.
  * `userdata` will be supplied based on rustls_{client,server}_session_set_userdata.
  *
- * The callback should return != 0 to indicate that the value has been
- * successfully persisted in its store.
+ * The callback should return RUSTLS_RESULT_OK to indicate that a value was
+ * successfully stored, or RUSTLS_RESULT_IO on failure.
  *
  * NOTE: the passed in `key` and `val` are only available during the
  * callback invocation.
@@ -993,7 +994,7 @@ void rustls_connection_free(struct rustls_connection *conn);
  */
 void rustls_error(unsigned int result, char *buf, size_t len, size_t *out_n);
 
-bool rustls_result_is_cert_error(rustls_result result);
+bool rustls_result_is_cert_error(unsigned int result);
 
 /**
  * Return a rustls_str containing the stringified version of a log level.

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -458,7 +458,7 @@ typedef uint32_t (*rustls_session_store_get_callback)(rustls_session_store_userd
  * NOTE: callbacks used in several sessions via a common config
  * must be implemented thread-safe.
  */
-typedef rustls_result (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
+typedef uint32_t (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
 
 /**
  * Returns a static string containing the rustls-ffi version as well as the

--- a/src/session.rs
+++ b/src/session.rs
@@ -71,14 +71,14 @@ pub type rustls_session_store_put_callback = Option<
         userdata: rustls_session_store_userdata,
         key: *const rustls_slice_bytes,
         val: *const rustls_slice_bytes,
-    ) -> rustls_result,
+    ) -> u32,
 >;
 
 pub(crate) type SessionStorePutCallback = unsafe extern "C" fn(
     userdata: rustls_session_store_userdata,
     key: *const rustls_slice_bytes,
     val: *const rustls_slice_bytes,
-) -> rustls_result;
+) -> u32;
 
 pub(crate) struct SessionStoreBroker {
     pub get_cb: SessionStoreGetCallback,
@@ -128,7 +128,8 @@ impl SessionStoreBroker {
             Ok(u) => u,
             Err(_) => return false,
         };
-        unsafe { matches!(cb(userdata, &key, &value), rustls_result::Ok) }
+        let result = unsafe { cb(userdata, &key, &value) };
+        result == rustls_result::Ok as u32
     }
 }
 


### PR DESCRIPTION
There were still three places where we could have undefined behavior if
C gave us an invalid rustls_result:

 - rustls_result_is_cert_error took a rustls_result as a parameter.
 - The callback for server certificate validation returned
   rustls_result.
 - The callbacks for session storage returned rustls_result.

Change all of these to use u32 and the try_from implementation.

Fix the comment for the session storage callbacks, which indicated the
wrong error strategy.

Remove result_to_error in favor of directly implementing Display on
rustls_result. This fixes an issue where CertInvalidData was turned into
Either::String rather than Either::Error, which caused
rustls_result_is_cert_error to (incorrectly) say it wasn't a cert error.
This PR also removes the Either struct and the From impls on it.

Fixes #226 