### PR TITLE
Misc CI fixes.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,12 @@ name: rustls-ffi
 permissions:
   contents: read
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '15 12 * * 3'
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,6 +77,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Install nightly rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          default: true
       - name: Configure CMake
         run: cmake -S . -B build
       - name: Build, debug configuration
@@ -93,6 +99,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Install nightly rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          default: true
       - name: Configure CMake
         run: cmake -S . -B build
       - name: Build, release configuration
@@ -106,6 +118,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Install nightly rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          default: true
       - run: touch src/lib.rs
       - run: cbindgen --version
       - run: make src/rustls.h

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,6 +102,7 @@ jobs:
         with:
           persist-credentials: false
       - run: touch src/lib.rs
+      - run: cbindgen --version
       - run: make src/rustls.h
       - run: git diff --exit-code
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.57.0 # MSRV - keep in sync with what rustls considers MSRV
+          - 1.60.0 # MSRV - keep in sync with what rustls considers MSRV
         os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rustls/rustls-ffi"
 categories = ["network-programming", "cryptography"]
 edition = "2021"
 links = "rustls_ffi"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [features]
 # Enable this feature when building as Rust dependency. It inhibits the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ libc = "0.2"
 sct = "0.7"
 rustls-pemfile = "0.2.1"
 log = "0.4.17"
-num_enum = "0.5.10"
 
 [lib]
 name = "rustls_ffi"

--- a/Makefile.Windows
+++ b/Makefile.Windows
@@ -50,7 +50,7 @@ $(RUSTLS_LIB): src/lib.rs Cargo.toml
 	@echo
 
 target/%.exe: common.obj %.obj $(RUSTLS_LIB)
-	$(call link_EXE, $@, $^ advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib)
+	$(call link_EXE, $@, $^ advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib ntdll.lib)
 
 clean:
 	rm -f *.obj target/.rustc_info.json $(RUSTLS_LIB) vc1*.pdb

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -11,3 +11,7 @@ include = ["rustls_tls_version"]
 
 [defines]
 "feature = read_buf" = "DEFINE_READ_BUF"
+
+[parse.expand]
+crates = ["rustls-ffi"]
+features = ["read_buf"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::ffi::{CStr, OsStr};
 use std::fs::File;
 use std::io::BufReader;
@@ -263,9 +263,7 @@ impl rustls::client::ServerCertVerifier for Verifier {
             rustls::Error::General("internal error with thread-local storage".to_string())
         })?;
         let result: u32 = unsafe { cb(userdata, &params) };
