### PR TITLE
ci: resolve deprecation warnings, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,10 +36,9 @@ jobs:
           persist-credentials: false
 
       - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - env:
           CARGO_UNSTABLE_HTTP_REGISTRY: true
         run: make CC=${{ matrix.cc }} PROFILE=release test
@@ -78,11 +77,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install nightly rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          default: true
+        uses: dtolnay/rust-toolchain@nightly
       - name: Configure CMake
         run: cmake -S . -B build
       - name: Build, debug configuration
@@ -100,11 +95,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install nightly rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          default: true
+        uses: dtolnay/rust-toolchain@nightly
       - name: Configure CMake
         run: cmake -S . -B build
       - name: Build, release configuration
@@ -119,11 +110,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install nightly rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          default: true
+        uses: dtolnay/rust-toolchain@nightly
       - run: touch src/lib.rs
       - run: cbindgen --version
       - run: make src/rustls.h
@@ -139,11 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          default: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo doc (all features)
         run: cargo doc --all-features --no-deps --workspace
@@ -160,11 +143,7 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          default: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo test (debug; all features; -Z minimal-versions)
         run: cargo -Z minimal-versions test --all-features
@@ -178,17 +157,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.67.1
-          override: true
-          default: true
           components: rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -199,17 +173,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.67.1
-          override: true
-          default: true
           components: clippy
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings
+      - name: Check clippy
+        run: cargo clippy --workspace -- -D warnings
 
   clippy-nightly-optional:
     name: Clippy nightly (optional)
@@ -220,17 +189,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          override: true
-          default: true
           components: clippy
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings
+      - name: Check clippy
+        run: cargo clippy --workspace -- -D warnings
 
   clang-tidy:
     name: Clang Tidy
@@ -253,11 +216,7 @@ jobs:
           persist-credentials: false
 
       - name: Install nightly Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
       - run: rustup override set "nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)"
       - run: rustup component add miri
       - run: cargo miri test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
             rust: stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -48,7 +48,7 @@ jobs:
     name: Valgrind
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install valgrind
@@ -60,7 +60,7 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Setup PATH for CL.EXE
@@ -74,7 +74,7 @@ jobs:
     name: Windows CMake, Debug configuration
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install nightly rust toolchain
@@ -96,7 +96,7 @@ jobs:
     name: Windows CMake, Release configuration
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install nightly rust toolchain
@@ -115,7 +115,7 @@ jobs:
   ensure-header-updated:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install nightly rust toolchain
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install rust toolchain
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install rust toolchain
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install rust toolchain
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Clang tidy
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 

--- a/tests/verify-static-libraries.py
+++ b/tests/verify-static-libraries.py
@@ -36,7 +36,7 @@ def main():
         want = ""
 
     build = subprocess.run(
-        ["cargo", "build"],
+        ["cargo", "build", "--color", "never"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         env=dict(os.environ, RUSTFLAGS="--print native-static-libs")


### PR DESCRIPTION
## Description

This branch brings over some CI changes that were applied to other Rustls repos previously (e.g. https://github.com/rustls/rustls/pull/1214, https://github.com/rustls/webpki/pull/33).

Most importantly it fixes warnings of the form:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

and

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### ci: actions/checkout v2 -> v3.

Simple version bump.

### ci: actions-rs/toolchain -> dtolnay/rust-toolchain.
The `actions-rs/toolchain` workflow action is abandoned and its use generates deprecation warnings from GitHub actions.

In the other Rustls ecosystems projects we've switched to the maintained `dtolnay/rust-toolchain` action as an alternative.

This commit makes that change for the rustls-ffi actions. One additional change is required to `tests/verify-static-libraries.py` to tell `cargo` to always skip using color when we're building with the intent to regex match output.

### github: add dependabot config.
This commit brings the same `dependabot.yml` config we use for the main rustls repo over to rustls-ffi.

* Cargo ecosystem updates are applied daily with an open PR limit of 10.
* GitHub actions ecosystem updates are applied weekly.