### PR TITLE
small test and documentation fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,8 @@ where
 }
 
 // An implementation of BoxCastPtr means that when we give C code a pointer to the relevant type,
-// it is actually a Box.
+// it is actually a Box. At most one of BoxCastPtr or ArcCastPtr should be implemented for a given
+// type.
 pub(crate) trait BoxCastPtr: CastPtr + Sized {
     fn to_box(ptr: *mut Self) -> Option<Box<Self::RustType>> {
         if ptr.is_null() {
@@ -351,7 +352,8 @@ pub(crate) trait BoxCastPtr: CastPtr + Sized {
 }
 
 // An implementation of ArcCastPtr means that when we give C code a pointer to the relevant type,
-// it is actually a Arc.
+// it is actually a Arc. At most one of BoxCastPtr or ArcCastPtr should be implemented for a given
+// // type.
 pub(crate) trait ArcCastPtr: CastConstPtr + Sized {
     /// Sometimes we create an Arc, then call `into_raw` and return the resulting raw pointer
     /// to C. C can then call rustls_server_session_new multiple times using that

--- a/tests/client-server.py
+++ b/tests/client-server.py
@@ -200,6 +200,7 @@ def main():
         sys.exit(1)
 
     # Standard client/server tests.
+    print("\n### Standard client/server tests\n")
     server_popen = run_server(server, valgrind, {})
     wait_tcp_port(HOST, PORT)
     run_client_tests(client, valgrind)
@@ -207,6 +208,7 @@ def main():
     server_popen.wait()
 
     # Client/server tests w/ vectored I/O.
+    print("\n### Vectored I/O client/server tests\n")
     server_popen = run_server(server, valgrind, {
         "VECTORED_IO": ""
     })
@@ -216,6 +218,7 @@ def main():
     server_popen.wait()
 
     # Client/server tests w/ mandatory client authentication.
+    print("\n### Mandatory mTLS client/server tests\n")
     server_popen = run_server(server, valgrind, {
         "AUTH_CERT": "testdata/minica.pem",
     })
@@ -225,6 +228,7 @@ def main():
     server_popen.wait()
 
     # Client/server tests w/ mandatory client authentication & CRL.
+    print("\n### Mandatory mTLS w/ CRLs client/server tests\n")
     run_server(server, valgrind, {
         "AUTH_CERT": "testdata/minica.pem",
         "AUTH_CRL": "testdata/test.crl.pem",

--- a/tests/client-server.py
+++ b/tests/client-server.py
@@ -27,7 +27,7 @@ def wait_tcp_port(host, port):
             break
         else:
             if i > 0:
-                print("client-server.py: still trying to connect to host{}:{port}")
+                print(f"client-server.py: still trying to connect to {host}:{port}")
             time.sleep(0.1)
     else:
         print("client-server.py: unable to connect")

--- a/tests/server.c
+++ b/tests/server.c
@@ -289,8 +289,11 @@ main(int argc, const char **argv)
     }
 
     client_cert_root_store = rustls_root_cert_store_new();
-    rustls_root_cert_store_add_pem(
+    result = rustls_root_cert_store_add_pem(
       client_cert_root_store, (uint8_t *)certbuf, certbuf_len, true);
+    if(result != RUSTLS_RESULT_OK) {
+      goto cleanup;
+    }
     client_cert_verifier_builder =
       rustls_allow_any_authenticated_client_builder_new(
         client_cert_root_store);


### PR DESCRIPTION
Pulling out a handful of small changes from https://github.com/rustls/rustls-ffi/pull/341 that can be landed immediately without blocking on a finalized Rustls release.

### tests: fix f-string in client-server.py

Another instance of a f-string gone awry. It might be nice to RIIR this integration test driver, or invest in more Python CI capabilities (like running `flake8`) to catch this class of bug sooner.

### tests: print headers for client/server test types

I was finding it challenging to quickly scan the client/server integration test output to identify which scenario was failing. This commit adds some headers to make that easier.

### tests: check add pem result in server.c

Previously the result from adding a PEM input file to a root cert store wasn't being checked. This was an omission from https://github.com/rustls/rustls-ffi/pull/321 Unfortunately it seems `clang-tidy` doesn't catch this :cry: My kingdom for `#[must_use]` return type annotations.

### lib: note BoxCastPtr/ArcCastPtr are mutually exclusive

As [discussed in #341](https://github.com/rustls/rustls-ffi/pull/341#discussion_r1343288704), only one of `BoxCastPtr` or `ArcCastPtr` should be implemented for a type