### PR TITLE
Support IP addresses in server names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.21.0-alpha.1"
-source = "git+https://github.com/rustls/rustls?branch=main#e84cf29d4cdf9a76791eca4a501dbcc0f14bd750"
+source = "git+https://github.com/rustls/rustls?branch=main#6831835c56696d61024f2ae1261b41edad54e685"
 dependencies = [
  "log",
  "ring",


### PR DESCRIPTION
This actually involved basically no changes in functionality. It updates documentation to be clear that IP addresses are allowed, and updates some field and parameter names from dns_name or sni_name to server_name.

Note: there's one fix still needed after this. `InvalidDnsNameError => write!(f, "hostname was either malformed or an IP address (rustls does not support certificates for IP addresses)"),` should become "InvalidDnsNameError => write!(f, "server name was malformed (not a valid hostname or IP address)". But that was likely to cause conflicts with @cpu's in-progress fix for #297 so I'm omitting it for now.

Fixes #292