### PR TITLE
Attempt to fix occasional CI client/server test flakes.

### DIFF
--- a/tests/client-server.py
+++ b/tests/client-server.py
@@ -219,6 +219,7 @@ def main():
     server_popen = run_server(server, valgrind, {
         "AUTH_CERT": "testdata/minica.pem",
     })
+    wait_tcp_port(HOST, PORT)
     run_mtls_client_tests(client, valgrind)
     server_popen.kill()
     server_popen.wait()
@@ -228,6 +229,7 @@ def main():
         "AUTH_CERT": "testdata/minica.pem",
         "AUTH_CRL": "testdata/test.crl.pem",
     })
+    wait_tcp_port(HOST, PORT)
     run_mtls_client_crl_tests(client, valgrind)
 
 

--- a/tests/client-server.py
+++ b/tests/client-server.py
@@ -32,7 +32,7 @@ def wait_tcp_port(host, port):
     else:
         print("client-server.py: unable to connect")
         sys.exit(1)
-    print("client-server.py: detected server is up on {host}:{port}")
+    print(f"client-server.py: detected server is up on {host}:{port}")
 
 class Failure(Exception):
     pass


### PR DESCRIPTION
## Description

This branch attempts to resolve https://github.com/rustls/rustls-ffi/issues/336. I say "attempts" because I've had little luck trying to force the flake to happen in CI (even when hacking up the build tasks to just run multiple instances of the Windows/MacOS tests that seem to catch the flake most often).

I _think_ this is the most obvious reason why we'd see the flakes we see, but it's hard to say conclusively :-)

### tests: fix wait_tcp_port format string.
The success-case `print` for the `wait_tcp_port` helper wasn't formatting its message as an f-string, instead printing the literal `{host}` and `{port}` placeholders.

### tests: wait for tcp port for all test types.
The `run_mtls_client_tests` and `run_mtls_client_crl_tests` were being run without calling `wait_tcp_port` first. I suspect this is the reason we sometimes see the connect tests fail in CI on some platforms with output about the connection being refused.
