### PR TITLE
Fix double free on building a server config when a client verifier got set

### DIFF
--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1125,7 +1125,7 @@ rustls_result rustls_server_config_builder_new_custom(const struct rustls_suppor
  * If input is NULL, this will return NULL.
  * For memory lifetime, see rustls_server_config_builder_new.
  */
-void rustls_server_config_builder_set_client_verifier(struct rustls_server_config_builder *config_builder,
+void rustls_server_config_builder_set_client_verifier(struct rustls_server_config_builder *builder,
                                                       const struct rustls_client_cert_verifier *verifier);
 
 /**
@@ -1135,7 +1135,7 @@ void rustls_server_config_builder_set_client_verifier(struct rustls_server_confi
  * If input is NULL, this will return NULL.
  * For memory lifetime, see rustls_server_config_builder_new.
  */
-void rustls_server_config_builder_set_client_verifier_optional(struct rustls_server_config_builder *config_builder,
+void rustls_server_config_builder_set_client_verifier_optional(struct rustls_server_config_builder *builder,
                                                                const struct rustls_client_cert_verifier_optional *verifier);
 
 /**

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1122,7 +1122,6 @@ rustls_result rustls_server_config_builder_new_custom(const struct rustls_suppor
  * Create a rustls_server_config_builder for TLS sessions that require
  * valid client certificates. The passed rustls_client_cert_verifier may
  * be used in several builders.
- * If input is NULL, this will return NULL.
  * For memory lifetime, see rustls_server_config_builder_new.
  */
 void rustls_server_config_builder_set_client_verifier(struct rustls_server_config_builder *builder,
@@ -1132,7 +1131,6 @@ void rustls_server_config_builder_set_client_verifier(struct rustls_server_confi
  * Create a rustls_server_config_builder for TLS sessions that accept
  * valid client certificates, but do not require them. The passed
  * rustls_client_cert_verifier_optional may be used in several builders.
- * If input is NULL, this will return NULL.
  * For memory lifetime, see rustls_server_config_builder_new.
  */
 void rustls_server_config_builder_set_client_verifier_optional(struct rustls_server_config_builder *builder,

--- a/src/server.rs
+++ b/src/server.rs
@@ -162,7 +162,6 @@ impl rustls_server_config_builder {
     /// Create a rustls_server_config_builder for TLS sessions that require
     /// valid client certificates. The passed rustls_client_cert_verifier may
     /// be used in several builders.
-    /// If input is NULL, this will return NULL.
     /// For memory lifetime, see rustls_server_config_builder_new.
     #[no_mangle]
     pub extern "C" fn rustls_server_config_builder_set_client_verifier(
@@ -179,7 +178,6 @@ impl rustls_server_config_builder {
     /// Create a rustls_server_config_builder for TLS sessions that accept
     /// valid client certificates, but do not require them. The passed
     /// rustls_client_cert_verifier_optional may be used in several builders.
-    /// If input is NULL, this will return NULL.
     /// For memory lifetime, see rustls_server_config_builder_new.
     #[no_mangle]
     pub extern "C" fn rustls_server_config_builder_set_client_verifier_optional(

--- a/src/server.rs
+++ b/src/server.rs
@@ -166,13 +166,13 @@ impl rustls_server_config_builder {
     /// For memory lifetime, see rustls_server_config_builder_new.
     #[no_mangle]
     pub extern "C" fn rustls_server_config_builder_set_client_verifier(
-        config_builder: *mut rustls_server_config_builder,
+        builder: *mut rustls_server_config_builder,
         verifier: *const rustls_client_cert_verifier,
     ) {
         ffi_panic_boundary! {
-        let mut config_builder = *try_box_from_ptr!(config_builder);
+        let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
         let verifier: Arc<AllowAnyAuthenticatedClient> = try_arc_from_ptr!(verifier);
-        config_builder.verifier = verifier;
+        builder.verifier = verifier;
         }
     }
 
@@ -183,14 +183,14 @@ impl rustls_server_config_builder {
     /// For memory lifetime, see rustls_server_config_builder_new.
     #[no_mangle]
     pub extern "C" fn rustls_server_config_builder_set_client_verifier_optional(
-        config_builder: *mut rustls_server_config_builder,
+        builder: *mut rustls_server_config_builder,
         verifier: *const rustls_client_cert_verifier_optional,
     ) {
         ffi_panic_boundary! {
-            let mut config_builder = *try_box_from_ptr!(config_builder);
+            let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
             let verifier: Arc<AllowAnyAnonymousOrAuthenticatedClient> = try_arc_from_ptr!(verifier);
 
-            config_builder.verifier = verifier;
+            builder.verifier = verifier;
         }
     }
 


### PR DESCRIPTION
Otherwise, we get a double free when building a config from a config builder.