### PR TITLE
Fix clippy errors for latest stable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -156,7 +156,7 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.65.0
           override: true
           default: true
           components: rustfmt
@@ -177,7 +177,28 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.65.0
+          override: true
+          default: true
+          components: clippy
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace -- -D warnings
+
+  clippy-nightly-optional:
+    name: Clippy nightly (optional)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
           override: true
           default: true
           components: clippy

--- a/src/client.rs
+++ b/src/client.rs
@@ -243,7 +243,7 @@ impl rustls::client::ServerCertVerifier for Verifier {
         let intermediates: Vec<_> = intermediates.iter().map(|cert| cert.as_ref()).collect();
 
         let intermediates = rustls_slice_slice_bytes {
-            inner: &*intermediates,
+            inner: &intermediates,
         };
 
         let params = rustls_verify_server_cert_params {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ pub(crate) trait ArcCastPtr: CastConstPtr + Sized {
 macro_rules! try_slice {
     ( $ptr:expr, $count:expr ) => {
         if $ptr.is_null() {
-            return crate::panic::NullParameterOrDefault::value();
+            return $crate::panic::NullParameterOrDefault::value();
         } else {
             unsafe { slice::from_raw_parts($ptr, $count as usize) }
         }
@@ -396,7 +396,7 @@ macro_rules! try_slice {
 macro_rules! try_mut_slice {
     ( $ptr:expr, $count:expr ) => {
         if $ptr.is_null() {
-            return crate::panic::NullParameterOrDefault::value();
+            return $crate::panic::NullParameterOrDefault::value();
         } else {
             unsafe { slice::from_raw_parts_mut($ptr, $count as usize) }
         }
@@ -445,9 +445,9 @@ where
 #[macro_export]
 macro_rules! try_ref_from_ptr {
     ( $var:ident ) => {
-        match crate::try_from($var) {
+        match $crate::try_from($var) {
             Some(c) => c,
-            None => return crate::panic::NullParameterOrDefault::value(),
+            None => return $crate::panic::NullParameterOrDefault::value(),
         }
     };
 }
@@ -456,9 +456,9 @@ macro_rules! try_ref_from_ptr {
 #[macro_export]
 macro_rules! try_mut_from_ptr {
     ( $var:ident ) => {
-        match crate::try_from_mut($var) {
+        match $crate::try_from_mut($var) {
             Some(c) => c,
-            None => return crate::panic::NullParameterOrDefault::value(),
+            None => return $crate::panic::NullParameterOrDefault::value(),
         }
     };
 }
@@ -467,9 +467,9 @@ macro_rules! try_mut_from_ptr {
 #[macro_export]
 macro_rules! try_box_from_ptr {
     ( $var:ident ) => {
-        match crate::try_box_from($var) {
+        match $crate::try_box_from($var) {
             Some(c) => c,
-            None => return crate::panic::NullParameterOrDefault::value(),
+            None => return $crate::panic::NullParameterOrDefault::value(),
         }
     };
 }
@@ -478,9 +478,9 @@ macro_rules! try_box_from_ptr {
 #[macro_export]
 macro_rules! try_arc_from_ptr {
     ( $var:ident ) => {
-        match crate::try_arc_from($var) {
+        match $crate::try_arc_from($var) {
             Some(c) => c,
-            None => return crate::panic::NullParameterOrDefault::value(),
+            None => return $crate::panic::NullParameterOrDefault::value(),
         }
     };
 }
@@ -491,7 +491,7 @@ macro_rules! try_callback {
     ( $var:ident ) => {
         match $var {
             Some(c) => c,
-            None => return crate::panic::NullParameterOrDefault::value(),
+            None => return $crate::panic::NullParameterOrDefault::value(),
         }
     };
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -113,7 +113,7 @@ macro_rules! ffi_panic_boundary {
             $($tt)*
         }) {
             Ok(ret) => ret,
-            Err(_) => return crate::PanicOrDefault::value(),
+            Err(_) => return $crate::PanicOrDefault::value(),
         }
     }
 }


### PR DESCRIPTION
Also update workflows so clippy is tested with a specific Rust version, not just the latest stable. This reduces the chance of CI breaking for reasons unrelated to changes in the codebase.