### PR TITLE
cipher: fix unneeded return statements.

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -634,7 +634,7 @@ impl rustls_allow_any_authenticated_client_verifier {
                 },
                 Some(x) => x,
             };
-            return Arc::into_raw(client_cert_verifier.boxed()) as *const _;
+            Arc::into_raw(client_cert_verifier.boxed()) as *const _
         }
     }
 
@@ -784,7 +784,7 @@ impl rustls_allow_any_anonymous_or_authenticated_client_verifier {
                 },
                 Some(x) => x,
             };
-            return Arc::into_raw(client_cert_verifier.boxed()) as *const _;
+            Arc::into_raw(client_cert_verifier.boxed()) as *const _
         }
     }
 


### PR DESCRIPTION
This commit addresses some [nightly clippy findings from CI](https://github.com/rustls/rustls-ffi/actions/runs/5582869452/jobs/10202602785?pr=337), two instances of unneeded `return` statements.