### PR TITLE
make rustls_slice_slice_bytes_len function unsafe

### DIFF
--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -77,12 +77,10 @@ pub struct rustls_slice_slice_bytes<'a> {
 /// Return the length of the outer slice. If the input pointer is NULL,
 /// returns 0.
 #[no_mangle]
-pub extern "C" fn rustls_slice_slice_bytes_len(input: *const rustls_slice_slice_bytes) -> size_t {
-    unsafe {
-        match input.as_ref() {
-            Some(c) => c.inner.len(),
-            None => 0,
-        }
+pub unsafe extern "C" fn rustls_slice_slice_bytes_len(input: *const rustls_slice_slice_bytes) -> size_t {
+    match input.as_ref() {
+        Some(c) => c.inner.len(),
+        None => 0,
     }
 }
 
@@ -293,12 +291,10 @@ pub struct rustls_slice_str<'a> {
 /// Return the length of the outer slice. If the input pointer is NULL,
 /// returns 0.
 #[no_mangle]
-pub extern "C" fn rustls_slice_str_len(input: *const rustls_slice_str) -> size_t {
-    unsafe {
-        match input.as_ref() {
-            Some(c) => c.inner.len(),
-            None => 0,
-        }
+pub unsafe extern "C" fn rustls_slice_str_len(input: *const rustls_slice_str) -> size_t {
+    match input.as_ref() {
+        Some(c) => c.inner.len(),
+        None => 0,
     }
 }
 


### PR DESCRIPTION
https://github.com/rustls/rustls-ffi/blob/55df12216f0004af12c5967725a0b46d9c4bd466/src/rslice.rs#L80-L87
Hello, It is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the start function may not notice this safety requirement.
The unsafe function called needs to ensure that the parameter must be:

- The pointer must be properly aligned.
- It must be “dereferenceable” in the sense defined in the module documentation.
- The pointer must point to an initialized instance of T.
- You must enforce Rust’s aliasing rules, since the returned lifetime 'a is arbitrarily chosen and does not necessarily reflect the actual lifetime of the data. In particular, while this reference exists, the memory the pointer points to must not get mutated (except inside UnsafeCell).

https://doc.rust-lang.org/std/primitive.pointer.html#method.as_ref

Marking them unsafe also means that callers must make sure they know what they're doing.