### PR TITLE
server: adjust sni_hostname() -> server_name().

### DIFF
--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1487,15 +1487,15 @@ rustls_result rustls_server_connection_new(const struct rustls_server_config *co
                                            struct rustls_connection **conn_out);
 
 /**
- * Copy the SNI hostname to `buf` which can hold up  to `count` bytes,
- * and the length of that hostname in `out_n`. The string is stored in UTF-8
- * with no terminating NUL byte.
+ * Copy the server name from the server name indication (SNI) extension to `buf` which can
+ * hold up  to `count` bytes, and the length of that server name in `out_n`. The string is
+ * stored in UTF-8 with no terminating NUL byte.
  * Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
  * Returns Ok with *out_n == 0 if there is no SNI hostname available on this connection
  * because it hasn't been processed yet, or because the client did not send SNI.
- * <https://docs.rs/rustls/0.20.0/rustls/server/struct.ServerConnection.html#method.sni_hostname>
+ * <https://docs.rs/rustls/0.21.0/rustls/server/struct.ServerConnection.html#method.server_name>
  */
-rustls_result rustls_server_connection_get_sni_hostname(const struct rustls_connection *conn,
+rustls_result rustls_server_connection_get_server_name(const struct rustls_connection *conn,
                                                         uint8_t *buf,
                                                         size_t count,
                                                         size_t *out_n);

--- a/src/server.rs
+++ b/src/server.rs
@@ -349,15 +349,15 @@ impl rustls_server_config {
     }
 }
 
-/// Copy the SNI hostname to `buf` which can hold up  to `count` bytes,
-/// and the length of that hostname in `out_n`. The string is stored in UTF-8
-/// with no terminating NUL byte.
+/// Copy the server name from the server name indication (SNI) extension to `buf` which can
+/// hold up  to `count` bytes, and the length of that server name in `out_n`. The string is
+/// stored in UTF-8 with no terminating NUL byte.
 /// Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
 /// Returns Ok with *out_n == 0 if there is no SNI hostname available on this connection
 /// because it hasn't been processed yet, or because the client did not send SNI.
-/// <https://docs.rs/rustls/0.20.0/rustls/server/struct.ServerConnection.html#method.sni_hostname>
+/// <https://docs.rs/rustls/0.21.0/rustls/server/struct.ServerConnection.html#method.server_name>
 #[no_mangle]
-pub extern "C" fn rustls_server_connection_get_sni_hostname(
+pub extern "C" fn rustls_server_connection_get_server_name(
     conn: *const rustls_connection,
     buf: *mut u8,
     count: size_t,
@@ -375,7 +375,7 @@ pub extern "C" fn rustls_server_connection_get_sni_hostname(
             Some(s) => s,
             _ => return rustls_result::InvalidParameter,
         };
-        let sni_hostname = match server_connection.sni_hostname() {
+        let sni_hostname = match server_connection.server_name() {
             Some(sni_hostname) => sni_hostname,
             None => {
                 unsafe {


### PR DESCRIPTION
This follows the upstream change in Rustls to prefer `server_name` over `sni_hostname`. See rustls/rustls@9b8fa40.

Resolves https://github.com/rustls/rustls-ffi/issues/295