### PR TITLE
docs: update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 0.12.0 (2023-12-03)
+
+This release updates to [Rustls 0.22], but does not yet expose support for
+customizing the cryptographic provider. This will be added in a future release,
+and 0.12.0 continues to use `*ring*` as the only cryptographic provider.
+
+[Rustls 0.22]: https://github.com/rustls/rustls/releases/tag/v%2F0.22.0
+
+### Added
+
+* `RUSTLS_RESULT_CLIENT_CERT_VERIFIER_BUILDER_NO_ROOT_ANCHORS` error code,
+  returned when a client cert verifier is being built that hasn't provided any
+  root trust anchors.
+* The server certificate verifier now supports CRL revocation checking through
+  policy and CRLs provided to the server certificate verifier builder.
+* Client certificate verifier builder now supports controlling CRL revocation
+  status check depth and unknown revocation policy.
+
+### Changed
+
+* The root certificate store constructor (`rustls_root_cert_store_new`) and the
+  function to add PEM content (`rustls_root_cert_store_add_pem`) have been
+  replaced with a new `rustls_root_cert_store_builder` type, constructed with
+  `rustls_root_cert_store_builder_new`. PEM content can be added with
+  `rustls_root_cert_store_builder_add_pem` and
+  `rustls_root_cert_store_builder_load_roots_from_file`.
+* The client verifier builders (
+  `rustls_allow_any_anonymous_or_authenticated_client_builder`, and 
+  `rustls_allow_any_authenticated_client_builder`) as well as the client
+  verifier types (`rustls_allow_any_anonymous_or_authenticated_client_verifier`, 
+  `rustls_allow_any_authenticated_client_verifier`) have been replaced with
+  `rustls_web_pki_client_cert_verifier_builder` and `rustls_client_cert_verifier`.
+* The server config client verifier setters 
+  (`rustls_server_config_builder_set_client_verifier` and
+  `rustls_server_config_builder_set_client_verifier_optional`) have been
+  replaced with `rustls_server_config_builder_set_client_verifier`.
+* The client config builder functions for specifying root trust anchors 
+  (`rustls_client_config_builder_use_roots` and
+  `rustls_client_config_builder_load_roots_from_file`) have been replaced
+  with a server certificate verifier builder 
+  (`rustls_web_pki_server_cert_verifier_builder`) constructed with
+  `rustls_web_pki_server_cert_verifier_builder_new` and
+  a `rustls_root_cert_store`. The built `rustls_web_pki_server_cert_verifier`
+  can be provided to a client config builder with
+  `rustls_client_config_builder_set_server_verifier`.
+* CRL validation defaults to checking the full certificate chain, and treating
+  unknown revocation status as an error condition.
+
+### Removed
+
+* `RUSTLS_RESULT_CERT_SCT_*` error codes have been removed.
+
 ## 0.11.0 (2023-07-14)
 
 ### Added

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -532,7 +532,7 @@ impl rustls_root_cert_store_builder {
     /// This may be useful on systems that have syntactically invalid root
     /// certificates.
     #[no_mangle]
-    pub extern "C" fn rustls_client_config_builder_load_roots_from_file(
+    pub extern "C" fn rustls_root_cert_store_builder_load_roots_from_file(
         builder: *mut rustls_root_cert_store_builder,
         filename: *const c_char,
         strict: bool,

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -44,27 +44,25 @@ impl<'a> Castable for rustls_certificate<'a> {
     type RustType = CertificateDer<'a>;
 }
 
-impl<'a> rustls_certificate<'a> {
-    /// Get the DER data of the certificate itself.
-    /// The data is owned by the certificate and has the same lifetime.
-    #[no_mangle]
-    pub extern "C" fn rustls_certificate_get_der(
-        cert: *const rustls_certificate,
-        out_der_data: *mut *const u8,
-        out_der_len: *mut size_t,
-    ) -> rustls_result {
-        ffi_panic_boundary! {
-            let cert = try_ref_from_ptr!(cert);
-            if out_der_data.is_null() || out_der_len.is_null() {
-                return NullParameter
-            }
-            let der = cert.as_ref();
-            unsafe {
-                *out_der_data = der.as_ptr();
-                *out_der_len = der.len();
-            }
-            rustls_result::Ok
+/// Get the DER data of the certificate itself.
+/// The data is owned by the certificate and has the same lifetime.
+#[no_mangle]
+pub extern "C" fn rustls_certificate_get_der(
+    cert: *const rustls_certificate,
+    out_der_data: *mut *const u8,
+    out_der_len: *mut size_t,
+) -> rustls_result {
+    ffi_panic_boundary! {
+        let cert = try_ref_from_ptr!(cert);
+        if out_der_data.is_null() || out_der_len.is_null() {
+            return NullParameter
         }
+        let der = cert.as_ref();
+        unsafe {
+            *out_der_data = der.as_ptr();
+            *out_der_len = der.len();
+        }
+        rustls_result::Ok
     }
 }
 

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -980,9 +980,9 @@ rustls_result rustls_root_cert_store_builder_add_pem(struct rustls_root_cert_sto
  * This may be useful on systems that have syntactically invalid root
  * certificates.
  */
-rustls_result rustls_client_config_builder_load_roots_from_file(struct rustls_root_cert_store_builder *builder,
-                                                                const char *filename,
-                                                                bool strict);
+rustls_result rustls_root_cert_store_builder_load_roots_from_file(struct rustls_root_cert_store_builder *builder,
+                                                                  const char *filename,
+                                                                  bool strict);
 
 /**
  * Create a new `rustls_root_cert_store` from the builder.

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -837,6 +837,14 @@ rustls_result rustls_accepted_into_connection(struct rustls_accepted *accepted,
 void rustls_accepted_free(struct rustls_accepted *accepted);
 
 /**
+ * Get the DER data of the certificate itself.
+ * The data is owned by the certificate and has the same lifetime.
+ */
+rustls_result rustls_certificate_get_der(const struct rustls_certificate *cert,
+                                         const uint8_t **out_der_data,
+                                         size_t *out_der_len);
+
+/**
  * Return a 16-bit unsigned integer corresponding to this cipher suite's assignment from
  * <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>.
  * The bytes from the assignment are interpreted in network order.

--- a/tests/client.c
+++ b/tests/client.c
@@ -433,7 +433,7 @@ main(int argc, const char **argv)
 
   if(getenv("CA_FILE")) {
     server_cert_root_store_builder = rustls_root_cert_store_builder_new();
-    result = rustls_client_config_builder_load_roots_from_file(
+    result = rustls_root_cert_store_builder_load_roots_from_file(
       server_cert_root_store_builder, getenv("CA_FILE"), true);
     if(result != RUSTLS_RESULT_OK) {
       print_error("loading trusted certificates", result);


### PR DESCRIPTION
This branch adds an updated `CHANGELOG.md` covering the to-be-published 0.12.0 release. Additionally it fixes one misnamed function caught during review of the changes since the last release, and a fn that was accidentally dropped from the `rustls.h` interface.

To generate the changelog content I pulled the 0.11.0 `src/rustls.h` and the `src/rustls.h` from `main`, ran them through `gcc` to remove comments and post-processed to remove whitespace and `#` lines. I then reviewed the diff and tried to account for all of the changes in the text:
```bash
gcc -fpreprocessed -E old.rustls.h | sed '/^\s*$/d' | grep -v '#' > old.h
gcc -fpreprocessed -E src/rustls.h | sed '/^\s*$/d' | grep -v '#' > new.h
diff new.h old.h
```