### PR TITLE
Small AlertDescription and NoneVerifier error fixes.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9,8 +9,8 @@ use std::time::SystemTime;
 use libc::{c_char, size_t};
 use rustls::client::{ResolvesClientCert, ServerCertVerified, ServerCertVerifier};
 use rustls::{
-    sign::CertifiedKey, Certificate, ClientConfig, ClientConnection, ProtocolVersion,
-    RootCertStore, SupportedCipherSuite, WantsVerifier, ALL_CIPHER_SUITES,
+    sign::CertifiedKey, Certificate, CertificateError, ClientConfig, ClientConnection,
+    ProtocolVersion, RootCertStore, SupportedCipherSuite, WantsVerifier, ALL_CIPHER_SUITES,
 };
 
 use crate::cipher::{rustls_certified_key, rustls_root_cert_store, rustls_supported_ciphersuite};
@@ -80,7 +80,9 @@ impl ServerCertVerifier for NoneVerifier {
         _ocsp_response: &[u8],
         _now: SystemTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        Err(rustls::Error::InvalidCertificateSignature)
+        Err(rustls::Error::InvalidCertificate(
+            CertificateError::BadSignature,
+        ))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -206,7 +206,7 @@ pub enum rustls_result {
 }
 
 pub(crate) fn map_error(input: rustls::Error) -> rustls_result {
-    use rustls::internal::msgs::enums::AlertDescription as alert;
+    use rustls::AlertDescription as alert;
     use rustls_result::*;
     use sct::Error as sct;
 
@@ -285,7 +285,7 @@ pub(crate) fn map_error(input: rustls::Error) -> rustls_result {
 
 impl Display for rustls_result {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use rustls::internal::msgs::enums::AlertDescription as alert;
+        use rustls::AlertDescription as alert;
         use rustls_result::*;
         use sct::Error as sct;
 


### PR DESCRIPTION
This branch pulls out two easy fixes that don't require any adjustment of the `rustls_result` enum. The remaining fixes will take a little bit more care so I thought I'd put these up for review first. Updates #297 

### error: fix AlertDescription import path. - 269f18b697cac6885781a16f705c19c64aae0284
The `AlertDescription` enum was moved out of `rustls::internal::msgs::enums` into the top-level API. This commit updates the rustls-ffi import to match.

### client: update NoneVerifier err return type. - c73624966a09d3652def5f5c3cab569919c78a5b
The upstream `error::InvalidCertificateSignature` type was replaced with  a differentiated `InvalidCertificate` error that has a `CertificateError::BadSignature` variant. 

This commit updates the rustls-ffi `NoneVerifier` to use this more specific error type as its return from `verify_server_cert`.