### PR TITLE
Avoid creating references to out params

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -47,8 +47,9 @@ impl rustls_certificate {
     ) -> rustls_result {
         ffi_panic_boundary! {
             let cert = try_ref_from_ptr!(cert);
-            if out_der_data.is_null() { return NullParameter }
-            if out_der_len.is_null() { return NullParameter }
+            if out_der_data.is_null() || out_der_len.is_null() {
+                return NullParameter
+            }
             let der = cert.as_ref();
             unsafe {
                 *out_der_data = der.as_ptr();

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -16,8 +16,8 @@ use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 use crate::error::rustls_result;
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::{
-    ffi_panic_boundary, null_check, try_mut_from_ptr, try_ref_from_ptr, try_slice, ArcCastPtr,
-    BoxCastPtr, CastConstPtr, CastPtr,
+    ffi_panic_boundary, try_mut_from_ptr, try_ref_from_ptr, try_slice, ArcCastPtr, BoxCastPtr,
+    CastConstPtr, CastPtr,
 };
 use rustls_result::NullParameter;
 use std::ops::Deref;
@@ -47,8 +47,8 @@ impl rustls_certificate {
     ) -> rustls_result {
         ffi_panic_boundary! {
             let cert = try_ref_from_ptr!(cert);
-            null_check!(out_der_data);
-            null_check!(out_der_len);
+            if out_der_data.is_null() { return NullParameter }
+            if out_der_len.is_null() { return NullParameter }
             let der = cert.as_ref();
             unsafe {
                 *out_der_data = der.as_ptr();

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -16,8 +16,8 @@ use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 use crate::error::rustls_result;
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::{
-    ffi_panic_boundary, try_mut_from_ptr, try_ref_from_ptr, try_slice, ArcCastPtr, BoxCastPtr,
-    CastConstPtr, CastPtr,
+    ffi_panic_boundary, null_check, try_mut_from_ptr, try_ref_from_ptr, try_slice, ArcCastPtr,
+    BoxCastPtr, CastConstPtr, CastPtr,
 };
 use rustls_result::NullParameter;
 use std::ops::Deref;
@@ -47,11 +47,13 @@ impl rustls_certificate {
     ) -> rustls_result {
         ffi_panic_boundary! {
             let cert = try_ref_from_ptr!(cert);
-            let out_der_data: &mut *const u8 = try_mut_from_ptr!(out_der_data);
-            let out_der_len: &mut size_t = try_mut_from_ptr!(out_der_len);
+            null_check!(out_der_data);
+            null_check!(out_der_len);
             let der = cert.as_ref();
-            *out_der_data = der.as_ptr();
-            *out_der_len = der.len();
+            unsafe {
+                *out_der_data = der.as_ptr();
+                *out_der_len = der.len();
+            }
             rustls_result::Ok
         }
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -148,7 +148,9 @@ impl rustls_connection {
     ) -> rustls_io_result {
         ffi_panic_boundary! {
             let conn: &mut Connection = try_mut_from_ptr!(conn);
-            if out_n.is_null() { return rustls_io_result(EINVAL) }
+            if out_n.is_null() {
+                return rustls_io_result(EINVAL)
+            }
             let callback: ReadCallback = try_callback!(callback);
 
             let mut reader = CallbackReader { callback, userdata };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
-use std::{cmp::min, convert::TryFrom, fmt::Display, slice};
+use std::cmp::min;
+use std::convert::TryFrom;
+use std::fmt::Display;
 
 use crate::ffi_panic_boundary;
 use libc::{c_char, c_uint, size_t};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,16 +472,6 @@ macro_rules! try_mut_from_ptr {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! null_check {
-    ( $var:ident ) => {
-        if $var.is_null() {
-            return crate::panic::NullParameterOrDefault::value();
-        }
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
 macro_rules! try_box_from_ptr {
     ( $var:ident ) => {
         match crate::try_box_from($var) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,6 +472,16 @@ macro_rules! try_mut_from_ptr {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! null_check {
+    ( $var:ident ) => {
+        if $var.is_null() {
+            return crate::panic::NullParameterOrDefault::value();
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! try_box_from_ptr {
     ( $var:ident ) => {
         match crate::try_box_from($var) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! [You may also want to read the rustls-ffi README](https://github.com/rustls/rustls-ffi#rustls-ffi-bindings).
 
 use crate::rslice::rustls_str;
-use libc::{c_void, size_t};
+use libc::c_void;
 use std::cell::RefCell;
 use std::mem;
 use std::sync::Arc;
@@ -433,14 +433,6 @@ where
     F: ArcCastPtr<RustType = T>,
 {
     F::to_arc(from)
-}
-
-impl CastPtr for size_t {
-    type RustType = size_t;
-}
-
-impl CastPtr for *const u8 {
-    type RustType = *const u8;
 }
 
 /// If the provided pointer is non-null, convert it to a reference.


### PR DESCRIPTION
Creating a reference to uninitialized memory is undefined behavior. Callers of this library are likely to pass pointers to uninitialized memory as out params. We should support that by not turning out params into references.

Instead, keep them as raw pointers and use an unsafe block where we actually write the param.

Fixes #245