### PR TITLE
Cargo.toml: update rustls to version 0.20.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ no_log_capture = []
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "=0.20", features = [ "dangerous_configuration" ] }
+rustls = { version = "=0.20.1", features = [ "dangerous_configuration" ] }
 webpki = "0.22"
 libc = "0.2"
 sct = "0.7"

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::{env, fs, path::PathBuf};
 
 // Keep in sync with Cargo.toml.
-const RUSTLS_CRATE_VERSION: &str = "0.20.0";
+const RUSTLS_CRATE_VERSION: &str = "0.20.1";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());


### PR DESCRIPTION
Wanted to do this in a separate commit from the code changes. Updates
#147.