### PR TITLE
tests: update Windows expected linker parts

### DIFF
--- a/tests/static_libs.rs
+++ b/tests/static_libs.rs
@@ -64,6 +64,8 @@ fn expected_linker_parts() -> &'static [&'static str] {
             "kernel32.lib",
             "ws2_32.lib",
             "kernel32.lib",
+            "ntdll.lib",
+            "kernel32.lib",
             "msvcrt.lib",
         ]
     }


### PR DESCRIPTION
The Windows CI task that runs the integration test suite responsible for checking the expected linker parts [started to fail yesterday](https://github.com/rustls/rustls-ffi/actions/runs/7475063671/job/20350991534). This commit updates the expected list to match the current output.