-        let result: rustls_result =
-            rustls_result::try_from(result).unwrap_or(rustls_result::General);
-        match result {
+        match rustls_result::from(result) {
             rustls_result::Ok => Ok(ServerCertVerified::assertion()),
             r => Err(error::cert_result_to_error(r)),
         }

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -324,7 +324,10 @@ typedef int rustls_io_result;
  * cases that should be a struct that contains, at a minimum, a file descriptor.
  * The buf and out_n pointers are borrowed and should not be retained across calls.
  */
-typedef rustls_io_result (*rustls_read_callback)(void *userdata, uint8_t *buf, size_t n, size_t *out_n);
+typedef rustls_io_result (*rustls_read_callback)(void *userdata,
+                                                 uint8_t *buf,
+                                                 size_t n,
+                                                 size_t *out_n);
 
 /**
  * A read-only view on a Rust byte slice.
@@ -364,7 +367,8 @@ typedef struct rustls_verify_server_cert_params {
   struct rustls_slice_bytes ocsp_response;
 } rustls_verify_server_cert_params;
 
-typedef uint32_t (*rustls_verify_server_cert_callback)(rustls_verify_server_cert_user_data userdata, const struct rustls_verify_server_cert_params *params);
+typedef uint32_t (*rustls_verify_server_cert_callback)(rustls_verify_server_cert_user_data userdata,
+                                                       const struct rustls_verify_server_cert_params *params);
 
 typedef size_t rustls_log_level;
 
@@ -389,7 +393,10 @@ typedef void (*rustls_log_callback)(void *userdata, const struct rustls_log_para
  * cases that should be a struct that contains, at a minimum, a file descriptor.
  * The buf and out_n pointers are borrowed and should not be retained across calls.
  */
-typedef rustls_io_result (*rustls_write_callback)(void *userdata, const uint8_t *buf, size_t n, size_t *out_n);
+typedef rustls_io_result (*rustls_write_callback)(void *userdata,
+                                                  const uint8_t *buf,
+                                                  size_t n,
+                                                  size_t *out_n);
 
 /**
  * A callback for rustls_connection_write_tls_vectored.
@@ -405,7 +412,10 @@ typedef rustls_io_result (*rustls_write_callback)(void *userdata, const uint8_t 
  * cases that should be a struct that contains, at a minimum, a file descriptor.
  * The buf and out_n pointers are borrowed and should not be retained across calls.
  */
-typedef rustls_io_result (*rustls_write_vectored_callback)(void *userdata, const struct rustls_iovec *iov, size_t count, size_t *out_n);
+typedef rustls_io_result (*rustls_write_vectored_callback)(void *userdata,
+                                                           const struct rustls_iovec *iov,
+                                                           size_t count,
+                                                           size_t *out_n);
 
 /**
  * Any context information the callback will receive when invoked.
@@ -472,7 +482,8 @@ typedef struct rustls_client_hello {
  * EXPERIMENTAL: this feature of rustls-ffi is likely to change in the future, as
  * the rustls library is re-evaluating their current approach to client hello handling.
  */
-typedef const struct rustls_certified_key *(*rustls_client_hello_callback)(rustls_client_hello_userdata userdata, const struct rustls_client_hello *hello);
+typedef const struct rustls_certified_key *(*rustls_client_hello_callback)(rustls_client_hello_userdata userdata,
+                                                                           const struct rustls_client_hello *hello);
 
 /**
  * Any context information the callback will receive when invoked.
@@ -506,7 +517,12 @@ typedef void *rustls_session_store_userdata;
  * NOTE: callbacks used in several sessions via a common config
  * must be implemented thread-safe.
  */
-typedef uint32_t (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, int remove_after, uint8_t *buf, size_t count, size_t *out_n);
+typedef uint32_t (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata,
+                                                      const struct rustls_slice_bytes *key,
+                                                      int remove_after,
+                                                      uint8_t *buf,
+                                                      size_t count,
+                                                      size_t *out_n);
 
 /**
  * Prototype of a callback that can be installed by the application at the
@@ -523,7 +539,9 @@ typedef uint32_t (*rustls_session_store_get_callback)(rustls_session_store_userd
  * NOTE: callbacks used in several sessions via a common config
  * must be implemented thread-safe.
  */
-typedef uint32_t (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
+typedef uint32_t (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata,
+                                                      const struct rustls_slice_bytes *key,
+                                                      const struct rustls_slice_bytes *val);
 
 extern const struct rustls_supported_ciphersuite *RUSTLS_ALL_CIPHER_SUITES[9];
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use crate::error::rustls_result;
 use crate::rslice::rustls_slice_bytes;
 use crate::userdata_get;
@@ -108,9 +106,7 @@ impl SessionStoreBroker {
                 data.len(),
                 &mut out_n,
             );
-            let result: rustls_result =
-                rustls_result::try_from(result).unwrap_or(rustls_result::General);
-            match result {
+            match rustls_result::from(result) {
                 rustls_result::Ok => {
                     data.set_len(out_n);
                     Some(data)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ IF(WIN32)
         client
         debug "${CMAKE_SOURCE_DIR}/target/debug/rustls_ffi.lib"
         optimized "${CMAKE_SOURCE_DIR}/target/release/rustls_ffi.lib"
-        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib
+        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib ntdll.lib
     )
     set_property(TARGET client PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 ENDIF(WIN32)
@@ -34,7 +34,7 @@ IF(WIN32)
         server
         debug "${CMAKE_SOURCE_DIR}/target/debug/rustls_ffi.lib"
         optimized "${CMAKE_SOURCE_DIR}/target/release/rustls_ffi.lib"
-        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib
+        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib ntdll.lib
     )
     set_property(TARGET server PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 ENDIF(WIN32)

--- a/tests/verify-static-libraries.py
+++ b/tests/verify-static-libraries.py
@@ -22,7 +22,7 @@ def main():
             "advapi32.lib credui.lib kernel32.lib secur32.lib "
             "legacy_stdio_definitions.lib "
             "kernel32.lib advapi32.lib userenv.lib "
-            "kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib "
+            "kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib ntdll.lib msvcrt.lib "
             "legacy_stdio_definitions.lib"
         )
     else:

--- a/tests/verify-static-libraries.py
+++ b/tests/verify-static-libraries.py
@@ -9,6 +9,14 @@ STATIC_LIBS_RE = re.compile(
 )
 
 
+def uniquify_consecutive(items):
+    r = []
+    for i in items.split():
+        if not (r and r[-1] == i):
+            r.append(i)
+    return r
+
+
 def main():
     # If you need to change the values here, be sure to update the values in
     # the README. Alternatively, it is possible that adding new libraries to
@@ -20,10 +28,9 @@ def main():
     elif sys.platform.startswith("win32"):
         want = (
             "advapi32.lib credui.lib kernel32.lib secur32.lib "
-            "legacy_stdio_definitions.lib "
-            "kernel32.lib advapi32.lib userenv.lib "
-            "kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib ntdll.lib msvcrt.lib "
-            "legacy_stdio_definitions.lib"
+            "legacy_stdio_definitions.lib kernel32.lib advapi32.lib "
+            "bcrypt.lib kernel32.lib ntdll.lib userenv.lib ws2_32.lib "
+            "kernel32.lib ws2_32.lib kernel32.lib msvcrt.lib"
         )
     else:
         want = ""
@@ -39,7 +46,8 @@ def main():
         print("could not find list of native static libraries, check for "
               "compilation errors")
         sys.exit(1)
-    got = match.group(1).decode("ascii")
+    got = uniquify_consecutive(match.group(1).decode("ascii"))
+    want = uniquify_consecutive(want)
     if want != got:
         print(
             "got unexpected list of native static libraries, "


### PR DESCRIPTION
Unfortunately the `main` branch's CI has bitrot. This branch pulls together a handful of fixes.

### ci: print bindgen version used for rustls.h diff
The existing CI has a step where it regenerates `rustls.h` using `make src/rustls.h`, which in turn invokes `cbindgen`.

I'm seeing a diff created in CI that I don't see locally and suspect the reason is a difference in `cbindgen` versions. To help debug this now and into the future, this commit updates CI to print its `cbindgen` version before performing the diff check.

### src/rustls.h: regen with cbindgen 0.24.5
CI is using the latest available cbindgen (0.24.5), which produces a different formatted output than previous versions.

This commit regenerates the `src/rustls.h` header file using 0.24.5 to match what CI expects, avoiding a CI failure from the detected diff.

### makefiles: fix Windows unresolved symbol link errs.
Previously, building the tip of `main` in CI for Windows, Windows CMake (Debug), and Windows CMake (Release) was failing with link-time errors of the form:

```
rustls_ffi.lib(std-391022a4250a8b9a.std.feb3b897-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __imp_NtWriteFile referenced in function _ZN3std3sys7windows6handle6Handle17synchronous_write17h5e143db420a86fa8E
[D:\a\rustls-ffi\rustls-ffi\build\tests\server.vcxproj]
```

The fix is to explicitly include `ntdll.lib` in the native static libs that we link on Windows. Doing this fixes the builds once we also update the `verify-static-libraries.py` script to expect this additional lib.

This may be related to [an upstream `rust-lang/rust` change](https://github.com/rust-lang/rust/pull/108262) but I'm not 100% sure.

### cargo: track rustls MSRV, 1.57 -> 1.60

Rustls has updated its MSRV from 1.57 to 1.60. This commit tracks that change in this repo.

### ci: cron schedule for workflows, merge_group support.
This commit does two things:

* In preparation for one day enabling merge queue on this repo, it adds `merge_group` as a trigger for the CI tasks.
* It adds a `schedule` trigger that will run the CI tasks weekly, to detect bitrot sooner than we might otherwise.

### error: replace num_enum with minimal macro rule.
The `num_enum` dependency brings with it a large number of transitive dependencies. Some of those transitive deps now have an aggressive MSRV of 1.64+.

The existing usage of `num_enum` is very minimal: just one derived trait for the `rustls_result` enum to provide it with a `From` impl for u32 primitive values.

This commit replaces the `num_enum` crate with a small `u32_enum_builder!` macro rule loosely based on the Rustls `enum_builder` macro. Since our use case is narrower, I've simplified the macro and tailored it to the rustls-ffi use-case.

With the new implementation we can also drop the use of `try_from`. In each case where we're converting from code -> result we're happy for the default `from` impl's `InvalidParameter` variant to be used when given an unknown code, making the use of `try_from` unnecessary.

This approach adds one complication related to `cbindgen`: it now has to be instructed to expand the `rustls-ffi` crate before generating bindings in order to find the `rustls_result` enum. Doing this requires tweaking the `cbindgen.toml` to add a `parse.expand` configuration setting. Notably this also means `cbindgen` now has to be run with a nightly `rustc`. Since this is a developer only workflow it shouldn't be too onerous a requirement.

We're now happily building with Rust 1.60 again and can also breathe easy knowing we have a slimmer dependency profile!

### tests: ignore consecutive duplicates in lib check.
In some instances (e.g. building the CMake configuration in debug mode with the nightly rustc) the `--print native-static-libs` output of `cargo build` can include many repeating instances of a lib.

While the order and duplicates are generally expected to be meaningful, many consecutive duplicates are not.

This commit updates the `verify-static-libraries.py` script to collapse consecutive duplicates before doing the check of expected vs actual.