### PR TITLE
SNI hostname getter: set `out_n = 0` if unavailable

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -384,6 +384,9 @@ pub extern "C" fn rustls_server_connection_get_sni_hostname(
         let sni_hostname = match server_connection.sni_hostname() {
             Some(sni_hostname) => sni_hostname,
             None => {
+                unsafe {
+                    *out_n = 0;
+                }
                 return rustls_result::Ok
             },
         };


### PR DESCRIPTION
Tiny bug fix PR.

The docs of `rustls_server_connection_get_sni_hostname` state:

> Returns Ok with *out_n == 0 if there is no SNI hostname available on this connection