### PR TITLE
Clarify comment for rustls_certified_key_build

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -280,6 +280,17 @@ impl rustls_certified_key {
     /// the original caller has called `rustls_certified_key_free`, other objects
     /// may retain a pointer to the object. The memory will be freed when all
     /// references are gone.
+    ///
+    /// This function does not take ownership of any of its input pointers. It
+    /// parses the pointed-to data and makes a copy of the result. You may
+    /// free the cert_chain and private_key pointers after calling it.
+    ///
+    /// Typically, you will build a `rustls_certified_key`, use it to create a
+    /// `rustls_server_config` (which increments the reference count), and then
+    /// immediately call `rustls_certified_key_free`. That leaves the
+    /// `rustls_server_config` in posession of the sole reference, so the
+    /// `rustls_certified_key`'s memory will automatically be released when
+    /// the `rustls_server_config` is freed.
     #[no_mangle]
     pub extern "C" fn rustls_certified_key_build(
         cert_chain: *const u8,

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -288,7 +288,7 @@ impl rustls_certified_key {
     /// Typically, you will build a `rustls_certified_key`, use it to create a
     /// `rustls_server_config` (which increments the reference count), and then
     /// immediately call `rustls_certified_key_free`. That leaves the
-    /// `rustls_server_config` in posession of the sole reference, so the
+    /// `rustls_server_config` in possession of the sole reference, so the
     /// `rustls_certified_key`'s memory will automatically be released when
     /// the `rustls_server_config` is freed.
     #[no_mangle]

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -556,7 +556,7 @@ const struct rustls_supported_ciphersuite *rustls_default_ciphersuites_get_entry
  * Typically, you will build a `rustls_certified_key`, use it to create a
  * `rustls_server_config` (which increments the reference count), and then
  * immediately call `rustls_certified_key_free`. That leaves the
- * `rustls_server_config` in posession of the sole reference, so the
+ * `rustls_server_config` in possession of the sole reference, so the
  * `rustls_certified_key`'s memory will automatically be released when
  * the `rustls_server_config` is freed.
  */

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -548,6 +548,17 @@ const struct rustls_supported_ciphersuite *rustls_default_ciphersuites_get_entry
  * the original caller has called `rustls_certified_key_free`, other objects
  * may retain a pointer to the object. The memory will be freed when all
  * references are gone.
+ *
+ * This function does not take ownership of any of its input pointers. It
+ * parses the pointed-to data and makes a copy of the result. You may
+ * free the cert_chain and private_key pointers after calling it.
+ *
+ * Typically, you will build a `rustls_certified_key`, use it to create a
+ * `rustls_server_config` (which increments the reference count), and then
+ * immediately call `rustls_certified_key_free`. That leaves the
+ * `rustls_server_config` in posession of the sole reference, so the
+ * `rustls_certified_key`'s memory will automatically be released when
+ * the `rustls_server_config` is freed.
  */
 rustls_result rustls_certified_key_build(const uint8_t *cert_chain,
                                          size_t cert_chain_len,


### PR DESCRIPTION
It does not take ownership of the pointers it is passed, and the
resulting struct should usually be freed right after creating a config
with it.