### PR TITLE
tests: dns_name -> server_name.

### DIFF
--- a/tests/client.c
+++ b/tests/client.c
@@ -373,8 +373,8 @@ verify(void *userdata, const rustls_verify_server_cert_params *params)
 
   fprintf(stderr,
           "client: custom certificate verifier called for %.*s\n",
-          (int)params->dns_name.len,
-          params->dns_name.data);
+          (int)params->server_name.len,
+          params->server_name.data);
   fprintf(stderr, "client: end entity len: %zu\n", params->end_entity_cert_der.len);
   fprintf(stderr, "client: intermediates:\n");
   for(i = 0; i < intermediates_len; i++) {


### PR DESCRIPTION
This commit updates the `tests/client.c` program to fix a stale reference to the now renamed `dns_name` field of the `rustls_verify_server_cert_params` struct. This field is now called `server_name` to reflect that it may contain an IP address.

<details><summary>This fixes the following build error:</summary>
<p>

```
Run make CC=clang PROFILE=release test
mkdir -p target
clang -o target/client.o -c tests/client.c -Werror -Wall -Wextra -Wpedantic -g -I src/ -fsanitize=address -fsanitize=undefined -O3
tests/client.c:37[6](https://github.com/rustls/rustls-ffi/actions/runs/4502338870/jobs/7924017944?pr=303#step:4:7):24: error: no member named 'dns_name' in 'struct rustls_verify_server_cert_params'
          (int)params->dns_name.len,
               ~~~~~~  ^
tests/client.c:3[7](https://github.com/rustls/rustls-ffi/actions/runs/4502338870/jobs/7924017944?pr=303#step:4:8)7:19: error: no member named 'dns_name' in 'struct rustls_verify_server_cert_params'
          params->dns_name.data);
          ~~~~~~  ^
2 errors generated.
Makefile:4[8](https://github.com/rustls/rustls-ffi/actions/runs/4502338870/jobs/7924017944?pr=303#step:4:9): recipe for target 'target/client.o' failed
make: *** [target/client.o] Error 1
Error: Process completed with exit code 2.
```

</p>
</details> 