### PR TITLE
Fix lifecycle of rustls_root_cert_store

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -16,8 +16,8 @@ use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 use crate::error::rustls_result;
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::{
-    ffi_panic_boundary, try_mut_from_ptr, try_ref_from_ptr, try_slice, ArcCastPtr, BoxCastPtr,
-    CastConstPtr, CastPtr,
+    ffi_panic_boundary, try_box_from_ptr, try_mut_from_ptr, try_ref_from_ptr, try_slice,
+    ArcCastPtr, BoxCastPtr, CastConstPtr, CastPtr,
 };
 use rustls_result::NullParameter;
 use std::ops::Deref;
@@ -428,8 +428,7 @@ impl rustls_certified_key {
     }
 }
 
-/// A root cert store that is done being constructed and is now read-only.
-/// Under the hood, this object corresponds to an Arc<RootCertStore>.
+/// A root certificate store.
 /// <https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html>
 pub struct rustls_root_cert_store {
     // We use the opaque struct pattern to tell C about our types without
@@ -461,7 +460,7 @@ impl rustls_root_cert_store {
     ///
     /// When `strict` is true an error will return a `CertificateParseError`
     /// result. So will an attempt to parse data that has zero certificates.
-
+    ///
     /// When `strict` is false, unparseable root certificates will be ignored.
     /// This may be useful on systems that have syntactically invalid root
     /// certificates.
@@ -494,18 +493,13 @@ impl rustls_root_cert_store {
         }
     }
 
-    /// "Free" a rustls_root_cert_store previously returned from
-    /// rustls_root_cert_store_builder_build. Since rustls_root_cert_store is actually an
-    /// atomically reference-counted pointer, extant rustls_root_cert_store may still
-    /// hold an internal reference to the Rust object. However, C code must
-    /// consider this pointer unusable after "free"ing it.
+    /// Free a rustls_root_cert_store previously returned from rustls_root_cert_store_builder_build.
     /// Calling with NULL is fine. Must not be called twice with the same value.
     #[no_mangle]
     pub extern "C" fn rustls_root_cert_store_free(store: *mut rustls_root_cert_store) {
         ffi_panic_boundary! {
-            let store: &mut RootCertStore = try_mut_from_ptr!(store);
-            // Convert the pointer to a Box and drop it.
-            unsafe { drop(Box::from_raw(store)) }
+            let store = try_box_from_ptr!(store);
+            drop(store)
         }
     }
 }
@@ -529,11 +523,13 @@ impl rustls_client_cert_verifier {
     /// can be used in several rustls_server_config instances. Must be freed by
     /// the application when no longer needed. See the documentation of
     /// rustls_client_cert_verifier_free for details about lifetime.
+    /// This copies the contents of the rustls_root_cert_store. It does not take
+    /// ownership of the pointed-to memory.
     #[no_mangle]
     pub extern "C" fn rustls_client_cert_verifier_new(
-        store: *mut rustls_root_cert_store,
+        store: *const rustls_root_cert_store,
     ) -> *const rustls_client_cert_verifier {
-        let store: &mut RootCertStore = try_mut_from_ptr!(store);
+        let store: &RootCertStore = try_ref_from_ptr!(store);
         return Arc::into_raw(AllowAnyAuthenticatedClient::new(store.clone())) as *const _;
     }
 
@@ -581,11 +577,13 @@ impl rustls_client_cert_verifier_optional {
     /// verifier can be used in several rustls_server_config instances. Must be
     /// freed by the application when no longer needed. See the documentation of
     /// rustls_client_cert_verifier_optional_free for details about lifetime.
+    /// This copies the contents of the rustls_root_cert_store. It does not take
+    /// ownership of the pointed-to data.
     #[no_mangle]
     pub extern "C" fn rustls_client_cert_verifier_optional_new(
-        store: *mut rustls_root_cert_store,
+        store: *const rustls_root_cert_store,
     ) -> *const rustls_client_cert_verifier_optional {
-        let store: &mut RootCertStore = try_mut_from_ptr!(store);
+        let store: &RootCertStore = try_ref_from_ptr!(store);
         return Arc::into_raw(AllowAnyAnonymousOrAuthenticatedClient::new(store.clone()))
             as *const _;
     }

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -159,8 +159,7 @@ typedef struct rustls_connection rustls_connection;
 typedef struct rustls_iovec rustls_iovec;
 
 /**
- * A root cert store that is done being constructed and is now read-only.
- * Under the hood, this object corresponds to an Arc<RootCertStore>.
+ * A root certificate store.
  * <https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html>
  */
 typedef struct rustls_root_cert_store rustls_root_cert_store;
@@ -599,6 +598,7 @@ struct rustls_root_cert_store *rustls_root_cert_store_new(void);
  *
  * When `strict` is true an error will return a `CertificateParseError`
  * result. So will an attempt to parse data that has zero certificates.
+ *
  * When `strict` is false, unparseable root certificates will be ignored.
  * This may be useful on systems that have syntactically invalid root
  * certificates.
@@ -609,11 +609,7 @@ rustls_result rustls_root_cert_store_add_pem(struct rustls_root_cert_store *stor
                                              bool strict);
 
 /**
- * "Free" a rustls_root_cert_store previously returned from
- * rustls_root_cert_store_builder_build. Since rustls_root_cert_store is actually an
- * atomically reference-counted pointer, extant rustls_root_cert_store may still
- * hold an internal reference to the Rust object. However, C code must
- * consider this pointer unusable after "free"ing it.
+ * Free a rustls_root_cert_store previously returned from rustls_root_cert_store_builder_build.
  * Calling with NULL is fine. Must not be called twice with the same value.
  */
 void rustls_root_cert_store_free(struct rustls_root_cert_store *store);
@@ -623,8 +619,10 @@ void rustls_root_cert_store_free(struct rustls_root_cert_store *store);
  * can be used in several rustls_server_config instances. Must be freed by
  * the application when no longer needed. See the documentation of
  * rustls_client_cert_verifier_free for details about lifetime.
+ * This copies the contents of the rustls_root_cert_store. It does not take
+ * ownership of the pointed-to memory.
  */
-const struct rustls_client_cert_verifier *rustls_client_cert_verifier_new(struct rustls_root_cert_store *store);
+const struct rustls_client_cert_verifier *rustls_client_cert_verifier_new(const struct rustls_root_cert_store *store);
 
 /**
  * "Free" a verifier previously returned from
@@ -641,8 +639,10 @@ void rustls_client_cert_verifier_free(const struct rustls_client_cert_verifier *
  * verifier can be used in several rustls_server_config instances. Must be
  * freed by the application when no longer needed. See the documentation of
  * rustls_client_cert_verifier_optional_free for details about lifetime.
+ * This copies the contents of the rustls_root_cert_store. It does not take
+ * ownership of the pointed-to data.
  */
-const struct rustls_client_cert_verifier_optional *rustls_client_cert_verifier_optional_new(struct rustls_root_cert_store *store);
+const struct rustls_client_cert_verifier_optional *rustls_client_cert_verifier_optional_new(const struct rustls_root_cert_store *store);
 
 /**
  * "Free" a verifier previously returned from


### PR DESCRIPTION
Comments said that rustls_root_cert_store was represented as an Arc under the hood, but that's not true. It's represented as a Box. Instead, it's rustls_client_cert_verifier and rustls_client_cert_verifier_optional that are wrapped in an Arc.

Also, updated a couple of functions that take rustls_client_cert_verifier to accept a const one.