### PR TITLE
CI: Set clippy to deny warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -183,7 +183,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace
+          args: --workspace -- -D warnings
 
   miri:
     name: Miri


### PR DESCRIPTION
Thanks to @djc for pointing out that we don't currently do this.