### PR TITLE
tests: fixup static lib assertion

### DIFF
--- a/tests/verify-static-libraries.py
+++ b/tests/verify-static-libraries.py
@@ -20,7 +20,7 @@ def main():
     elif sys.platform.startswith("win32"):
         want = (
             "advapi32.lib credui.lib kernel32.lib secur32.lib "
-            "legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib "
+            "kernel32.lib advapi32.lib userenv.lib "
             "kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib "
             "legacy_stdio_definitions.lib"
         )

--- a/tests/verify-static-libraries.py
+++ b/tests/verify-static-libraries.py
@@ -42,7 +42,7 @@ def main():
     if want != got:
         print(
             "got unexpected list of native static libraries, "
-            "fix or update README: {} instead of {}"
+            "fix or update README. Got:\n {}\nInstead of:\n {}"
             .format(got, want)
         )
         sys.exit(1)


### PR DESCRIPTION
## Description

Fixing the remaining rustls-0.21.0 CI failure [identified in a smoketest branch](https://github.com/rustls/rustls-ffi/issues/294#issuecomment-1481512616).

With these fixes attached to the smoketest branch in addition to the in-flight PRs we get a :green_circle: build :tada:: https://github.com/cpu/rustls-ffi/actions/runs/4503112550

### tests: clarify verify-static-lib output - 6137272f308f4812345df0486f0624200708df0e
When the `verify-static-libraries.py` assertion fails the output with the actual vs expected results was all on one line, making it harder to visually diff.

This commit splits the output up across a few lines to make it easier to spot the difference.

### tests: adjust expected native static libs.

It looks like the early duplicate `legacy_stdio_definitions.lib` has fallen away. This commit removes it from the expected string, leaving only one instance and fixing the test.