### PR TITLE
docs: update docs.rs links to prefer /latest.

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -24,7 +24,7 @@ use std::ops::Deref;
 
 /// An X.509 certificate, as used in rustls.
 /// Corresponds to `Certificate` in the Rust API.
-/// <https://docs.rs/rustls/0.20.0/rustls/struct.Certificate.html>
+/// <https://docs.rs/rustls/latest/rustls/struct.Certificate.html>
 pub struct rustls_certificate {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -253,7 +253,7 @@ mod tests {
 /// The complete chain of certificates to send during a TLS handshake,
 /// plus a private key that matches the end-entity (leaf) certificate.
 /// Corresponds to `CertifiedKey` in the Rust API.
-/// <https://docs.rs/rustls/0.20.0/rustls/sign/struct.CertifiedKey.html>
+/// <https://docs.rs/rustls/latest/rustls/sign/struct.CertifiedKey.html>
 pub struct rustls_certified_key {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -434,7 +434,7 @@ impl rustls_certified_key {
 }
 
 /// A root certificate store.
-/// <https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html>
+/// <https://docs.rs/rustls/latest/rustls/struct.RootCertStore.html>
 pub struct rustls_root_cert_store {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -452,7 +452,7 @@ impl rustls_root_cert_store {
     /// Create a rustls_root_cert_store. Caller owns the memory and must
     /// eventually call rustls_root_cert_store_free. The store starts out empty.
     /// Caller must add root certificates with rustls_root_cert_store_add_pem.
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html#method.empty>
+    /// <https://docs.rs/rustls/latest/rustls/struct.RootCertStore.html#method.empty>
     #[no_mangle]
     pub extern "C" fn rustls_root_cert_store_new() -> *mut rustls_root_cert_store {
         ffi_panic_boundary! {

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,7 +31,7 @@ use crate::{
 /// to turn it into a *rustls_client_config. This object is not safe
 /// for concurrent mutation. Under the hood, it corresponds to a
 /// `Box<ClientConfig>`.
-/// <https://docs.rs/rustls/0.20.0/rustls/struct.ConfigBuilder.html>
+/// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
 pub struct rustls_client_config_builder {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -55,7 +55,7 @@ impl BoxCastPtr for rustls_client_config_builder {}
 
 /// A client config that is done being constructed and is now read-only.
 /// Under the hood, this object corresponds to an `Arc<ClientConfig>`.
-/// <https://docs.rs/rustls/0.20.0/rustls/struct.ClientConfig.html>
+/// <https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html>
 pub struct rustls_client_config {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -296,7 +296,7 @@ impl rustls_client_config_builder {
     /// Feel free to use an appropriate error from the RUSTLS_RESULT_CERT_*
     /// section.
     ///
-    /// <https://docs.rs/rustls/0.20.0/rustls/client/struct.DangerousClientConfig.html#method.set_certificate_verifier>
+    /// <https://docs.rs/rustls/latest/rustls/client/struct.DangerousClientConfig.html#method.set_certificate_verifier>
     #[no_mangle]
     pub extern "C" fn rustls_client_config_builder_dangerous_set_certificate_verifier(
         config_builder: *mut rustls_client_config_builder,
@@ -388,7 +388,7 @@ impl rustls_client_config_builder {
     /// This function makes a copy of the data in `protocols` and does not retain
     /// any pointers, so the caller can free the pointed-to memory after calling.
     ///
-    /// <https://docs.rs/rustls/0.20.0/rustls/client/struct.ClientConfig.html#structfield.alpn_protocols>
+    /// <https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#structfield.alpn_protocols>
     #[no_mangle]
     pub extern "C" fn rustls_client_config_builder_set_alpn_protocols(
         builder: *mut rustls_client_config_builder,
@@ -410,7 +410,7 @@ impl rustls_client_config_builder {
     }
 
     /// Enable or disable SNI.
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.ClientConfig.html#structfield.enable_sni>
+    /// <https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html#structfield.enable_sni>
     #[no_mangle]
     pub extern "C" fn rustls_client_config_builder_set_enable_sni(
         config: *mut rustls_client_config_builder,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -138,7 +138,7 @@ impl rustls_connection {
     /// `rustls_connection_set_userdata`.
     /// Returns 0 for success, or an errno value on error. Passes through return values
     /// from callback. See rustls_read_callback for more details.
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.read_tls>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.read_tls>
     #[no_mangle]
     pub extern "C" fn rustls_connection_read_tls(
         conn: *mut rustls_connection,
@@ -175,7 +175,7 @@ impl rustls_connection {
     /// `rustls_connection_set_userdata`.
     /// Returns 0 for success, or an errno value on error. Passes through return values
     /// from callback. See rustls_write_callback for more details.
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.write_tls>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.write_tls>
     #[no_mangle]
     pub extern "C" fn rustls_connection_write_tls(
         conn: *mut rustls_connection,
@@ -212,7 +212,7 @@ impl rustls_connection {
     /// `rustls_connection_set_userdata`.
     /// Returns 0 for success, or an errno value on error. Passes through return values
     /// from callback. See rustls_write_callback for more details.
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.Writer.html#method.write_vectored>
+    /// <https://docs.rs/rustls/latest/rustls/struct.Writer.html#method.write_vectored>
     #[no_mangle]
     pub extern "C" fn rustls_connection_write_tls_vectored(
         conn: *mut rustls_connection,
@@ -243,7 +243,7 @@ impl rustls_connection {
     /// Decrypt any available ciphertext from the internal buffer and put it
     /// into the internal plaintext buffer, potentially making bytes available
     /// for rustls_connection_read().
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.process_new_packets>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.process_new_packets>
     #[no_mangle]
     pub extern "C" fn rustls_connection_process_new_packets(
         conn: *mut rustls_connection,
@@ -265,7 +265,7 @@ impl rustls_connection {
         }
     }
 
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.CommonState.html#method.wants_read>
+    /// <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.wants_read>
     #[no_mangle]
     pub extern "C" fn rustls_connection_wants_read(conn: *const rustls_connection) -> bool {
         ffi_panic_boundary! {
@@ -274,7 +274,7 @@ impl rustls_connection {
         }
     }
 
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.CommonState.html#method.wants_write>
+    /// <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.wants_write>
     #[no_mangle]
     pub extern "C" fn rustls_connection_wants_write(conn: *const rustls_connection) -> bool {
         ffi_panic_boundary! {
@@ -283,7 +283,7 @@ impl rustls_connection {
         }
     }
 
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.CommonState.html#method.is_handshaking>
+    /// <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.is_handshaking>
     #[no_mangle]
     pub extern "C" fn rustls_connection_is_handshaking(conn: *const rustls_connection) -> bool {
         ffi_panic_boundary! {
@@ -296,7 +296,7 @@ impl rustls_connection {
     /// to completing the TLS handshake) and unsent TLS records. By default, there
     /// is no limit. The limit can be set at any time, even if the current buffer
     /// use is higher.
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.set_buffer_limit>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.set_buffer_limit>
     #[no_mangle]
     pub extern "C" fn rustls_connection_set_buffer_limit(conn: *mut rustls_connection, n: usize) {
         ffi_panic_boundary! {
@@ -306,7 +306,7 @@ impl rustls_connection {
     }
 
     /// Queues a close_notify fatal alert to be sent in the next write_tls call.
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.send_close_notify>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.send_close_notify>
     #[no_mangle]
     pub extern "C" fn rustls_connection_send_close_notify(conn: *mut rustls_connection) {
         ffi_panic_boundary! {
@@ -323,7 +323,7 @@ impl rustls_connection {
     /// affecting the connection. A mutating function call is one where the
     /// first argument has type `struct rustls_connection *` (as opposed to
     ///  `const struct rustls_connection *`).
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.peer_certificates>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.peer_certificates>
     #[no_mangle]
     pub extern "C" fn rustls_connection_get_peer_certificate(
         conn: *const rustls_connection,
@@ -348,7 +348,7 @@ impl rustls_connection {
     /// first argument has type `struct rustls_connection *` (as opposed to
     ///  `const struct rustls_connection *`).
     /// <https://www.iana.org/assignments/tls-parameters/>
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.alpn_protocol>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.alpn_protocol>
     #[no_mangle]
     pub extern "C" fn rustls_connection_get_alpn_protocol(
         conn: *const rustls_connection,
@@ -376,8 +376,8 @@ impl rustls_connection {
     /// Return the TLS protocol version that has been negotiated. Before this
     /// has been decided during the handshake, this will return 0. Otherwise,
     /// the u16 version number as defined in the relevant RFC is returned.
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.protocol_version>
-    /// <https://docs.rs/rustls/0.20.0/rustls/internal/msgs/enums/enum.ProtocolVersion.html>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.protocol_version>
+    /// <https://docs.rs/rustls/latest/rustls/internal/msgs/enums/enum.ProtocolVersion.html>
     #[no_mangle]
     pub extern "C" fn rustls_connection_get_protocol_version(
         conn: *const rustls_connection,
@@ -394,7 +394,7 @@ impl rustls_connection {
     /// Retrieves the cipher suite agreed with the peer.
     /// This returns NULL until the ciphersuite is agreed.
     /// The returned pointer lives as long as the program.
-    /// <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.negotiated_cipher_suite>
+    /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.negotiated_cipher_suite>
     #[no_mangle]
     pub extern "C" fn rustls_connection_get_negotiated_ciphersuite(
         conn: *const rustls_connection,
@@ -423,7 +423,7 @@ impl rustls_connection {
     /// `rustls_connection_write_tls`.
     /// On success, store the number of bytes actually written in *out_n
     /// (this may be less than `count`).
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.Writer.html#method.write>
+    /// <https://docs.rs/rustls/latest/rustls/struct.Writer.html#method.write>
     #[no_mangle]
     pub extern "C" fn rustls_connection_write(
         conn: *mut rustls_connection,
@@ -459,7 +459,7 @@ impl rustls_connection {
     /// read from it, the memory in `buf` must be initialized before the call (for
     /// Rust-internal reasons). Initializing a buffer once and then using it
     /// multiple times without zeroizing before each call is fine.
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.Reader.html#method.read>
+    /// <https://docs.rs/rustls/latest/rustls/struct.Reader.html#method.read>
     #[no_mangle]
     pub extern "C" fn rustls_connection_read(
         conn: *mut rustls_connection,

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,7 +154,7 @@ pub enum rustls_result {
     AcceptorNotReady = 7012,
     AlreadyUsed = 7013,
 
-    // From https://docs.rs/rustls/0.21.0/rustls/enum.Error.html
+    // From https://docs.rs/rustls/latest/rustls/enum.Error.html
     NoCertificatesPresented = 7101,
     DecryptError = 7102,
     FailedToGetCurrentTime = 7103,
@@ -220,7 +220,7 @@ pub enum rustls_result {
     General = 7112,
 
     // From Error, with fields that get flattened.
-    // https://docs.rs/rustls/0.21.0/rustls/internal/msgs/enums/enum.AlertDescription.html
+    // https://docs.rs/rustls/latest/rustls/internal/msgs/enums/enum.AlertDescription.html
     AlertCloseNotify = 7200,
     AlertUnexpectedMessage = 7201,
     AlertBadRecordMac = 7202,
@@ -257,7 +257,7 @@ pub enum rustls_result {
     AlertNoApplicationProtocol = 7233,
     AlertUnknown = 7234,
 
-    // https://docs.rs/sct/0.7.0/sct/enum.Error.html
+    // https://docs.rs/sct/latest/sct/enum.Error.html
     CertSCTMalformed = 7319,
     CertSCTInvalidSignature = 7320,
     CertSCTTimestampInFuture = 7321,

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -161,7 +161,7 @@ typedef struct rustls_acceptor rustls_acceptor;
 /**
  * An X.509 certificate, as used in rustls.
  * Corresponds to `Certificate` in the Rust API.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.Certificate.html>
+ * <https://docs.rs/rustls/latest/rustls/struct.Certificate.html>
  */
 typedef struct rustls_certificate rustls_certificate;
 
@@ -169,7 +169,7 @@ typedef struct rustls_certificate rustls_certificate;
  * The complete chain of certificates to send during a TLS handshake,
  * plus a private key that matches the end-entity (leaf) certificate.
  * Corresponds to `CertifiedKey` in the Rust API.
- * <https://docs.rs/rustls/0.20.0/rustls/sign/struct.CertifiedKey.html>
+ * <https://docs.rs/rustls/latest/rustls/sign/struct.CertifiedKey.html>
  */
 typedef struct rustls_certified_key rustls_certified_key;
 
@@ -195,7 +195,7 @@ typedef struct rustls_client_cert_verifier_optional rustls_client_cert_verifier_
 /**
  * A client config that is done being constructed and is now read-only.
  * Under the hood, this object corresponds to an `Arc<ClientConfig>`.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.ClientConfig.html>
+ * <https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html>
  */
 typedef struct rustls_client_config rustls_client_config;
 
@@ -206,7 +206,7 @@ typedef struct rustls_client_config rustls_client_config;
  * to turn it into a *rustls_client_config. This object is not safe
  * for concurrent mutation. Under the hood, it corresponds to a
  * `Box<ClientConfig>`.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.ConfigBuilder.html>
+ * <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
  */
 typedef struct rustls_client_config_builder rustls_client_config_builder;
 
@@ -222,14 +222,14 @@ typedef struct rustls_iovec rustls_iovec;
 
 /**
  * A root certificate store.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html>
+ * <https://docs.rs/rustls/latest/rustls/struct.RootCertStore.html>
  */
 typedef struct rustls_root_cert_store rustls_root_cert_store;
 
 /**
  * A server config that is done being constructed and is now read-only.
  * Under the hood, this object corresponds to an `Arc<ServerConfig>`.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.ServerConfig.html>
+ * <https://docs.rs/rustls/latest/rustls/struct.ServerConfig.html>
  */
 typedef struct rustls_server_config rustls_server_config;
 
@@ -239,7 +239,7 @@ typedef struct rustls_server_config rustls_server_config;
  * done configuring settings, call rustls_server_config_builder_build
  * to turn it into a *const rustls_server_config. This object is not safe
  * for concurrent mutation.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.ConfigBuilder.html>
+ * <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
  */
 typedef struct rustls_server_config_builder rustls_server_config_builder;
 
@@ -437,7 +437,7 @@ typedef struct rustls_slice_u16 {
  * `rustls_string` will be 0. The signature_schemes field carries the values
  * supplied by the client or, if the client did not send this TLS extension,
  * the default schemes in the rustls library. See:
- * <https://docs.rs/rustls/0.20.0/rustls/internal/msgs/enums/enum.SignatureScheme.html>.
+ * <https://docs.rs/rustls/latest/rustls/internal/msgs/enums/enum.SignatureScheme.html>.
  * `alpn` carries the list of ALPN protocol names that the client proposed to
  * the server. Again, the length of this list will be 0 if none were supplied.
  *
@@ -901,7 +901,7 @@ void rustls_certified_key_free(const struct rustls_certified_key *key);
  * Create a rustls_root_cert_store. Caller owns the memory and must
  * eventually call rustls_root_cert_store_free. The store starts out empty.
  * Caller must add root certificates with rustls_root_cert_store_add_pem.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.RootCertStore.html#method.empty>
+ * <https://docs.rs/rustls/latest/rustls/struct.RootCertStore.html#method.empty>
  */
 struct rustls_root_cert_store *rustls_root_cert_store_new(void);
 
@@ -1026,7 +1026,7 @@ rustls_result rustls_client_config_builder_new_custom(const struct rustls_suppor
  * Feel free to use an appropriate error from the RUSTLS_RESULT_CERT_*
  * section.
  *
- * <https://docs.rs/rustls/0.20.0/rustls/client/struct.DangerousClientConfig.html#method.set_certificate_verifier>
+ * <https://docs.rs/rustls/latest/rustls/client/struct.DangerousClientConfig.html#method.set_certificate_verifier>
  */
 rustls_result rustls_client_config_builder_dangerous_set_certificate_verifier(struct rustls_client_config_builder *config_builder,
                                                                               rustls_verify_server_cert_callback callback);
@@ -1060,7 +1060,7 @@ rustls_result rustls_client_config_builder_load_roots_from_file(struct rustls_cl
  * This function makes a copy of the data in `protocols` and does not retain
  * any pointers, so the caller can free the pointed-to memory after calling.
  *
- * <https://docs.rs/rustls/0.20.0/rustls/client/struct.ClientConfig.html#structfield.alpn_protocols>
+ * <https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#structfield.alpn_protocols>
  */
 rustls_result rustls_client_config_builder_set_alpn_protocols(struct rustls_client_config_builder *builder,
                                                               const struct rustls_slice_bytes *protocols,
@@ -1068,7 +1068,7 @@ rustls_result rustls_client_config_builder_set_alpn_protocols(struct rustls_clie
 
 /**
  * Enable or disable SNI.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.ClientConfig.html#structfield.enable_sni>
+ * <https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html#structfield.enable_sni>
  */
 void rustls_client_config_builder_set_enable_sni(struct rustls_client_config_builder *config,
                                                  bool enable);
@@ -1156,7 +1156,7 @@ void rustls_connection_set_log_callback(struct rustls_connection *conn, rustls_l
  * `rustls_connection_set_userdata`.
  * Returns 0 for success, or an errno value on error. Passes through return values
  * from callback. See rustls_read_callback for more details.
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.read_tls>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.read_tls>
  */
 rustls_io_result rustls_connection_read_tls(struct rustls_connection *conn,
                                             rustls_read_callback callback,
@@ -1173,7 +1173,7 @@ rustls_io_result rustls_connection_read_tls(struct rustls_connection *conn,
  * `rustls_connection_set_userdata`.
  * Returns 0 for success, or an errno value on error. Passes through return values
  * from callback. See rustls_write_callback for more details.
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.write_tls>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.write_tls>
  */
 rustls_io_result rustls_connection_write_tls(struct rustls_connection *conn,
                                              rustls_write_callback callback,
@@ -1190,7 +1190,7 @@ rustls_io_result rustls_connection_write_tls(struct rustls_connection *conn,
  * `rustls_connection_set_userdata`.
  * Returns 0 for success, or an errno value on error. Passes through return values
  * from callback. See rustls_write_callback for more details.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.Writer.html#method.write_vectored>
+ * <https://docs.rs/rustls/latest/rustls/struct.Writer.html#method.write_vectored>
  */
 rustls_io_result rustls_connection_write_tls_vectored(struct rustls_connection *conn,
                                                       rustls_write_vectored_callback callback,
@@ -1201,22 +1201,22 @@ rustls_io_result rustls_connection_write_tls_vectored(struct rustls_connection *
  * Decrypt any available ciphertext from the internal buffer and put it
  * into the internal plaintext buffer, potentially making bytes available
  * for rustls_connection_read().
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.process_new_packets>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.process_new_packets>
  */
 rustls_result rustls_connection_process_new_packets(struct rustls_connection *conn);
 
 /**
- * <https://docs.rs/rustls/0.20.0/rustls/struct.CommonState.html#method.wants_read>
+ * <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.wants_read>
  */
 bool rustls_connection_wants_read(const struct rustls_connection *conn);
 
 /**
- * <https://docs.rs/rustls/0.20.0/rustls/struct.CommonState.html#method.wants_write>
+ * <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.wants_write>
  */
 bool rustls_connection_wants_write(const struct rustls_connection *conn);
 
 /**
- * <https://docs.rs/rustls/0.20.0/rustls/struct.CommonState.html#method.is_handshaking>
+ * <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.is_handshaking>
  */
 bool rustls_connection_is_handshaking(const struct rustls_connection *conn);
 
@@ -1225,13 +1225,13 @@ bool rustls_connection_is_handshaking(const struct rustls_connection *conn);
  * to completing the TLS handshake) and unsent TLS records. By default, there
  * is no limit. The limit can be set at any time, even if the current buffer
  * use is higher.
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.set_buffer_limit>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.set_buffer_limit>
  */
 void rustls_connection_set_buffer_limit(struct rustls_connection *conn, size_t n);
 
 /**
  * Queues a close_notify fatal alert to be sent in the next write_tls call.
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.send_close_notify>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.send_close_notify>
  */
 void rustls_connection_send_close_notify(struct rustls_connection *conn);
 
@@ -1244,7 +1244,7 @@ void rustls_connection_send_close_notify(struct rustls_connection *conn);
  * affecting the connection. A mutating function call is one where the
  * first argument has type `struct rustls_connection *` (as opposed to
  *  `const struct rustls_connection *`).
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.peer_certificates>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.peer_certificates>
  */
 const struct rustls_certificate *rustls_connection_get_peer_certificate(const struct rustls_connection *conn,
                                                                         size_t i);
@@ -1260,7 +1260,7 @@ const struct rustls_certificate *rustls_connection_get_peer_certificate(const st
  * first argument has type `struct rustls_connection *` (as opposed to
  *  `const struct rustls_connection *`).
  * <https://www.iana.org/assignments/tls-parameters/>
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.alpn_protocol>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.alpn_protocol>
  */
 void rustls_connection_get_alpn_protocol(const struct rustls_connection *conn,
                                          const uint8_t **protocol_out,
@@ -1270,8 +1270,8 @@ void rustls_connection_get_alpn_protocol(const struct rustls_connection *conn,
  * Return the TLS protocol version that has been negotiated. Before this
  * has been decided during the handshake, this will return 0. Otherwise,
  * the u16 version number as defined in the relevant RFC is returned.
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.protocol_version>
- * <https://docs.rs/rustls/0.20.0/rustls/internal/msgs/enums/enum.ProtocolVersion.html>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.protocol_version>
+ * <https://docs.rs/rustls/latest/rustls/internal/msgs/enums/enum.ProtocolVersion.html>
  */
 uint16_t rustls_connection_get_protocol_version(const struct rustls_connection *conn);
 
@@ -1279,7 +1279,7 @@ uint16_t rustls_connection_get_protocol_version(const struct rustls_connection *
  * Retrieves the cipher suite agreed with the peer.
  * This returns NULL until the ciphersuite is agreed.
  * The returned pointer lives as long as the program.
- * <https://docs.rs/rustls/0.20.0/rustls/enum.Connection.html#method.negotiated_cipher_suite>
+ * <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.negotiated_cipher_suite>
  */
 const struct rustls_supported_ciphersuite *rustls_connection_get_negotiated_ciphersuite(const struct rustls_connection *conn);
 
@@ -1289,7 +1289,7 @@ const struct rustls_supported_ciphersuite *rustls_connection_get_negotiated_ciph
  * `rustls_connection_write_tls`.
  * On success, store the number of bytes actually written in *out_n
  * (this may be less than `count`).
- * <https://docs.rs/rustls/0.20.0/rustls/struct.Writer.html#method.write>
+ * <https://docs.rs/rustls/latest/rustls/struct.Writer.html#method.write>
  */
 rustls_result rustls_connection_write(struct rustls_connection *conn,
                                       const uint8_t *buf,
@@ -1308,7 +1308,7 @@ rustls_result rustls_connection_write(struct rustls_connection *conn,
  * read from it, the memory in `buf` must be initialized before the call (for
  * Rust-internal reasons). Initializing a buffer once and then using it
  * multiple times without zeroizing before each call is fine.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.Reader.html#method.read>
+ * <https://docs.rs/rustls/latest/rustls/struct.Reader.html#method.read>
  */
 rustls_result rustls_connection_read(struct rustls_connection *conn,
                                      uint8_t *buf,
@@ -1446,7 +1446,7 @@ void rustls_server_config_builder_free(struct rustls_server_config_builder *conf
  * With `ignore` != 0, the server will ignore the client ordering of cipher
  * suites, aka preference, during handshake and respect its own ordering
  * as configured.
- * <https://docs.rs/rustls/0.20.0/rustls/struct.ServerConfig.html#structfield.ignore_client_order>
+ * <https://docs.rs/rustls/latest/rustls/struct.ServerConfig.html#structfield.ignore_client_order>
  */
 rustls_result rustls_server_config_builder_set_ignore_client_order(struct rustls_server_config_builder *builder,
                                                                    bool ignore);
@@ -1461,7 +1461,7 @@ rustls_result rustls_server_config_builder_set_ignore_client_order(struct rustls
  * This function makes a copy of the data in `protocols` and does not retain
  * any pointers, so the caller can free the pointed-to memory after calling.
  *
- * <https://docs.rs/rustls/0.20.0/rustls/server/struct.ServerConfig.html#structfield.alpn_protocols>
+ * <https://docs.rs/rustls/latest/rustls/server/struct.ServerConfig.html#structfield.alpn_protocols>
  */
 rustls_result rustls_server_config_builder_set_alpn_protocols(struct rustls_server_config_builder *builder,
                                                               const struct rustls_slice_bytes *protocols,
@@ -1519,7 +1519,7 @@ rustls_result rustls_server_connection_new(const struct rustls_server_config *co
  * Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
  * Returns Ok with *out_n == 0 if there is no SNI hostname available on this connection
  * because it hasn't been processed yet, or because the client did not send SNI.
- * <https://docs.rs/rustls/0.21.0/rustls/server/struct.ServerConnection.html#method.server_name>
+ * <https://docs.rs/rustls/latest/rustls/server/struct.ServerConnection.html#method.server_name>
  */
 rustls_result rustls_server_connection_get_server_name(const struct rustls_connection *conn,
                                                        uint8_t *buf,

--- a/src/server.rs
+++ b/src/server.rs
@@ -37,7 +37,7 @@ use crate::{
 /// done configuring settings, call rustls_server_config_builder_build
 /// to turn it into a *const rustls_server_config. This object is not safe
 /// for concurrent mutation.
-/// <https://docs.rs/rustls/0.20.0/rustls/struct.ConfigBuilder.html>
+/// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
 pub struct rustls_server_config_builder {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -62,7 +62,7 @@ impl BoxCastPtr for rustls_server_config_builder {}
 
 /// A server config that is done being constructed and is now read-only.
 /// Under the hood, this object corresponds to an `Arc<ServerConfig>`.
-/// <https://docs.rs/rustls/0.20.0/rustls/struct.ServerConfig.html>
+/// <https://docs.rs/rustls/latest/rustls/struct.ServerConfig.html>
 pub struct rustls_server_config {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -207,7 +207,7 @@ impl rustls_server_config_builder {
     /// With `ignore` != 0, the server will ignore the client ordering of cipher
     /// suites, aka preference, during handshake and respect its own ordering
     /// as configured.
-    /// <https://docs.rs/rustls/0.20.0/rustls/struct.ServerConfig.html#structfield.ignore_client_order>
+    /// <https://docs.rs/rustls/latest/rustls/struct.ServerConfig.html#structfield.ignore_client_order>
     #[no_mangle]
     pub extern "C" fn rustls_server_config_builder_set_ignore_client_order(
         builder: *mut rustls_server_config_builder,
@@ -229,7 +229,7 @@ impl rustls_server_config_builder {
     /// This function makes a copy of the data in `protocols` and does not retain
     /// any pointers, so the caller can free the pointed-to memory after calling.
     ///
-    /// <https://docs.rs/rustls/0.20.0/rustls/server/struct.ServerConfig.html#structfield.alpn_protocols>
+    /// <https://docs.rs/rustls/latest/rustls/server/struct.ServerConfig.html#structfield.alpn_protocols>
     #[no_mangle]
     pub extern "C" fn rustls_server_config_builder_set_alpn_protocols(
         builder: *mut rustls_server_config_builder,
@@ -355,7 +355,7 @@ impl rustls_server_config {
 /// Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
 /// Returns Ok with *out_n == 0 if there is no SNI hostname available on this connection
 /// because it hasn't been processed yet, or because the client did not send SNI.
-/// <https://docs.rs/rustls/0.21.0/rustls/server/struct.ServerConnection.html#method.server_name>
+/// <https://docs.rs/rustls/latest/rustls/server/struct.ServerConnection.html#method.server_name>
 #[no_mangle]
 pub extern "C" fn rustls_server_connection_get_server_name(
     conn: *const rustls_connection,
@@ -435,7 +435,7 @@ impl ResolvesServerCert for ResolvesServerCertFromChoices {
 /// `rustls_string` will be 0. The signature_schemes field carries the values
 /// supplied by the client or, if the client did not send this TLS extension,
 /// the default schemes in the rustls library. See:
-/// <https://docs.rs/rustls/0.20.0/rustls/internal/msgs/enums/enum.SignatureScheme.html>.
+/// <https://docs.rs/rustls/latest/rustls/internal/msgs/enums/enum.SignatureScheme.html>.
 /// `alpn` carries the list of ALPN protocol names that the client proposed to
 /// the server. Again, the length of this list will be 0 if none were supplied.
 ///


### PR DESCRIPTION
Previously the Rustls docs linked to docs.rs with URLs containing specific versions of the target crate (e.g.
`docs.rs/rustls/0.20.0/...`). In this commit all such links are replaced with to use `/latest` instead of a fixed version.

This provides a simple way to keep things up to date and the risk of future breakage is fairly small since this crate is kept in close synchronicity with the crates it links to.

Resolves #304. 