### PR TITLE
ci: explicitly pin cbindgen version for diff check.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,6 +111,12 @@ jobs:
           persist-credentials: false
       - name: Install nightly rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+      - name: Install cbindgen
+        # Pin the installed version of cbindgen so that local usage can be
+        # reliably matched to CI. There can be non-semantic differences in
+        # output between point releases of cbindgen that will fail this check
+        # otherwise.
+        run: cargo install cbindgen --force --version 0.24.5
       - run: touch src/lib.rs
       - run: cbindgen --version
       - run: make src/rustls.h


### PR DESCRIPTION
This branch installs an explicitly pinned version of `cbindgen` before performing the diff check of the `ensure-header-updated` workflow step.

Previously we used the version of `cbindgen` that was installed on the base GitHub runner image, which can be hard to match to the version used in local development and may change out from under us.

Since there can be non-semantic differences in output between point releases of `cbindgen` that will fail the diff check it's important developers can predict the exact version that will used in CI in order to match it when generating an updated `.h` locally.
