### PR TITLE
v0.12.0: update to rustls 0.22, address breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0-alpha.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d42991943cf48034955ba6d9a28f30e6b1e5fd73e46737ce52e8461bcc28e3"
+checksum = "5bc238b76c51bbc449c55ffbc39d03772a057cc8cf783c49d4af4c2537b74a8b"
 dependencies = [
  "log",
  "ring",
@@ -130,14 +130,13 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
- "sct",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.0.0-alpha.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9975e1f0807681e097d288d545dc40c98a4d3a6ef95a40b18d00e5e4daa9a4"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
  "base64",
  "rustls-pki-types",
@@ -145,15 +144,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "0.2.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d3edd6cdcdf26eda538757038343986e666d0b8ba4b5ac1de663b78475550d"
+checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0-alpha.8"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139cdfd1d8b96f927fbe0a0c98785afe94b63e95a7ef815ebae9263d20e10a0d"
+checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -165,16 +164,6 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "spin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ rustls = { version = "=0.22.0-alpha.6", features = [ "ring" ]}
 pki-types = { package = "rustls-pki-types", version = "0.2.3", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.8", features = ["std"] }
 libc = "0.2"
-sct = "0.7"
 rustls-pemfile = "=2.0.0-alpha.2"
 log = "0.4.17"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ read_buf = ["rustls/read_buf"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "=0.22.0-alpha.6", features = [ "ring" ]}
-pki-types = { package = "rustls-pki-types", version = "0.2.3", features = ["std"] }
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.8", features = ["std"] }
+rustls = { version = "0.22", features = [ "ring" ]}
+pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
+webpki = { package = "rustls-webpki", version = "0.102.0", features = ["std"] }
 libc = "0.2"
-rustls-pemfile = "=2.0.0-alpha.2"
+rustls-pemfile = "2"
 log = "0.4.17"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README-crates.io.md"

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::{env, fs, path::PathBuf};
 
 // Keep in sync with Cargo.toml.
-const RUSTLS_CRATE_VERSION: &str = "0.22.0-alpha.6";
+const RUSTLS_CRATE_VERSION: &str = "0.22";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -675,7 +675,9 @@ impl rustls_client_cert_verifier {
 /// done configuring settings, call `rustls_web_pki_client_cert_verifier_builder_build`
 /// to turn it into a `rustls_client_cert_verifier`. This object is not safe
 /// for concurrent mutation.
-// TODO(@cpu): Add rustdoc link once available.
+///
+/// See <https://docs.rs/rustls/latest/rustls/server/struct.ClientCertVerifierBuilder.html>
+/// for more information.
 pub struct rustls_web_pki_client_cert_verifier_builder {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -943,7 +945,9 @@ impl rustls_web_pki_client_cert_verifier_builder {
 /// done configuring settings, call `rustls_web_pki_server_cert_verifier_builder_build`
 /// to turn it into a `rustls_server_cert_verifier`. This object is not safe
 /// for concurrent mutation.
-// TODO(@cpu): Add rustdoc link once available.
+///
+/// See <https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html>
+/// for more information.
 pub struct rustls_web_pki_server_cert_verifier_builder {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.

--- a/src/error.rs
+++ b/src/error.rs
@@ -241,6 +241,7 @@ impl rustls_result {
 /// inputs, including Ok, return rustls::Error::General.
 pub(crate) fn cert_result_to_error(result: rustls_result) -> rustls::Error {
     use rustls::Error::*;
+    use rustls::OtherError;
     use rustls_result::*;
     match result {
         CertEncodingBad => InvalidCertificate(CertificateError::BadEncoding),
@@ -257,7 +258,9 @@ pub(crate) fn cert_result_to_error(result: rustls_result) -> rustls::Error {
         CertApplicationVerificationFailure => {
             InvalidCertificate(CertificateError::ApplicationVerificationFailure)
         }
-        CertOtherError => InvalidCertificate(CertificateError::Other(Arc::from(Box::from("")))),
+        CertOtherError => InvalidCertificate(CertificateError::Other(OtherError(Arc::from(
+            Box::from(""),
+        )))),
         _ => rustls::Error::General("".into()),
     }
 }

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -301,6 +301,9 @@ typedef struct rustls_supported_ciphersuite rustls_supported_ciphersuite;
  * done configuring settings, call `rustls_web_pki_client_cert_verifier_builder_build`
  * to turn it into a `rustls_client_cert_verifier`. This object is not safe
  * for concurrent mutation.
+ *
+ * See <https://docs.rs/rustls/latest/rustls/server/struct.ClientCertVerifierBuilder.html>
+ * for more information.
  */
 typedef struct rustls_web_pki_client_cert_verifier_builder rustls_web_pki_client_cert_verifier_builder;
 
@@ -310,6 +313,9 @@ typedef struct rustls_web_pki_client_cert_verifier_builder rustls_web_pki_client
  * done configuring settings, call `rustls_web_pki_server_cert_verifier_builder_build`
  * to turn it into a `rustls_server_cert_verifier`. This object is not safe
  * for concurrent mutation.
+ *
+ * See <https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html>
+ * for more information.
  */
 typedef struct rustls_web_pki_server_cert_verifier_builder rustls_web_pki_server_cert_verifier_builder;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -83,7 +83,7 @@ impl rustls_server_config_builder {
     pub extern "C" fn rustls_server_config_builder_new() -> *mut rustls_server_config_builder {
         ffi_panic_boundary! {
             let builder = ServerConfigBuilder {
-                           base: rustls::ServerConfig::builder().with_safe_defaults(),
+                           base: rustls::ServerConfig::builder(),
                            verifier: WebPkiClientVerifier::no_client_auth(),
                            cert_resolver: None,
                            session_storage: None,
@@ -138,7 +138,12 @@ impl rustls_server_config_builder {
                 }
             }
 
-            let result = rustls::ServerConfig::builder().with_cipher_suites(&cs_vec).with_safe_default_kx_groups().with_protocol_versions(&versions);
+            let provider = rustls::crypto::CryptoProvider{
+                cipher_suites: cs_vec,
+                ..rustls::crypto::ring::default_provider()
+            };
+            let result = rustls::ServerConfig::builder_with_provider(provider.into())
+                .with_protocol_versions(&versions);
             let base = match result {
                 Ok(new) => new,
                 Err(_) => return rustls_result::InvalidParameter,


### PR DESCRIPTION
Updates rustls-ffi to use [rustls 0.22](https://github.com/rustls/rustls/releases/tag/v%2F0.22.0). This branch retains *ring* as the only supported crypto provider. Subsequent work will allow selection of *ring* or aws_lc_rs as well as mixing/matching.

* Version 0.11.1 -> 0.12.0
* Rustls 0.22.0-alpha-6 -> 0.22.0
* Webpki 0.102.0-alpha.8 -> 0.102.0
* Rustls pki-types 0.2.3 -> 1.0
* `CryptoProvider` is now a struct.
* `rustls::crypto::ring::RING` is now `rustls::crypto::ring::default_provider`.
* `WebPkiServerVerifier`'s default fns are removed, `rustls::crypto::{verify_tls12_signature|verify_tls13_signature}` and `rustls::crypto::WebPkiSupportedAlgorithms.supported_schemes` can be used instead.
* `rustls::Error::Other` now holds `rustls::OtherError` variant instead of `Arc<...>`.