### PR TITLE
session: remove impl StoresClientSessions

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -151,16 +151,6 @@ impl rustls::server::StoresServerSessions for SessionStoreBroker {
     }
 }
 
-impl rustls::client::StoresClientSessions for SessionStoreBroker {
-    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
-        self.store(key, value)
-    }
-
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.retrieve(key, false)
-    }
-}
-
 /// This struct can be considered thread safe, as long
 /// as the registered callbacks are thread safe. This is
 /// documented as a requirement in the API.


### PR DESCRIPTION
This trait no longer exists upstream. It was replaced by ClientSessionStore.

rustls-ffi does not yet export bindings for configuring client session support, only server session support. So we can safely remove this for now.