### PR TITLE
tests: improve readability of output

### DIFF
--- a/tests/client-server.py
+++ b/tests/client-server.py
@@ -30,7 +30,7 @@ def wait_tcp_port(host, port):
                 print("client-server.py: still trying to connect to host{}:{port}")
             time.sleep(0.1)
     else:
-        print("unable to connect")
+        print("client-server.py: unable to connect")
         sys.exit(1)
     print("client-server.py: detected server is up on {host}:{port}")
 

--- a/tests/client.c
+++ b/tests/client.c
@@ -48,14 +48,14 @@ make_conn(const char *hostname, const char *port)
                   getaddrinfo_output->ai_socktype,
                   getaddrinfo_output->ai_protocol);
   if(sockfd < 0) {
-    perror("making socket");
+    perror("client: making socket");
     goto cleanup;
   }
 
   int connect_result = connect(
     sockfd, getaddrinfo_output->ai_addr, getaddrinfo_output->ai_addrlen);
   if(connect_result < 0) {
-    perror("connecting");
+    perror("client: connecting");
     goto cleanup;
   }
   enum demo_result result = nonblock(sockfd);
@@ -205,7 +205,7 @@ send_request_and_read_response(struct conndata *conn,
 
     int select_result = select(sockfd + 1, &read_fds, &write_fds, NULL, NULL);
     if(select_result == -1) {
-      perror("select");
+      perror("client: select");
       goto cleanup;
     }
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -43,13 +43,21 @@ struct conndata
 {
   int fd;
   const char *verify_arg;
-  const char *program_name;
   struct bytevec data;
   struct rustls_connection *rconn;
 };
 
-void print_error(const char *program_name, const char *prefix,
-                 rustls_result result);
+extern const char *programname;
+
+/* Log a formatted message prefixed with `<programname>[<pid>]: "` */
+#define LOG(f_, ...)                                                          \
+  fprintf(                                                                    \
+    stderr, "%s[%ld]: " f_ "\n", programname, (long)getpid(), __VA_ARGS__)
+/* Since the `...` / __VA_ARGS__ technique requires at least one arg,
+ * we have a special case for when there are no formatting parameters. */
+#define LOG_SIMPLE(s) LOG("%s", s)
+
+void print_error(const char *prefix, rustls_result result);
 
 int write_all(int fd, const char *buf, int n);
 
@@ -119,11 +127,10 @@ const char *get_first_header_value(const char *headers, size_t headers_len,
 
 void log_cb(void *userdata, const struct rustls_log_params *params);
 
-enum demo_result read_file(const char *progname, const char *filename,
-                           char *buf, size_t buflen, size_t *n);
+enum demo_result read_file(const char *filename, char *buf, size_t buflen,
+                           size_t *n);
 
-const struct rustls_certified_key *load_cert_and_key(const char *progname,
-                                                     const char *certfile,
+const struct rustls_certified_key *load_cert_and_key(const char *certfile,
                                                      const char *keyfile);
 
 #endif /* COMMON_H */

--- a/tests/server.c
+++ b/tests/server.c
@@ -151,7 +151,7 @@ handle_conn(struct conndata *conn)
 
     int result = select(sockfd + 1, &read_fds, &write_fds, NULL, &tv);
     if(result == -1) {
-      perror("select");
+      perror("server: select");
       goto cleanup;
     }
     if(result == 0) {
@@ -254,7 +254,7 @@ main(int argc, const char **argv)
   struct sigaction siga = { 0 };
   siga.sa_handler = handle_signal;
   if(sigaction(SIGTERM, &siga, NULL) == -1) {
-    perror("setting a signal handler");
+    perror("server: setting a signal handler");
     return 1;
   }
 #endif /* _WIN32 */
@@ -343,12 +343,12 @@ main(int argc, const char **argv)
 
   if(bind(sockfd, (struct sockaddr *)&my_addr, sizeof(struct sockaddr_in)) ==
      -1) {
-    perror("bind");
+    perror("server: bind");
     goto cleanup;
   }
 
   if(listen(sockfd, 50) == -1) {
-    perror("listen");
+    perror("server: listen");
     goto cleanup;
   }
   LOG("listening on localhost:8443. AUTH_CERT=%s, AUTH_CRL=%s, VECTORED_IO=%s",
@@ -365,7 +365,7 @@ main(int argc, const char **argv)
       break;
     }
     if(clientfd < 0) {
-      perror("accept");
+      perror("server: accept");
       goto cleanup;
     }
 


### PR DESCRIPTION
Following up on #336 I realized our test output is pretty hard to read.

In this PR I changed client-server.py so it suppresses `client` output. If the `client` command fails, it then prints the suppressed output along with the command line and environment. I'd like to also suppress the `server` output in the same way but that will require a bigger refactoring, since the `server` is currently started once and shared by multiple client runs. Most likely we'll wind up wanting to start one server and one client in each test case.

I also added LOG and LOG_SIMPLE macros to client.c and server.c. This simplifies a lot of fprintf calls, and also allows us to print the pid with each log line, which will help tell apart separate server invocations in the logs.

The test `server` now prints its relevant environment variables at startup.