### PR TITLE
Update MSRV to 1.56.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.52.1 # MSRV - keep in sync with what rustls considers MSRV
+          - 1.56.0 # MSRV - keep in sync with what rustls considers MSRV
         os: [ubuntu-18.04]
         # but only stable on macos/windows (slower platforms)
         include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rustls/rustls-ffi"
 categories = ["network-programming", "cryptography"]
 edition = "2018"
 links = "rustls_ffi"
+rust-version = "1.56"
 
 [features]
 # Enable this feature when building as Rust dependency. It inhibits the


### PR DESCRIPTION
This follows rustls' lead: https://github.com/rustls/rustls#release-history