### PR TITLE
Remove references to old "crustls" name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,6 @@ install: target/$(PROFILE)/librustls_ffi.a
 	install target/$(PROFILE)/librustls_ffi.a $(DESTDIR)/lib/librustls.a
 	mkdir -p $(DESTDIR)/include
 	install src/rustls.h $(DESTDIR)/include/
-	ln -s librustls.a $(DESTDIR)/lib/libcrustls.a
-	ln -s rustls.h $(DESTDIR)/include/crustls.h
 
 clean:
 	rm -rf target

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,4 +1,4 @@
-include_guard = "CRUSTLS_H"
+include_guard = "RUSTLS_H"
 
 usize_is_size_t = true
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -557,7 +557,7 @@ impl rustls_client_config {
         let client = ClientConnection::new(config, server_name).unwrap();
 
         // We've succeeded. Put the client on the heap, and transfer ownership
-        // to the caller. After this point, we must return CRUSTLS_OK so the
+        // to the caller. After this point, we must return rustls_result::Ok so the
         // caller knows it is responsible for this memory.
         let c = Connection::from_client(client);
         BoxCastPtr::set_mut_ptr(conn_out, c);

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1,5 +1,5 @@
-#ifndef CRUSTLS_H
-#define CRUSTLS_H
+#ifndef RUSTLS_H
+#define RUSTLS_H
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -1553,4 +1553,4 @@ rustls_result rustls_server_config_builder_set_persistence(struct rustls_server_
                                                            rustls_session_store_get_callback get_cb,
                                                            rustls_session_store_put_callback put_cb);
 
-#endif /* CRUSTLS_H */
+#endif /* RUSTLS_H */

--- a/src/server.rs
+++ b/src/server.rs
@@ -340,7 +340,7 @@ impl rustls_server_config {
                 Err(e) => return map_error(e),
             };
             // We've succeeded. Put the server on the heap, and transfer ownership
-            // to the caller. After this point, we must return CRUSTLS_OK so the
+            // to the caller. After this point, we must return rustls_result::Ok so the
             // caller knows it is responsible for this memory.
             let c = Connection::from_server(server_connection);
             BoxCastPtr::set_mut_ptr(conn_out, c);

--- a/tests/client.c
+++ b/tests/client.c
@@ -34,7 +34,7 @@ int
 make_conn(const char *hostname, const char *port)
 {
   int sockfd = 0;
-  enum crustls_demo_result result = 0;
+  enum demo_result result = 0;
   struct addrinfo *getaddrinfo_output = NULL, hints;
 
   memset(&hints, 0, sizeof(hints));
@@ -64,7 +64,7 @@ make_conn(const char *hostname, const char *port)
     goto cleanup;
   }
   result = nonblock(sockfd);
-  if(result != CRUSTLS_DEMO_OK) {
+  if(result != DEMO_OK) {
     return 1;
   }
 
@@ -85,13 +85,13 @@ cleanup:
  * Do one read from the socket, and process all resulting bytes into the
  * rustls_connection, then copy all plaintext bytes from the session to stdout.
  * Returns:
- *  - CRUSTLS_DEMO_OK for success
- *  - CRUSTLS_DEMO_AGAIN if we got an EAGAIN or EWOULDBLOCK reading from the
+ *  - DEMO_OK for success
+ *  - DEMO_AGAIN if we got an EAGAIN or EWOULDBLOCK reading from the
  *    socket
- *  - CRUSTLS_DEMO_EOF if we got EOF
- *  - CRUSTLS_DEMO_ERROR for other errors.
+ *  - DEMO_EOF if we got EOF
+ *  - DEMO_ERROR for other errors.
  */
-enum crustls_demo_result
+enum demo_result
 do_read(struct conndata *conn, struct rustls_connection *rconn)
 {
   int err = 1;
@@ -106,21 +106,21 @@ do_read(struct conndata *conn, struct rustls_connection *rconn)
     fprintf(stderr,
             "client: reading from socket: EAGAIN or EWOULDBLOCK: %s\n",
             strerror(errno));
-    return CRUSTLS_DEMO_AGAIN;
+    return DEMO_AGAIN;
   }
   else if(err != 0) {
     fprintf(stderr, "client: reading from socket: errno %d\n", err);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
 
   result = rustls_connection_process_new_packets(rconn);
   if(result != RUSTLS_RESULT_OK) {
     print_error("server", "in process_new_packets", result);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
 
   result = copy_plaintext_to_buffer(conn);
-  if(result != CRUSTLS_DEMO_EOF) {
+  if(result != DEMO_EOF) {
     return result;
   }
 
@@ -131,15 +131,15 @@ do_read(struct conndata *conn, struct rustls_connection *rconn)
     fprintf(stderr,
             "client: error: read returned %zu bytes after receiving close_notify\n",
             n);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
   else if (signed_n < 0 && errno != EWOULDBLOCK) {
     fprintf(stderr,
             "client: error: read returned incorrect error after receiving close_notify: %s\n",
             strerror(errno));
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
-  return CRUSTLS_DEMO_EOF;
+  return DEMO_EOF;
 }
 
 static const char *CONTENT_LENGTH = "Content-Length";
@@ -224,13 +224,13 @@ send_request_and_read_response(struct conndata *conn,
          select awaiting the next bit of data. */
       for(;;) {
         result = do_read(conn, rconn);
-        if(result == CRUSTLS_DEMO_AGAIN) {
+        if(result == DEMO_AGAIN) {
           break;
         }
-        else if(result == CRUSTLS_DEMO_EOF) {
+        else if(result == DEMO_EOF) {
           goto drain_plaintext;
         }
-        else if(result != CRUSTLS_DEMO_OK) {
+        else if(result != DEMO_OK) {
           goto cleanup;
         }
         if(headers_len == 0) {
@@ -276,7 +276,7 @@ send_request_and_read_response(struct conndata *conn,
             stderr, "client: error in rustls_connection_write_tls: errno %d\n", err);
           goto cleanup;
         }
-        if(result == CRUSTLS_DEMO_AGAIN) {
+        if(result == DEMO_AGAIN) {
           break;
         }
         else if(n == 0) {
@@ -291,7 +291,7 @@ send_request_and_read_response(struct conndata *conn,
 
 drain_plaintext:
   result = copy_plaintext_to_buffer(conn);
-  if(result != CRUSTLS_DEMO_OK && result != CRUSTLS_DEMO_EOF) {
+  if(result != DEMO_OK && result != DEMO_EOF) {
     goto cleanup;
   }
   fprintf(stderr, "client: writing %zu bytes to stdout\n", conn->data.len);

--- a/tests/common.c
+++ b/tests/common.c
@@ -74,9 +74,9 @@ write_all(int fd, const char *buf, int n)
 /*
  * Set a socket to be nonblocking.
  *
- * Returns CRUSTLS_DEMO_OK on success, CRUSTLS_DEMO_ERROR on error.
+ * Returns DEMO_OK on success, DEMO_ERROR on error.
  */
-enum crustls_demo_result
+enum demo_result
 nonblock(int sockfd)
 {
 #ifdef _WIN32
@@ -84,22 +84,22 @@ nonblock(int sockfd)
 
   if(ioctlsocket(sockfd, FIONBIO, &nonblock) != 0) {
     perror("Error setting socket nonblocking");
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
 #else
   int flags;
   flags = fcntl(sockfd, F_GETFL, 0);
   if(flags < 0) {
     perror("getting socket flags");
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
   flags = fcntl(sockfd, F_SETFL, flags | O_NONBLOCK);
   if(flags < 0) {
     perror("setting socket nonblocking");
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
 #endif
-  return CRUSTLS_DEMO_OK;
+  return DEMO_OK;
 }
 
 int
@@ -183,8 +183,8 @@ bytevec_consume(struct bytevec *vec, size_t n)
 
 // Ensure there are at least n bytes available between vec->len and
 // vec->capacity. If this requires reallocating, this may return
-// CRUSTLS_DEMO_ERROR.
-enum crustls_demo_result
+// DEMO_ERROR.
+enum demo_result
 bytevec_ensure_available(struct bytevec *vec, size_t n)
 {
   size_t available = vec->capacity - vec->len;
@@ -198,12 +198,12 @@ bytevec_ensure_available(struct bytevec *vec, size_t n)
     newdata = realloc(vec->data, newsize);
     if(newdata == NULL) {
       fprintf(stderr, "out of memory trying to get %zu bytes\n", newsize);
-      return CRUSTLS_DEMO_ERROR;
+      return DEMO_ERROR;
     }
     vec->data = newdata;
     vec->capacity = newsize;
   }
-  return CRUSTLS_DEMO_OK;
+  return DEMO_OK;
 }
 
 /**
@@ -217,8 +217,8 @@ copy_plaintext_to_buffer(struct conndata *conn)
   size_t n;
   struct rustls_connection *rconn = conn->rconn;
 
-  if(bytevec_ensure_available(&conn->data, 1024) != CRUSTLS_DEMO_OK) {
-    return CRUSTLS_DEMO_ERROR;
+  if(bytevec_ensure_available(&conn->data, 1024) != DEMO_OK) {
+    return DEMO_ERROR;
   }
 
   for(;;) {
@@ -227,23 +227,23 @@ copy_plaintext_to_buffer(struct conndata *conn)
     result = rustls_connection_read(rconn, (uint8_t *)buf, avail, &n);
     if(result == RUSTLS_RESULT_PLAINTEXT_EMPTY) {
       /* This is expected. It just means "no more bytes for now." */
-      return CRUSTLS_DEMO_OK;
+      return DEMO_OK;
     }
     if(result != RUSTLS_RESULT_OK) {
       print_error(conn->program_name, "Error in rustls_connection_read", result);
-      return CRUSTLS_DEMO_ERROR;
+      return DEMO_ERROR;
     }
     if(n == 0) {
       fprintf(stderr, "got 0-byte read, cleanly ending connection\n");
-      return CRUSTLS_DEMO_EOF;
+      return DEMO_EOF;
     }
     bytevec_consume(&conn->data, n);
-    if(bytevec_ensure_available(&conn->data, 1024) != CRUSTLS_DEMO_OK) {
-      return CRUSTLS_DEMO_ERROR;
+    if(bytevec_ensure_available(&conn->data, 1024) != DEMO_OK) {
+      return DEMO_ERROR;
     }
   }
 
-  return CRUSTLS_DEMO_ERROR;
+  return DEMO_ERROR;
 }
 
 /**

--- a/tests/common.h
+++ b/tests/common.h
@@ -23,12 +23,12 @@ const char * ws_strerror(int err);
 #endif /* !STDOUT_FILENO */
 #endif /* _WIN32 */
 
-enum crustls_demo_result
+enum demo_result
 {
-  CRUSTLS_DEMO_OK,
-  CRUSTLS_DEMO_ERROR,
-  CRUSTLS_DEMO_AGAIN,
-  CRUSTLS_DEMO_EOF,
+  DEMO_OK,
+  DEMO_ERROR,
+  DEMO_AGAIN,
+  DEMO_EOF,
 };
 
 /* A growable vector of bytes. */
@@ -53,7 +53,7 @@ int
 write_all(int fd, const char *buf, int n);
 
 /* Make a socket nonblocking. */
-enum crustls_demo_result
+enum demo_result
 nonblock(int sockfd);
 
 /* A callback that reads bytes from the network. */
@@ -88,17 +88,17 @@ bytevec_consume(struct bytevec *vec, size_t n);
 
 /* Ensure there are at least n bytes available between vec->len and
  * vec->capacity. If this requires reallocating, this may return
- * CRUSTLS_DEMO_ERROR. */
-enum crustls_demo_result
+ * DEMO_ERROR. */
+enum demo_result
 bytevec_ensure_available(struct bytevec *vec, size_t n);
 
 /* Read all available bytes from the rustls_connection until EOF.
  * Note that EOF here indicates "no more bytes until
  * process_new_packets", not "stream is closed".
  *
- * Returns CRUSTLS_DEMO_OK for success,
- * CRUSTLS_DEMO_ERROR for error,
- * CRUSTLS_DEMO_EOF for "connection cleanly terminated by peer"
+ * Returns DEMO_OK for success,
+ * DEMO_ERROR for error,
+ * DEMO_EOF for "connection cleanly terminated by peer"
  */
 int
 copy_plaintext_to_buffer(struct conndata *conn);

--- a/tests/server.c
+++ b/tests/server.c
@@ -28,22 +28,22 @@
 #include "rustls.h"
 #include "common.h"
 
-enum crustls_demo_result
+enum demo_result
 read_file(const char *filename, char *buf, size_t buflen, size_t *n)
 {
   FILE *f = fopen(filename, "r");
   if(f == NULL) {
     fprintf(stderr, "server: opening %s: %s\n", filename, strerror(errno));
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
   *n = fread(buf, 1, buflen, f);
   if(!feof(f)) {
     fprintf(stderr, "server: reading %s: %s\n", filename, strerror(errno));
     fclose(f);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
   fclose(f);
-  return CRUSTLS_DEMO_OK;
+  return DEMO_OK;
 }
 
 typedef enum exchange_state
@@ -56,13 +56,13 @@ typedef enum exchange_state
  * Do one read from the socket, and process all resulting bytes into the
  * rustls_connection, then copy all plaintext bytes from the session to stdout.
  * Returns:
- *  - CRUSTLS_DEMO_OK for success
- *  - CRUSTLS_DEMO_AGAIN if we got an EAGAIN or EWOULDBLOCK reading from the
+ *  - DEMO_OK for success
+ *  - DEMO_AGAIN if we got an EAGAIN or EWOULDBLOCK reading from the
  *    socket
- *  - CRUSTLS_DEMO_EOF if we got EOF
- *  - CRUSTLS_DEMO_ERROR for other errors.
+ *  - DEMO_EOF if we got EOF
+ *  - DEMO_ERROR for other errors.
  */
-enum crustls_demo_result
+enum demo_result
 do_read(struct conndata *conn, struct rustls_connection *rconn)
 {
   int err = 1;
@@ -76,26 +76,26 @@ do_read(struct conndata *conn, struct rustls_connection *rconn)
     fprintf(stderr,
             "server: reading from socket: EAGAIN or EWOULDBLOCK: %s\n",
             strerror(errno));
-    return CRUSTLS_DEMO_AGAIN;
+    return DEMO_AGAIN;
   }
   else if(err != 0) {
     fprintf(stderr, "server: reading from socket: errno %d\n", err);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
 
   if(n == 0) {
-    return CRUSTLS_DEMO_EOF;
+    return DEMO_EOF;
   }
   fprintf(stderr, "server: read %zu bytes from socket\n", n);
 
   result = rustls_connection_process_new_packets(rconn);
   if(result != RUSTLS_RESULT_OK) {
     print_error("server", "in process_new_packets", result);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
 
   result = copy_plaintext_to_buffer(conn);
-  if(result != CRUSTLS_DEMO_EOF) {
+  if(result != DEMO_EOF) {
     fprintf(stderr, "server: do_read returning %d\n", result);
     return result;
   }
@@ -107,18 +107,18 @@ do_read(struct conndata *conn, struct rustls_connection *rconn)
     fprintf(stderr,
             "server: error: read returned %zu bytes after receiving close_notify\n",
             n);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
   else if (signed_n < 0 && errno != EWOULDBLOCK) {
     fprintf(stderr,
             "server: error: read returned incorrect error after receiving close_notify: %s\n",
             strerror(errno));
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
-  return CRUSTLS_DEMO_EOF;
+  return DEMO_EOF;
 }
 
-enum crustls_demo_result
+enum demo_result
 send_response(struct conndata *conn)
 {
   struct rustls_connection *rconn = conn->rconn;
@@ -130,7 +130,7 @@ send_response(struct conndata *conn)
 
   if(response == NULL) {
     fprintf(stderr, "server: failed malloc\n");
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
 
   n = snprintf(response, response_size, "%s %d\r\n\r\n", prefix, body_size);
@@ -145,9 +145,9 @@ send_response(struct conndata *conn)
   free(response);
   if(n != response_size) {
     fprintf(stderr, "server: failed to write all response bytes. wrote %zu\n", n);
-    return CRUSTLS_DEMO_ERROR;
+    return DEMO_ERROR;
   }
-  return CRUSTLS_DEMO_OK;
+  return DEMO_OK;
 }
 
 void
@@ -198,13 +198,13 @@ handle_conn(struct conndata *conn)
          select awaiting the next bit of data. */
       for(;;) {
         result = do_read(conn, rconn);
-        if(result == CRUSTLS_DEMO_AGAIN) {
+        if(result == DEMO_AGAIN) {
           break;
         }
-        else if(result == CRUSTLS_DEMO_EOF) {
+        else if(result == DEMO_EOF) {
           goto cleanup;
         }
-        else if(result != CRUSTLS_DEMO_OK) {
+        else if(result != DEMO_OK) {
           goto cleanup;
         }
       }
@@ -234,7 +234,7 @@ handle_conn(struct conndata *conn)
         fprintf(stderr, "server: no ALPN protocol was negotiated\n");
       }
 
-      if(send_response(conn) != CRUSTLS_DEMO_OK) {
+      if(send_response(conn) != DEMO_OK) {
         goto cleanup;
       };
     }
@@ -261,12 +261,12 @@ load_cert_and_key(const char *certfile, const char *keyfile)
   size_t keybuf_len;
 
   int result = read_file(certfile, certbuf, sizeof(certbuf), &certbuf_len);
-  if(result != CRUSTLS_DEMO_OK) {
+  if(result != DEMO_OK) {
     return NULL;
   }
 
   result = read_file(keyfile, keybuf, sizeof(keybuf), &keybuf_len);
-  if(result != CRUSTLS_DEMO_OK) {
+  if(result != DEMO_OK) {
     return NULL;
   }
 


### PR DESCRIPTION
Remove symlinking of old library name (libcrustls.a and crustls.h).

Rename header guard to "RUSTLS_H".

Rename CRUSTLS_DEMO_* constants to DEMO_*.