### PR TITLE
Nightly clippy fixes.

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -22,7 +22,6 @@ use crate::{
     ArcCastPtr, BoxCastPtr, CastConstPtr, CastPtr,
 };
 use rustls_result::{AlreadyUsed, NullParameter};
-use std::ops::Deref;
 
 /// An X.509 certificate, as used in rustls.
 /// Corresponds to `Certificate` in the Rust API.
@@ -360,7 +359,7 @@ impl rustls_certified_key {
                 }
             };
             let certified_key: &CertifiedKey = try_ref_from_ptr!(certified_key);
-            let mut new_key = certified_key.deref().clone();
+            let mut new_key = certified_key.clone();
             if !ocsp_response.is_null() {
                 let ocsp_slice = unsafe{ &*ocsp_response };
                 new_key.ocsp = Some(Vec::from(try_slice!(ocsp_slice.data, ocsp_slice.len)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) struct Userdata {
 /// UserdataGuard pops an entry off the USERDATA stack, restoring the
 /// thread-local state to its value previous to the creation of the UserdataGuard.
 /// Invariants: As long as a UserdataGuard is live:
-//// - The stack of userdata items for this thread must have at least one item.
+///  - The stack of userdata items for this thread must have at least one item.
 ///  - The top item on that stack must be the one this guard was built with.
 ///  - The `data` field must not be None.
 /// If any of these invariants fails, try_drop will return an error.


### PR DESCRIPTION
## Description

Small branch fixing some failures caught by the cron CI job's [nightly clippy](https://github.com/cpu/rustls-ffi/actions/runs/5738743060/job/15552946465) task.

### lib: fix small rustdoc mistake
New nightly clippy is flagging one of the lines of rustdoc comment in `lib.rs`:

> error: this item has comments with 4 forward slashes (`////`). These look like doc comments, but they aren't

The fix is simple, use only 3 forward slashes :-)

### cipher: remove redundant call.
Nightly clippy is flagging a redundant call in `cipher.rs`:

> call to `.deref()` on a reference in this situation does nothing

This commit removes the call to `deref` and also the now unnecessary import of the `std::ops::Deref` trait.