### PR TITLE
Prepare 0.11.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.11.0 (2023-07-14)
+
+### Added
+
+- Added support for providing certificate revocation lists (CRLs) to client
+  certificate verifiers via the new builder types. (#324).
+- Some new certificate revocation list related error codes starting with
+  RUSTLS_RESULT_CERT_REVOCATION_LIST. (#324).
+
+### Changed
+
+- rustls_client_cert_verifier became
+  rustls_allow_any_authenticated_client_verifier and must be constructed from a
+  rustls_allow_any_authenticated_client_builder.
+- rustls_client_cert_verifier_optional became
+  rustls_allow_any_anonymous_or_authenticated_client_verifier and must be
+  constructed from a rustls_allow_any_anonymous_or_authenticated_client_builder.
+
 ## 0.10.0 (2023-03-29)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README-crates.io.md"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ need to find another library to provide the cryptographic primitives.
 
 # Build
 
-You'll need to [install the Rust toolchain](https://rustup.rs/) version 1.57
+You'll need to [install the Rust toolchain](https://rustup.rs/) version 1.60
 or above and a C compiler (gcc and clang should both work). To build in optimized mode:
 
     make


### PR DESCRIPTION
## Description

This branch prepares for the 0.11.0 release.

- [x] Updated CHANGELOG with new version + date
- [X] Checked for outdated library dependencies
- [x] Tests pass locally with `--all-features` and `--no-default-features`
- [x] Updated `Cargo.toml` with new version
- [x] `cargo publish --dry-run` succeeds

### docs: update README to match MSRV.

The project MSRV was increased to 1.60 in https://github.com/rustls/rustls-ffi/pull/322 - this commit updates the README to match.

### docs: update CHANGELOG for 0.11.0 release.

This commit updates the CHANGELOG. I've tried to strike the right balance between covering the changes and not providing too much unnecessary detail. In particular I didn't call out each of the `_new` and `_free` renames in the Changed section, just the top level type name changes. Similarly in the Added section I didn't describe each of the new builder functions, but the overall idea. If preferred I can update both sections to cover each change in finer detail.

### cargo: bump version 0.10.0 -> 0.11.0

Does what it says on the tin. The changes in `main` are semver incompatible so we can't do this as a minor point release.