### PR TITLE
CI: restore integration tests, fixup MacOS/Windows expected linker parts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - env:
           CARGO_UNSTABLE_HTTP_REGISTRY: true
-        run: make CC=${{ matrix.cc }} PROFILE=release test
+        run: make CC=${{ matrix.cc }} PROFILE=release test integration
 
   valgrind:
     name: Valgrind
@@ -53,7 +53,7 @@ jobs:
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
       - run: export VALGRIND="valgrind -q"
-      - run: make test
+      - run: make test integration
 
   test-windows:
     name: Windows
@@ -67,7 +67,7 @@ jobs:
       # Remove link.exe from non-MSVC packages that interferes with MSVC link
       - run: rm "C:\Program Files\Git\usr\bin\link.exe"
       - run: rm "C:\msys64\usr\bin\link.exe"
-      - run: make -f Makefile.Windows
+      - run: make -f Makefile.Windows test integration
 
   test-windows-cmake-debug:
     name: Windows CMake, Debug configuration
@@ -82,9 +82,11 @@ jobs:
         run: cmake -S . -B build
       - name: Build, debug configuration
         run: cmake --build build --config Debug
+      - name: Integration test, debug configuration
+        run: cargo test --locked --test client_server client_server_integration -- --ignored --exact
         env:
-          CLIENT_BINARY: build/tests/Debug/client.exe
-          SERVER_BINARY: build/tests/Debug/server.exe
+          CLIENT_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Debug\client.exe
+          SERVER_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Debug\server.exe
 
   test-windows-cmake-release:
     name: Windows CMake, Release configuration
@@ -99,9 +101,11 @@ jobs:
         run: cmake -S . -B build
       - name: Build, release configuration
         run: cmake --build build --config Release
+      - name: Integration test, release configuration
+        run: cargo test --locked --test client_server client_server_integration -- --ignored --exact
         env:
-          CLIENT_BINARY: build/tests/Release/client.exe
-          SERVER_BINARY: build/tests/Release/server.exe
+          CLIENT_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\client.exe
+          SERVER_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\server.exe
 
   ensure-header-updated:
     runs-on: ubuntu-latest

--- a/Makefile.Windows
+++ b/Makefile.Windows
@@ -36,7 +36,7 @@ all: $(RUSTLS_LIB) target/client.exe target/server.exe
 
 test: all
 	$(call green_msg, getting 'https://httpbin.org/headers' ...)
-	target/client.exe httpbin.org 443 /headers
+	NO_CHECK_CERTIFICATE=1 target/client.exe httpbin.org 443 /headers
 	$(call green_msg, Running 'cargo test')
 	cargo test --locked
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To link against the resulting library, on **Linux**:
 
 To link against the resulting library, on **macOS**:
 
-    -lrustls -framework Security -liconv -lSystem -lc -l
+    -lrustls -liconv -lSystem -lc -l
 
 If the linking instructions above go out of date, [you can get an up-to-date list
 via](https://doc.rust-lang.org/rustc/command-line-arguments.html#--print-print-compiler-information):

--- a/tests/static_libs.rs
+++ b/tests/static_libs.rs
@@ -51,10 +51,8 @@ fn expected_linker_parts() -> &'static [&'static str] {
     #[cfg(target_os = "windows")]
     {
         &[
+            "bcrypt.lib",
             "advapi32.lib",
-            "credui.lib",
-            "kernel32.lib",
-            "secur32.lib",
             "legacy_stdio_definitions.lib",
             "kernel32.lib",
             "advapi32.lib",

--- a/tests/static_libs.rs
+++ b/tests/static_libs.rs
@@ -46,14 +46,7 @@ fn expected_linker_parts() -> &'static [&'static str] {
     }
     #[cfg(target_os = "macos")]
     {
-        &[
-            "-framework",
-            "Security",
-            "-liconv",
-            "-lSystem",
-            "-lc",
-            "-lm",
-        ]
+        &["-liconv", "-lSystem", "-lc", "-lm"]
     }
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
In https://github.com/rustls/rustls-ffi/pull/348 I neglected to update the callsites that were previously using `make test` so they would run the new Rust-based integration tests (behind `make integration`). It also seems like the Windows makefile `test` target wasn't being exercised at all (there was a missing required env var for the client.exe invocation). 

This branch fixes that, and along the way uncovered that the MacOS and Windows linker parts have drifted from expected. Those are updated in this branch as well. Unfortunately it seems like the Windows CMake builds disagree on the linker parts compared to the Windows Makefile builds. For now I've made the CMake builds only run the client/server integration test, and let the Makefile builds enforce the expected linker parts. We could also consider maintaining two different `expected_linker_parts` returns, but doing that will be a bit tricky since right now the expected values are chosen by `target_os` alone, and don't know about the build tooling in-use.