### PR TITLE
client auth type constructor changes

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -536,7 +536,8 @@ impl rustls_client_cert_verifier {
     ) -> *const rustls_client_cert_verifier {
         ffi_panic_boundary! {
             let store: &RootCertStore = try_ref_from_ptr!(store);
-            return Arc::into_raw(AllowAnyAuthenticatedClient::new(store.clone())) as *const _;
+            let client_cert_verifier = AllowAnyAuthenticatedClient::new(store.clone());
+            return Arc::into_raw(client_cert_verifier.boxed()) as *const _;
         }
     }
 
@@ -586,7 +587,8 @@ impl rustls_client_cert_verifier_optional {
     ) -> *const rustls_client_cert_verifier_optional {
         ffi_panic_boundary! {
             let store: &RootCertStore = try_ref_from_ptr!(store);
-            return Arc::into_raw(AllowAnyAnonymousOrAuthenticatedClient::new(store.clone()))
+            let client_cert_verifier = AllowAnyAnonymousOrAuthenticatedClient::new(store.clone());
+            return Arc::into_raw(client_cert_verifier.boxed())
                 as *const _;
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -86,7 +86,7 @@ impl rustls_server_config_builder {
         ffi_panic_boundary! {
             let builder = ServerConfigBuilder {
                            base: rustls::ServerConfig::builder().with_safe_defaults(),
-                           verifier: NoClientAuth::new(),
+                           verifier: NoClientAuth::boxed(),
                            cert_resolver: None,
                            session_storage: None,
                            alpn_protocols: vec![],
@@ -148,7 +148,7 @@ impl rustls_server_config_builder {
 
             let builder = ServerConfigBuilder {
                 base,
-                verifier: NoClientAuth::new(),
+                verifier: NoClientAuth::boxed(),
                 cert_resolver: None,
                 session_storage: None,
                 alpn_protocols: vec![],


### PR DESCRIPTION
Resolves https://github.com/rustls/rustls-ffi/issues/296 See https://github.com/rustls/rustls/commit/cd4f5c9 for more information.

### server: NoClientAuth::new -> ::boxed - be4c8755f87476667423e7034de4a633a99f74f2

The upstream constructor for `NoClientAuth` was renamed from `new` to `boxed`. This commit updates the rustls-ffi to use the new name.

### cipher: client verifiers constructor changes. - 1da22cadbaf995c2039290fefae2779d252b00f6

Both `AllowAnyAuthenticatedClient` and `AllowAnyAnonymousOrAuthenticatedClient` had their `new` constructors changed from returning an `Arc` to returning `Self` and offering a `boxed` for wrapping in an `Arc`.

This commit updates the `rustls_client_cert_verifier` and `rustls_client_cert_verifier_optional` fns to accommodate this change.

