### PR TITLE
rename to_arc to clone_arc

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -12,7 +12,7 @@ use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::server::rustls_server_config;
 use crate::{
     ffi_panic_boundary, free_box, rustls_result, set_boxed_mut_ptr, to_box, to_boxed_mut_ptr,
-    try_arc_from_ptr, try_callback, try_mut_from_ptr, try_ref_from_ptr, try_take, Castable,
+    try_callback, try_clone_arc, try_mut_from_ptr, try_ref_from_ptr, try_take, Castable,
     OwnershipBox,
 };
 use rustls_result::NullParameter;
@@ -400,7 +400,7 @@ impl rustls_accepted {
         ffi_panic_boundary! {
             let accepted: &mut Option<Accepted> = try_mut_from_ptr!(accepted);
             let accepted = try_take!(accepted);
-            let config: Arc<ServerConfig> = try_arc_from_ptr!(config);
+            let config: Arc<ServerConfig> = try_clone_arc!(config);
             match accepted.into_connection(config) {
                 Ok(built) => {
                     let wrapped = crate::connection::Connection::from_server(built);

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,8 +22,8 @@ use crate::rslice::NulByte;
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_str};
 use crate::{
     ffi_panic_boundary, free_arc, free_box, set_boxed_mut_ptr, to_arc_const_ptr, to_boxed_mut_ptr,
-    try_arc_from_ptr, try_box_from_ptr, try_mut_from_ptr, try_ref_from_ptr, try_slice,
-    userdata_get, Castable, OwnershipArc, OwnershipBox,
+    try_box_from_ptr, try_clone_arc, try_mut_from_ptr, try_ref_from_ptr, try_slice, userdata_get,
+    Castable, OwnershipArc, OwnershipBox,
 };
 
 /// A client config being constructed. A builder can be modified by,
@@ -442,7 +442,7 @@ impl rustls_client_config_builder {
             let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
             let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
             for &key_ptr in keys_ptrs {
-                let certified_key: Arc<CertifiedKey> = try_arc_from_ptr!(key_ptr);
+                let certified_key: Arc<CertifiedKey> = try_clone_arc!(key_ptr);
                 keys.push(certified_key);
             }
             config.cert_resolver = Some(Arc::new(ResolvesClientCertFromChoices { keys }));
@@ -545,7 +545,7 @@ impl rustls_client_config {
             }
             CStr::from_ptr(server_name)
         };
-        let config: Arc<ClientConfig> = try_arc_from_ptr!(config);
+        let config: Arc<ClientConfig> = try_clone_arc!(config);
         let server_name: &str = match server_name.to_str() {
             Ok(s) => s,
             Err(std::str::Utf8Error { .. }) => return rustls_result::InvalidDnsNameError,

--- a/src/server.rs
+++ b/src/server.rs
@@ -30,8 +30,8 @@ use crate::session::{
 };
 use crate::{
     ffi_panic_boundary, free_arc, free_box, set_boxed_mut_ptr, to_arc_const_ptr, to_boxed_mut_ptr,
-    try_arc_from_ptr, try_box_from_ptr, try_mut_from_ptr, try_ref_from_ptr, try_slice,
-    userdata_get, Castable, OwnershipArc, OwnershipBox, OwnershipRef,
+    try_box_from_ptr, try_clone_arc, try_mut_from_ptr, try_ref_from_ptr, try_slice, userdata_get,
+    Castable, OwnershipArc, OwnershipBox, OwnershipRef,
 };
 
 /// A server config being constructed. A builder can be modified by,
@@ -170,7 +170,7 @@ impl rustls_server_config_builder {
     ) {
         ffi_panic_boundary! {
         let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
-        let verifier: Arc<AllowAnyAuthenticatedClient> = try_arc_from_ptr!(verifier);
+        let verifier: Arc<AllowAnyAuthenticatedClient> = try_clone_arc!(verifier);
         builder.verifier = verifier;
         }
     }
@@ -186,7 +186,7 @@ impl rustls_server_config_builder {
     ) {
         ffi_panic_boundary! {
             let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
-            let verifier: Arc<AllowAnyAnonymousOrAuthenticatedClient> = try_arc_from_ptr!(verifier);
+            let verifier: Arc<AllowAnyAnonymousOrAuthenticatedClient> = try_clone_arc!(verifier);
 
             builder.verifier = verifier;
         }
@@ -273,7 +273,7 @@ impl rustls_server_config_builder {
         let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
         let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
         for &key_ptr in keys_ptrs {
-            let certified_key: Arc<CertifiedKey> = try_arc_from_ptr!(key_ptr);
+            let certified_key: Arc<CertifiedKey> = try_clone_arc!(key_ptr);
             keys.push(certified_key);
         }
             builder.cert_resolver = Some(Arc::new(ResolvesServerCertFromChoices::new(&keys)));
@@ -333,7 +333,7 @@ impl rustls_server_config {
         conn_out: *mut *mut rustls_connection,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let config: Arc<ServerConfig> = try_arc_from_ptr!(config);
+            let config: Arc<ServerConfig> = try_clone_arc!(config);
 
             let server_connection = match ServerConnection::new(config) {
                 Ok(sc) => sc,


### PR DESCRIPTION
to_arc converts a `*const C` into an `Option<Arc<T>>`. It had a lot of verbiage to explain what it was doing with reference counts. I think the conceptual model becomes a lot simpler if we rename the function to reflect what it is really doing: cloning the arc.