### PR TITLE
Fix freeing of Arcs

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -379,13 +379,7 @@ impl rustls_certified_key {
     #[no_mangle]
     pub extern "C" fn rustls_certified_key_free(key: *const rustls_certified_key) {
         ffi_panic_boundary! {
-            if key.is_null() {
-                return;
-            }
-            // To free the certified_key, we reconstruct the Arc. It should have a refcount of 1,
-            // representing the C code's copy. When it drops, that refcount will go down to 0
-            // and the inner ServerConfig will be dropped.
-            unsafe { drop(Arc::from_raw(key)) };
+            rustls_certified_key::free(key);
         }
     }
 
@@ -555,13 +549,7 @@ impl rustls_client_cert_verifier {
         verifier: *const rustls_client_cert_verifier,
     ) {
         ffi_panic_boundary! {
-            if verifier.is_null() {
-                return;
-            }
-            // To free the verifier, we reconstruct the Arc. It should have a refcount of 1,
-            // representing the C code's copy. When it drops, that refcount will go down to 0
-            // and the inner object will be dropped.
-            unsafe { drop(Arc::from_raw(verifier)) };
+            rustls_client_cert_verifier::free(verifier);
         }
     }
 }
@@ -610,13 +598,7 @@ impl rustls_client_cert_verifier_optional {
         verifier: *const rustls_client_cert_verifier_optional,
     ) {
         ffi_panic_boundary! {
-            if verifier.is_null() {
-                return;
-            }
-            // To free the verifier, we reconstruct the Arc. It should have a refcount of 1,
-            // representing the C code's copy. When it drops, that refcount will go down to 0
-            // and the inner object will be dropped.
-            unsafe { drop(Arc::from_raw(verifier)) };
+            rustls_client_cert_verifier_optional::free(verifier);
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -522,11 +522,7 @@ impl rustls_client_config {
     #[no_mangle]
     pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config) {
         ffi_panic_boundary! {
-            let config: &ClientConfig = try_ref_from_ptr!(config);
-            // To free the rustls_client_config, we reconstruct the Arc and then drop it. It should
-            // have a refcount of 1, representing the C code's copy. When it drops, that
-            // refcount will go down to 0 and the inner ClientConfig will be dropped.
-            unsafe { drop(Arc::from_raw(config)) };
+            rustls_client_config::free(config);
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -317,11 +317,7 @@ impl rustls_server_config {
     #[no_mangle]
     pub extern "C" fn rustls_server_config_free(config: *const rustls_server_config) {
         ffi_panic_boundary! {
-            let config: &ServerConfig = try_ref_from_ptr!(config);
-            // To free the rustls_server_config, we reconstruct the Arc. It should have a refcount of 1,
-            // representing the C code's copy. When it drops, that refcount will go down to 0
-            // and the inner ServerConfig will be dropped.
-            unsafe { drop(Arc::from_raw(config)) };
+            rustls_server_config::free(config);
         }
     }
 


### PR DESCRIPTION
Miri detected UB in how we were freeing Arcs. We were first creating a reference from the passed-in pointer, then passing that reference as input to Arc::from_raw, which by implicit conversion turned it back into a `*const Foo`.

Not only was this unnecessary, it is UB according to Stacked Borrows: the reference created a SharedReadOnly tag on the stack; but dropping the Arc requires SharedReadWrite because it decrements the ref count.