### PR TITLE
Zero callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ read_buf = ["rustls/read_buf"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.22", features = [ "ring" ]}
+rustls = { version = "0.22", features = [ "ring", "read_buf" ]}
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", features = ["std"] }
 libc = "0.2"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ target:
 	mkdir -p $@
 
 src/rustls.h: src/*.rs cbindgen.toml
-	cbindgen --lang C > $@
+	cbindgen --lang C --cpp-compat > $@
 
 target/$(PROFILE)/librustls_ffi.a: src/*.rs Cargo.toml
 	RUSTFLAGS="-C metadata=rustls-ffi" ${CARGO} build $(CARGOFLAGS)

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -559,7 +559,6 @@ impl rustls_root_cert_store_builder {
         }
     }
 
-
     /// Add one or more certificates to the root cert store builder using PEM
     /// encoded data read from the named file.
     ///

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,12 +9,10 @@ use rustls::{ClientConnection, ServerConnection, SupportedCipherSuite};
 
 use crate::io::{
     rustls_write_vectored_callback, CallbackReader, CallbackWriter, ReadCallback,
-    VectoredCallbackWriter, VectoredWriteCallback, WriteCallback
+    VectoredCallbackWriter, VectoredWriteCallback, WriteCallback,
 };
 #[cfg(all(unix))]
-use crate::io::{
-    FDReader, FDWriter
-};
+use crate::io::{FDReader, FDWriter};
 
 use crate::log::{ensure_log_registered, rustls_log_callback};
 
@@ -133,7 +131,7 @@ impl rustls_connection {
         conn.log_callback = cb;
     }
 
-    /// Read some TLS bytes from the provided file descriptor into internal buffers. 
+    /// Read some TLS bytes from the provided file descriptor into internal buffers.
     /// Returns 0 for success, or an errno value on error.
     /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.read_tls>
     #[cfg(all(unix))]
@@ -198,7 +196,7 @@ impl rustls_connection {
         }
     }
 
-    /// Write some TLS bytes to provided file descriptor. 
+    /// Write some TLS bytes to provided file descriptor.
     /// Returns 0 for success, or an errno value on error.
     /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.write_tls>
     #[cfg(all(unix))]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -11,7 +11,7 @@ use crate::io::{
     rustls_write_vectored_callback, CallbackReader, CallbackWriter, ReadCallback,
     VectoredCallbackWriter, VectoredWriteCallback, WriteCallback,
 };
-#[cfg(all(unix))]
+#[cfg(unix)]
 use crate::io::{FDReader, FDWriter};
 
 use crate::log::{ensure_log_registered, rustls_log_callback};
@@ -134,7 +134,7 @@ impl rustls_connection {
     /// Read some TLS bytes from the provided file descriptor into internal buffers.
     /// Returns 0 for success, or an errno value on error.
     /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.read_tls>
-    #[cfg(all(unix))]
+    #[cfg(unix)]
     #[no_mangle]
     pub extern "C" fn rustls_connection_read_tls_from_fd(
         conn: *mut rustls_connection,
@@ -199,7 +199,7 @@ impl rustls_connection {
     /// Write some TLS bytes to provided file descriptor.
     /// Returns 0 for success, or an errno value on error.
     /// <https://docs.rs/rustls/latest/rustls/enum.Connection.html#method.write_tls>
-    #[cfg(all(unix))]
+    #[cfg(unix)]
     #[no_mangle]
     pub extern "C" fn rustls_connection_write_tls_to_fd(
         conn: *mut rustls_connection,

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,6 @@
 use std::io::{Error, IoSlice, Read, Result, Write};
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 use std::os::unix::io::{FromRawFd, RawFd};
 
 use libc::{c_void, size_t};
@@ -101,19 +101,19 @@ impl Write for CallbackWriter {
     }
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 pub(crate) struct FDReader {
     pub fd: i32,
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 impl FromRawFd for FDReader {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self { fd }
     }
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 impl Read for FDReader {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         assert!(buf.len() <= isize::max_value() as usize);
@@ -124,19 +124,19 @@ impl Read for FDReader {
     }
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 pub(crate) struct FDWriter {
     pub fd: i32,
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 impl FromRawFd for FDWriter {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self { fd }
     }
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 impl Write for FDWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         assert!(buf.len() <= isize::max_value() as usize);

--- a/src/io.rs
+++ b/src/io.rs
@@ -101,7 +101,6 @@ impl Write for CallbackWriter {
     }
 }
 
-
 #[cfg(all(unix))]
 pub(crate) struct FDReader {
     pub fd: i32,
@@ -111,18 +110,18 @@ pub(crate) struct FDReader {
 impl FromRawFd for FDReader {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self { fd }
-    }   
+    }
 }
 
 #[cfg(all(unix))]
 impl Read for FDReader {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         assert!(buf.len() <= isize::max_value() as usize);
-        match unsafe { libc::read(self.fd, buf.as_mut_ptr() as _, buf.len()) } { 
+        match unsafe { libc::read(self.fd, buf.as_mut_ptr() as _, buf.len()) } {
             x if x < 0 => Err(Error::last_os_error()),
             x => Ok(x as usize),
         }
-    }   
+    }
 }
 
 #[cfg(all(unix))]
@@ -134,14 +133,14 @@ pub(crate) struct FDWriter {
 impl FromRawFd for FDWriter {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self { fd }
-    }   
+    }
 }
 
 #[cfg(all(unix))]
 impl Write for FDWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         assert!(buf.len() <= isize::max_value() as usize);
-        match unsafe { libc::write(self.fd, buf.as_ptr() as _, buf.len()) } { 
+        match unsafe { libc::write(self.fd, buf.as_ptr() as _, buf.len()) } {
             x if x < 0 => Err(Error::last_os_error()),
             x => Ok(x as usize),
         }


### PR DESCRIPTION
I have been working on JavaScript bindings for rustls-ffi and found these "improvements" useful while doing so. Maybe you would be willing to accept them as a PR? If so, please let me know what needs changing in order for the PR to be accepted.

In JavaScript (on V8) calling back into JS from C++/Rust has quite some overhead (~70 nanoseconds) and adds some complexity to ffi/bindings, so I have added ```read_tls_from_fd``` and ```write_tls_to_fd``` methods which allows us to bypass the callbacks altogether. I think this will only work on linux/macos, so have marked the new methods and imports as unix only. I'm not expert in Rust so if there is a cleaner way to do this please let me know.

I also added a ```root_cert_store_builder_load_roots_from_bytes``` method to load the cert store from an array of bytes rather than being forced to read from an external file. This is useful for me as I want to embed the certs in the executable or download them and load them on the fly without having to read from disk. I imagine others would find this useful too.

This PR also includes 2 small changes to ```Cargo.toml``` to add **read_buf** [feature](https://docs.rs/rustls/0.22.2/rustls/#crate-features) by default and to the ```Makefile``` to generate a C++ compatible header file using cbindgen - i cannot compile using C++ compiler with the current ```src/rustls.h```.

