### PR TITLE
rework `CastPtr`, `CastConstPtr`, `BoxCastPtr`, `ArcCastPtr`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,8 +519,6 @@ where
 /// ```rust,ignore
 /// let config: &mut ClientConfig = try_mut_from_ptr!(builder);
 /// ```
-#[doc(hidden)]
-#[macro_export]
 macro_rules! try_mut_from_ptr {
     ( $var:ident ) => {
         match $crate::try_from_mut($var) {
@@ -529,6 +527,8 @@ macro_rules! try_mut_from_ptr {
         }
     };
 }
+
+pub(crate) use try_mut_from_ptr;
 
 /// Converts a const pointer to a [`Castable`] to an optional ref to the underlying
 /// [`Castable::RustType`]. See [`cast_const_ptr`] for more information.
@@ -554,8 +554,6 @@ where
 /// ```rust, ignore
 ///   let config: &ClientConfig = try_ref_from_ptr!(builder);
 /// ```
-#[doc(hidden)]
-#[macro_export]
 macro_rules! try_ref_from_ptr {
     ( $var:ident ) => {
         match $crate::try_from($var) {
@@ -564,6 +562,8 @@ macro_rules! try_ref_from_ptr {
         }
     };
 }
+
+pub(crate) use try_ref_from_ptr;
 
 /// Convert a const pointer to a [`Castable`] to an optional `Arc` over the underlying
 /// [`Castable::RustType`]. See [`to_arc`] for more information.
@@ -581,8 +581,6 @@ where
 /// the underlying rust type using [`try_arc_from`]. Otherwise, return
 /// [`rustls_result::NullParameter`], or an appropriate default (`false`, `0`, `NULL`) based on the
 /// context. See [`try_arc_from`] for more information.
-#[doc(hidden)]
-#[macro_export]
 macro_rules! try_arc_from_ptr {
     ( $var:ident ) => {
         match $crate::try_arc_from($var) {
@@ -591,6 +589,8 @@ macro_rules! try_arc_from_ptr {
         }
     };
 }
+
+pub(crate) use try_arc_from_ptr;
 
 /// Convert a mutable pointer to a [`Castable`] to an optional `Box` over the underlying
 /// [`Castable::RustType`].
@@ -608,8 +608,6 @@ where
 /// over the underlying rust type using [`try_box_from`]. Otherwise, return [`rustls_result::NullParameter`],
 /// or an appropriate default (`false`, `0`, `NULL`) based on the context. See [`try_box_from`] for
 /// more information.
-#[doc(hidden)]
-#[macro_export]
 macro_rules! try_box_from_ptr {
     ( $var:ident ) => {
         match $crate::try_box_from($var) {
@@ -619,8 +617,8 @@ macro_rules! try_box_from_ptr {
     };
 }
 
-#[doc(hidden)]
-#[macro_export]
+pub(crate) use try_box_from_ptr;
+
 macro_rules! try_slice {
     ( $ptr:expr, $count:expr ) => {
         if $ptr.is_null() {
@@ -631,20 +629,8 @@ macro_rules! try_slice {
     };
 }
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! try_mut_slice {
-    ( $ptr:expr, $count:expr ) => {
-        if $ptr.is_null() {
-            return $crate::panic::NullParameterOrDefault::value();
-        } else {
-            unsafe { slice::from_raw_parts_mut($ptr, $count as usize) }
-        }
-    };
-}
+pub(crate) use try_slice;
 
-#[doc(hidden)]
-#[macro_export]
 macro_rules! try_callback {
     ( $var:ident ) => {
         match $var {
@@ -653,6 +639,9 @@ macro_rules! try_callback {
         }
     };
 }
+
+pub(crate) use try_callback;
+
 /// Returns a static string containing the rustls-ffi version as well as the
 /// rustls version. The string is alive for the lifetime of the program and does
 /// not need to be freed.


### PR DESCRIPTION
### rework CastPtr, CastConstPtr, BoxCastPtr, ArcCastPtr

This commit reworks the existing `CastPtr`, `CastConstPtr`, `BoxCastPtr`, and `ArcCastPtr` traits into a new `Castable` trait with an associated `Ownership`, constrained to be a type implementing the new `OwnershipMarker` trait. Three implementations of this `OwnershipMarker` trait are offered: `OwnershipBox`, `OwnershipArc` and `OwnershipRef`.

The net result is that the type system is now able to enforce our invariant that a single `Castable` type can't be cast to a pointer of more than one type of ownership (e.g. both an `Arc` and a `Box`).  Implementing `Castable` for the same type with different `Ownership`'s or `RustType`'s will be rejected by the compiler as a conflicting trait implementation. We always implement a distinct type per-ownership model, and per rust type.

Along the way crate-internal documentation for the traits and associated free-standing helper `fs`s were reworked for clarity/consistency.

Resolves #349 

### lib: remove pub export of macros

Previously the helper macros in `src/lib.rs` were marked `macro_export`, making them part of the public API. Since these were
meant to be crate internal, we also annotated the macros as `doc(hidden)` to avoid them appearing in the API docs. I suspect this was done before `pub(crate)` visibility was an option.

This commit removes the `macro_export` and `doc(hidden)` attributes and uses a `pub(crate)` re-export to make the macros available to crate-internal users without making them part of the public API.

This also uncovered that the `try_mut_slice!` macro wasn't being used anywhere and so it is removed outright.