### PR TITLE
clippy: fix on nightly toolchain

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,10 +177,14 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.67.1
+          toolchain: 1.70.0
           components: clippy
       - name: Check clippy
-        run: cargo clippy --workspace -- -D warnings
+        # We allow unknown lints here because sometimes the nightly job
+        # (below) will have a new lint that we want to suppress.
+        # If we suppress (e.g. #![allow(clippy::arc_with_non_send_sync)]),
+        # we would get an unknown-lint error from older clippy versions.
+        run: cargo clippy --workspace -- -D warnings -A unknown-lints
 
   clippy-nightly-optional:
     name: Clippy nightly (optional)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![crate_type = "staticlib"]
 #![allow(non_camel_case_types)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
+// TODO(#333): Fix this clippy warning.
+#![allow(clippy::arc_with_non_send_sync)]
 #![cfg_attr(feature = "read_buf", feature(read_buf))]
 
 //! This package contains bindings for using rustls via a C API. If


### PR DESCRIPTION
Right now on the nightly toolchain, clippy gives an error. This doesn't block merges because we mark the nightly clippy check as optional, and only require the clippy check for a specified toolchain version.

I've filed #333 to address the error. In this PR I disable that particular clippy lint and bump the required toolchain version to 1.73.0.