### PR TITLE
Add static libs on Windows

### DIFF
--- a/Makefile.Windows
+++ b/Makefile.Windows
@@ -50,7 +50,7 @@ $(RUSTLS_LIB): src/lib.rs Cargo.toml
 	@echo
 
 target/%.exe: common.obj %.obj $(RUSTLS_LIB)
-	$(call link_EXE, $@, $^ advapi32.lib userenv.lib ws2_32.lib)
+	$(call link_EXE, $@, $^ advapi32.lib cfgmgr32.lib credui.lib gdi32.lib kernel32.lib msimg32.lib opengl32.lib secur32.lib user32.lib winspool.lib kernel32.lib ws2_32.lib bcrypt.lib advapi32.lib userenv.lib kernel32.lib msvcrt.lib)
 
 clean:
 	rm -f *.obj target/.rustc_info.json $(RUSTLS_LIB) vc1*.pdb

--- a/Makefile.Windows
+++ b/Makefile.Windows
@@ -42,7 +42,7 @@ test: all
 
 $(RUSTLS_LIB): src/lib.rs Cargo.toml
 	$(call green_msg, Building '$@')
-	cargo build --release
+	RUSTFLAGS="--print native-static-libs" cargo build --release
 	@echo
 
 %.obj: tests/%.c


### PR DESCRIPTION
The Windows build was missing some of the libraries output by `--print native-static-libs`

Fixes #246

/cc @kevinburke for review