### PR TITLE
Mark RUSTLS_ALL_CIPHER_SUITES as public

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -128,7 +128,7 @@ pub extern "C" fn rustls_default_ciphersuites_get_entry(
 /// always be valid. The contents and order of this array may change between
 /// releases.
 #[no_mangle]
-static mut RUSTLS_ALL_CIPHER_SUITES: [*const rustls_supported_ciphersuite; 9] = [
+pub static mut RUSTLS_ALL_CIPHER_SUITES: [*const rustls_supported_ciphersuite; 9] = [
     &rustls::cipher_suite::TLS13_AES_256_GCM_SHA384 as *const SupportedCipherSuite as *const _,
     &rustls::cipher_suite::TLS13_AES_128_GCM_SHA256 as *const SupportedCipherSuite as *const _,
     &rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256 as *const SupportedCipherSuite

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -460,6 +460,8 @@ typedef uint32_t (*rustls_session_store_get_callback)(rustls_session_store_userd
  */
 typedef uint32_t (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
 
+extern const struct rustls_supported_ciphersuite *RUSTLS_ALL_CIPHER_SUITES[9];
+
 extern const size_t RUSTLS_ALL_CIPHER_SUITES_LEN;
 
 extern const struct rustls_supported_ciphersuite *RUSTLS_DEFAULT_CIPHER_SUITES[9];


### PR DESCRIPTION
This is a follow-up to #242, I had left a `pub` off of one item, and I just noticed it in a warning message from cbindgen.