### PR TITLE
docs: document the opaque struct pattern in one place

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,3 +93,18 @@ pointer is `NULL`:
 These are defined in [src/lib.rs](src/lib.rs). The `Castable` trait determines which
 C pointers can be cast to which Rust pointer types. These macros rely
 on that trait to ensure correct typing of conversions.
+
+## Opaque Struct Pattern
+
+The `struct` types rustls-ffi uses are often meant to be opaque to C code, meaning that 
+C code should know the types exist, but not what they contain. To achieve this we rely on 
+the opaque struct pattern described in [the Nomicon FFI guide](https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs).
+
+For example:
+```rust
+/// A cipher suite supported by rustls.
+pub struct rustls_supported_ciphersuite {
+    // Makes this type opaque to C code.
+    _private: [u8; 0],
+}
+```

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -32,9 +32,6 @@ use rustls_result::{AlreadyUsed, NullParameter};
 /// Corresponds to `CertificateDer` in the Rust pki-types API.
 /// <https://docs.rs/rustls-pki-types/latest/rustls_pki_types/struct.CertificateDer.html>
 pub struct rustls_certificate<'a> {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
     _marker: PhantomData<&'a ()>,
 }
@@ -268,9 +265,6 @@ mod tests {
 /// Corresponds to `CertifiedKey` in the Rust API.
 /// <https://docs.rs/rustls/latest/rustls/sign/struct.CertifiedKey.html>
 pub struct rustls_certified_key {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 
@@ -447,9 +441,6 @@ impl rustls_certified_key {
 /// call `rustls_root_cert_store_builder_build` to turn it into a `rustls_root_cert_store`.
 /// This object is not safe for concurrent mutation.
 pub struct rustls_root_cert_store_builder {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 
@@ -621,9 +612,6 @@ impl rustls_root_cert_store_builder {
 /// A root certificate store.
 /// <https://docs.rs/rustls/latest/rustls/struct.RootCertStore.html>
 pub struct rustls_root_cert_store {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 
@@ -679,9 +667,6 @@ impl rustls_client_cert_verifier {
 /// See <https://docs.rs/rustls/latest/rustls/server/struct.ClientCertVerifierBuilder.html>
 /// for more information.
 pub struct rustls_web_pki_client_cert_verifier_builder {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 
@@ -949,9 +934,6 @@ impl rustls_web_pki_client_cert_verifier_builder {
 /// See <https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html>
 /// for more information.
 pub struct rustls_web_pki_server_cert_verifier_builder {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,9 +36,6 @@ use crate::{
 /// `Box<ClientConfig>`.
 /// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
 pub struct rustls_client_config_builder {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 
@@ -59,9 +56,6 @@ impl Castable for rustls_client_config_builder {
 /// Under the hood, this object corresponds to an `Arc<ClientConfig>`.
 /// <https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html>
 pub struct rustls_client_config {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,9 +39,6 @@ use crate::{
 /// for concurrent mutation.
 /// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
 pub struct rustls_server_config_builder {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 
@@ -63,9 +60,6 @@ impl Castable for rustls_server_config_builder {
 /// Under the hood, this object corresponds to an `Arc<ServerConfig>`.
 /// <https://docs.rs/rustls/latest/rustls/struct.ServerConfig.html>
 pub struct rustls_server_config {
-    // We use the opaque struct pattern to tell C about our types without
-    // telling them what's inside.
-    // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
 }
 


### PR DESCRIPTION
Rather than inconsistently duplicating the same comment in all of our opaque structs let's document it once in `CONTRIBUTING.md`.