### PR TITLE
CI: upgrade runner OS, 18.04 -> 20.04.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
           - beta
           - nightly
           - 1.57.0 # MSRV - keep in sync with what rustls considers MSRV
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:
           - os: macos-latest
@@ -107,7 +107,7 @@ jobs:
 
   docs:
     name: Check for documentation errors
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
 
   minver:
     name: Check minimum versions
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
While reviewing https://github.com/rustls/rustls-ffi/pull/316 I noticed that CI was still not passing across the board. The root cause is that the Ubuntu 18.04 runner image that was being used for some of the GitHub actions workflows is no longer supported, resulting in those workflows getting stuck in a "waiting for runner" state (See https://github.com/actions/runner-images/issues/6002).

This commit updates the runner OS from 18.04 to 20.04.