### PR TITLE
Fix Valgrind CI job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install valgrind
-        run: sudo apt-get install -y valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
       - run: export VALGRIND="valgrind -q"
       - run: make test
 


### PR DESCRIPTION
I noticed this CI job was broken, running apt-get update before apt-get install seems to fix it.