### PR TITLE
`cargo fmt` inside of ffi_panic_boundary! invocations

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -178,7 +178,7 @@ impl rustls_acceptor {
         ffi_panic_boundary! {
             let acceptor: &mut Acceptor = try_mut_from_ptr!(acceptor);
             if out_accepted.is_null() {
-                return NullParameter
+                return NullParameter;
             }
             match acceptor.accept() {
                 Ok(None) => rustls_result::AcceptorNotReady,
@@ -406,7 +406,7 @@ impl rustls_accepted {
                     let wrapped = crate::connection::Connection::from_server(built);
                     set_boxed_mut_ptr(out_conn, wrapped);
                     rustls_result::Ok
-                },
+                }
                 Err(e) => map_error(e),
             }
         }

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -52,7 +52,7 @@ pub extern "C" fn rustls_certificate_get_der(
     ffi_panic_boundary! {
         let cert = try_ref_from_ptr!(cert);
         if out_der_data.is_null() || out_der_len.is_null() {
-            return NullParameter
+            return NullParameter;
         }
         let der = cert.as_ref();
         unsafe {
@@ -314,7 +314,11 @@ impl rustls_certified_key {
                 }
             };
             let certified_key = match rustls_certified_key::certified_key_build(
-                cert_chain, cert_chain_len, private_key, private_key_len) {
+                cert_chain,
+                cert_chain_len,
+                private_key,
+                private_key_len,
+            ) {
                 Ok(key) => Box::new(key),
                 Err(rr) => return rr,
             };
@@ -338,7 +342,7 @@ impl rustls_certified_key {
             let certified_key: &CertifiedKey = try_ref_from_ptr!(certified_key);
             match certified_key.cert.get(i) {
                 Some(cert) => cert as *const CertificateDer as *const _,
-                None => null()
+                None => null(),
             }
         }
     }
@@ -364,7 +368,7 @@ impl rustls_certified_key {
             let certified_key: &CertifiedKey = try_ref_from_ptr!(certified_key);
             let mut new_key = certified_key.clone();
             if !ocsp_response.is_null() {
-                let ocsp_slice = unsafe{ &*ocsp_response };
+                let ocsp_slice = unsafe { &*ocsp_response };
                 new_key.ocsp = Some(Vec::from(try_slice!(ocsp_slice.data, ocsp_slice.len)));
             } else {
                 new_key.ocsp = None;
@@ -491,7 +495,8 @@ impl rustls_root_cert_store_builder {
                 Some(b) => b,
             };
 
-            let certs_der: Result<Vec<CertificateDer>, _> = rustls_pemfile::certs(&mut Cursor::new(certs_pem)).collect();
+            let certs_der: Result<Vec<CertificateDer>, _> =
+                rustls_pemfile::certs(&mut Cursor::new(certs_pem)).collect();
             let certs_der = match certs_der {
                 Ok(vv) => vv,
                 Err(_) => return rustls_result::CertificateParseError,
@@ -552,7 +557,8 @@ impl rustls_root_cert_store_builder {
             };
 
             let mut bufreader = BufReader::new(&mut cafile);
-            let certs: Result<Vec<CertificateDer>, _> = rustls_pemfile::certs(&mut bufreader).collect();
+            let certs: Result<Vec<CertificateDer>, _> =
+                rustls_pemfile::certs(&mut bufreader).collect();
             let certs = match certs {
                 Ok(certs) => certs,
                 Err(_) => return rustls_result::Io,
@@ -711,7 +717,7 @@ impl rustls_web_pki_client_cert_verifier_builder {
     ) -> *mut rustls_web_pki_client_cert_verifier_builder {
         ffi_panic_boundary! {
             let store = try_clone_arc!(store);
-             let builder = ClientCertVerifierBuilder {
+            let builder = ClientCertVerifierBuilder {
                 root_hint_subjects: store.subjects(),
                 roots: store,
                 crls: Vec::default(),
@@ -738,22 +744,23 @@ impl rustls_web_pki_client_cert_verifier_builder {
         crl_pem_len: size_t,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
             };
 
             let crl_pem: &[u8] = try_slice!(crl_pem, crl_pem_len);
-            let crls_der: Result<Vec<CertificateRevocationListDer>, _> =  crls(&mut Cursor::new(crl_pem)).collect();
-            let crls_der = match crls_der{
+            let crls_der: Result<Vec<CertificateRevocationListDer>, _> =
+                crls(&mut Cursor::new(crl_pem)).collect();
+            let crls_der = match crls_der {
                 Ok(vv) => vv,
                 Err(_) => return rustls_result::CertificateRevocationListParseError,
             };
             if crls_der.is_empty() {
                 return rustls_result::CertificateRevocationListParseError;
             }
-
 
             client_verifier_builder.crls.extend(crls_der);
             rustls_result::Ok
@@ -768,7 +775,8 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -789,7 +797,8 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -807,7 +816,8 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -829,7 +839,8 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -877,18 +888,21 @@ impl rustls_web_pki_client_cert_verifier_builder {
         verifier_out: *mut *mut rustls_client_cert_verifier,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let client_verifier_builder = try_take!(client_verifier_builder);
 
             let mut builder = WebPkiClientVerifier::builder(client_verifier_builder.roots)
                 .with_crls(client_verifier_builder.crls);
             match client_verifier_builder.revocation_depth {
-                RevocationCheckDepth::EndEntity => builder = builder.only_check_end_entity_revocation(),
-                RevocationCheckDepth::Chain => {},
+                RevocationCheckDepth::EndEntity => {
+                    builder = builder.only_check_end_entity_revocation()
+                }
+                RevocationCheckDepth::Chain => {}
             }
             match client_verifier_builder.revocation_policy {
                 UnknownStatusPolicy::Allow => builder = builder.allow_unknown_revocation_status(),
-                UnknownStatusPolicy::Deny => {},
+                UnknownStatusPolicy::Deny => {}
             }
             if client_verifier_builder.allow_unauthenticated {
                 builder = builder.allow_unauthenticated();
@@ -896,7 +910,8 @@ impl rustls_web_pki_client_cert_verifier_builder {
             if client_verifier_builder.root_hint_subjects.is_empty() {
                 builder = builder.clear_root_hint_subjects();
             } else {
-                builder = builder.add_root_hint_subjects(client_verifier_builder.root_hint_subjects);
+                builder =
+                    builder.add_root_hint_subjects(client_verifier_builder.root_hint_subjects);
             }
 
             let verifier = match builder.build() {
@@ -977,7 +992,7 @@ impl ServerCertVerifierBuilder {
                 roots: store,
                 crls: Vec::default(),
                 revocation_depth: RevocationCheckDepth::Chain,
-                revocation_policy: UnknownStatusPolicy::Deny
+                revocation_policy: UnknownStatusPolicy::Deny,
             };
             to_boxed_mut_ptr(Some(builder))
         }
@@ -998,15 +1013,17 @@ impl ServerCertVerifierBuilder {
         crl_pem_len: size_t,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let server_verifier_builder = match server_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
             };
 
             let crl_pem: &[u8] = try_slice!(crl_pem, crl_pem_len);
-            let crls_der: Result<Vec<CertificateRevocationListDer>, _> =  crls(&mut Cursor::new(crl_pem)).collect();
-            let crls_der = match crls_der{
+            let crls_der: Result<Vec<CertificateRevocationListDer>, _> =
+                crls(&mut Cursor::new(crl_pem)).collect();
+            let crls_der = match crls_der {
                 Ok(vv) => vv,
                 Err(_) => return rustls_result::CertificateRevocationListParseError,
             };
@@ -1028,7 +1045,8 @@ impl ServerCertVerifierBuilder {
         builder: *mut rustls_web_pki_server_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let server_verifier_builder = match server_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -1049,7 +1067,8 @@ impl ServerCertVerifierBuilder {
         builder: *mut rustls_web_pki_server_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let server_verifier_builder = match server_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -1073,18 +1092,21 @@ impl ServerCertVerifierBuilder {
         verifier_out: *mut *mut rustls_server_cert_verifier,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> = try_mut_from_ptr!(builder);
+            let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> =
+                try_mut_from_ptr!(builder);
             let server_verifier_builder = try_take!(server_verifier_builder);
 
             let mut builder = WebPkiServerVerifier::builder(server_verifier_builder.roots)
                 .with_crls(server_verifier_builder.crls);
             match server_verifier_builder.revocation_depth {
-                RevocationCheckDepth::EndEntity => builder = builder.only_check_end_entity_revocation(),
-                RevocationCheckDepth::Chain => {},
+                RevocationCheckDepth::EndEntity => {
+                    builder = builder.only_check_end_entity_revocation()
+                }
+                RevocationCheckDepth::Chain => {}
             }
             match server_verifier_builder.revocation_policy {
                 UnknownStatusPolicy::Allow => builder = builder.allow_unknown_revocation_status(),
-                UnknownStatusPolicy::Deny => {},
+                UnknownStatusPolicy::Deny => {}
             }
 
             let verifier = match builder.build() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -154,7 +154,8 @@ impl rustls_client_config_builder {
         builder_out: *mut *mut rustls_client_config_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let cipher_suites: &[*const rustls_supported_ciphersuite] = try_slice!(cipher_suites, cipher_suites_len);
+            let cipher_suites: &[*const rustls_supported_ciphersuite] =
+                try_slice!(cipher_suites, cipher_suites_len);
             let mut cs_vec: Vec<SupportedCipherSuite> = Vec::new();
             for &cs in cipher_suites.iter() {
                 let cs = try_ref_from_ptr!(cs);
@@ -175,7 +176,7 @@ impl rustls_client_config_builder {
                 }
             }
 
-            let provider = rustls::crypto::CryptoProvider{
+            let provider = rustls::crypto::CryptoProvider {
                 cipher_suites: cs_vec,
                 ..rustls::crypto::ring::default_provider()
             };
@@ -366,7 +367,7 @@ impl rustls_client_config_builder {
                 None => return rustls_result::InvalidParameter,
             };
 
-            let verifier: Verifier = Verifier{callback};
+            let verifier: Verifier = Verifier { callback };
             config_builder.verifier = Arc::new(verifier);
             rustls_result::Ok
         }
@@ -451,7 +452,8 @@ impl rustls_client_config_builder {
     ) -> rustls_result {
         ffi_panic_boundary! {
             let config: &mut ClientConfigBuilder = try_mut_from_ptr!(builder);
-            let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
+            let keys_ptrs: &[*const rustls_certified_key] =
+                try_slice!(certified_keys, certified_keys_len);
             let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
             for &key_ptr in keys_ptrs {
                 let certified_key: Arc<CertifiedKey> = try_clone_arc!(key_ptr);
@@ -497,7 +499,10 @@ impl rustls_client_config_builder {
     ) -> *const rustls_client_config {
         ffi_panic_boundary! {
             let builder: Box<ClientConfigBuilder> = try_box_from_ptr!(builder);
-            let config = builder.base.dangerous().with_custom_certificate_verifier(builder.verifier);
+            let config = builder
+                .base
+                .dangerous()
+                .with_custom_certificate_verifier(builder.verifier);
             let mut config = match builder.cert_resolver {
                 Some(r) => config.with_client_cert_resolver(r),
                 None => config.with_no_client_auth(),
@@ -552,29 +557,29 @@ impl rustls_client_config {
         conn_out: *mut *mut rustls_connection,
     ) -> rustls_result {
         ffi_panic_boundary! {
-        let server_name: &CStr = unsafe {
-            if server_name.is_null() {
-                return NullParameter;
-            }
-            CStr::from_ptr(server_name)
-        };
-        let config: Arc<ClientConfig> = try_clone_arc!(config);
-        let server_name: &str = match server_name.to_str() {
-            Ok(s) => s,
-            Err(std::str::Utf8Error { .. }) => return rustls_result::InvalidDnsNameError,
-        };
-        let server_name: pki_types::ServerName = match server_name.try_into() {
-            Ok(sn) => sn,
-            Err(_) => return rustls_result::InvalidDnsNameError,
-        };
-        let client = ClientConnection::new(config, server_name).unwrap();
+            let server_name: &CStr = unsafe {
+                if server_name.is_null() {
+                    return NullParameter;
+                }
+                CStr::from_ptr(server_name)
+            };
+            let config: Arc<ClientConfig> = try_clone_arc!(config);
+            let server_name: &str = match server_name.to_str() {
+                Ok(s) => s,
+                Err(std::str::Utf8Error { .. }) => return rustls_result::InvalidDnsNameError,
+            };
+            let server_name: pki_types::ServerName = match server_name.try_into() {
+                Ok(sn) => sn,
+                Err(_) => return rustls_result::InvalidDnsNameError,
+            };
+            let client = ClientConnection::new(config, server_name).unwrap();
 
-        // We've succeeded. Put the client on the heap, and transfer ownership
-        // to the caller. After this point, we must return rustls_result::Ok so the
-        // caller knows it is responsible for this memory.
-        let c = Connection::from_client(client);
-        set_boxed_mut_ptr(conn_out, c);
-        rustls_result::Ok
+            // We've succeeded. Put the client on the heap, and transfer ownership
+            // to the caller. After this point, we must return rustls_result::Ok so the
+            // caller knows it is responsible for this memory.
+            let c = Connection::from_client(client);
+            set_boxed_mut_ptr(conn_out, c);
+            rustls_result::Ok
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -148,7 +148,7 @@ impl rustls_connection {
         ffi_panic_boundary! {
             let conn: &mut Connection = try_mut_from_ptr!(conn);
             if out_n.is_null() {
-                return rustls_io_result(EINVAL)
+                return rustls_io_result(EINVAL);
             }
             let callback: ReadCallback = try_callback!(callback);
 
@@ -185,7 +185,7 @@ impl rustls_connection {
         ffi_panic_boundary! {
             let conn: &mut Connection = try_mut_from_ptr!(conn);
             if out_n.is_null() {
-                return rustls_io_result(EINVAL)
+                return rustls_io_result(EINVAL);
             }
             let callback: WriteCallback = try_callback!(callback);
 
@@ -222,7 +222,7 @@ impl rustls_connection {
         ffi_panic_boundary! {
             let conn: &mut Connection = try_mut_from_ptr!(conn);
             if out_n.is_null() {
-                return rustls_io_result(EINVAL)
+                return rustls_io_result(EINVAL);
             }
             let callback: VectoredWriteCallback = try_callback!(callback);
 
@@ -332,7 +332,7 @@ impl rustls_connection {
             let conn: &Connection = try_ref_from_ptr!(conn);
             match conn.peer_certificates().and_then(|c| c.get(i)) {
                 Some(cert) => cert as *const CertificateDer as *const _,
-                None => null()
+                None => null(),
             }
         }
     }
@@ -357,7 +357,7 @@ impl rustls_connection {
         ffi_panic_boundary! {
             let conn: &Connection = try_ref_from_ptr!(conn);
             if protocol_out.is_null() || protocol_out_len.is_null() {
-                return
+                return;
             }
             match conn.alpn_protocol() {
                 Some(p) => unsafe {
@@ -367,7 +367,7 @@ impl rustls_connection {
                 None => unsafe {
                     *protocol_out = null();
                     *protocol_out_len = 0;
-                }
+                },
             }
         }
     }
@@ -434,7 +434,7 @@ impl rustls_connection {
             let conn: &mut Connection = try_mut_from_ptr!(conn);
             let write_buf: &[u8] = try_slice!(buf, count);
             if out_n.is_null() {
-                return NullParameter
+                return NullParameter;
             }
             let n_written: usize = match conn.writer().write(write_buf) {
                 Ok(n) => n,
@@ -469,22 +469,24 @@ impl rustls_connection {
         ffi_panic_boundary! {
             let conn: &mut Connection = try_mut_from_ptr!(conn);
             if buf.is_null() {
-                return NullParameter
+                return NullParameter;
             }
             if out_n.is_null() {
-                return NullParameter
+                return NullParameter;
             }
 
             // Safety: the memory pointed at by buf must be initialized
             // (required by documentation of this function).
-            let read_buf: &mut [u8] = unsafe {
-                slice::from_raw_parts_mut(buf, count)
-            };
+            let read_buf: &mut [u8] = unsafe { slice::from_raw_parts_mut(buf, count) };
 
             let n_read: usize = match conn.reader().read(read_buf) {
                 Ok(n) => n,
-                Err(e) if e.kind() == ErrorKind::UnexpectedEof => return rustls_result::UnexpectedEof,
-                Err(e) if e.kind() == ErrorKind::WouldBlock => return rustls_result::PlaintextEmpty,
+                Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
+                    return rustls_result::UnexpectedEof
+                }
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    return rustls_result::PlaintextEmpty
+                }
                 Err(_) => return rustls_result::Io,
             };
             unsafe {
@@ -518,18 +520,21 @@ impl rustls_connection {
         ffi_panic_boundary! {
             let conn: &mut Connection = try_mut_from_ptr!(conn);
             if buf.is_null() || out_n.is_null() {
-                return NullParameter
+                return NullParameter;
             }
-            let read_buf: &mut [std::mem::MaybeUninit<u8>] = unsafe {
-                slice::from_raw_parts_mut(buf, count)
-            };
+            let read_buf: &mut [std::mem::MaybeUninit<u8>] =
+                unsafe { slice::from_raw_parts_mut(buf, count) };
 
             let mut read_buf: std::io::BorrowedBuf<'_> = read_buf.into();
 
             let n_read: usize = match conn.reader().read_buf(read_buf.unfilled()) {
                 Ok(()) => read_buf.filled().len(),
-                Err(e) if e.kind() == ErrorKind::UnexpectedEof => return rustls_result::UnexpectedEof,
-                Err(e) if e.kind() == ErrorKind::WouldBlock => return rustls_result::PlaintextEmpty,
+                Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
+                    return rustls_result::UnexpectedEof
+                }
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    return rustls_result::PlaintextEmpty
+                }
                 Err(_) => return rustls_result::Io,
             };
             unsafe {

--- a/src/error.rs
+++ b/src/error.rs
@@ -203,12 +203,12 @@ impl rustls_result {
     ) {
         ffi_panic_boundary! {
             if buf.is_null() {
-                return
+                return;
             }
             if out_n.is_null() {
-                return
+                return;
             }
-            let error_str =  rustls_result::from(result).to_string();
+            let error_str = rustls_result::from(result).to_string();
             let out_len: usize = min(len - 1, error_str.len());
             unsafe {
                 std::ptr::copy_nonoverlapping(error_str.as_ptr() as *mut c_char, buf, out_len);

--- a/src/server.rs
+++ b/src/server.rs
@@ -77,13 +77,13 @@ impl rustls_server_config_builder {
     pub extern "C" fn rustls_server_config_builder_new() -> *mut rustls_server_config_builder {
         ffi_panic_boundary! {
             let builder = ServerConfigBuilder {
-                           base: rustls::ServerConfig::builder(),
-                           verifier: WebPkiClientVerifier::no_client_auth(),
-                           cert_resolver: None,
-                           session_storage: None,
-                           alpn_protocols: vec![],
-                           ignore_client_order: None,
-                       };
+                base: rustls::ServerConfig::builder(),
+                verifier: WebPkiClientVerifier::no_client_auth(),
+                cert_resolver: None,
+                session_storage: None,
+                alpn_protocols: vec![],
+                ignore_client_order: None,
+            };
             to_boxed_mut_ptr(builder)
         }
     }
@@ -111,7 +111,8 @@ impl rustls_server_config_builder {
         builder_out: *mut *mut rustls_server_config_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let cipher_suites: &[*const rustls_supported_ciphersuite] = try_slice!(cipher_suites, cipher_suites_len);
+            let cipher_suites: &[*const rustls_supported_ciphersuite] =
+                try_slice!(cipher_suites, cipher_suites_len);
             let mut cs_vec: Vec<SupportedCipherSuite> = Vec::new();
             for &cs in cipher_suites.iter() {
                 let cs = try_ref_from_ptr!(cs);
@@ -132,7 +133,7 @@ impl rustls_server_config_builder {
                 }
             }
 
-            let provider = rustls::crypto::CryptoProvider{
+            let provider = rustls::crypto::CryptoProvider {
                 cipher_suites: cs_vec,
                 ..rustls::crypto::ring::default_provider()
             };
@@ -247,13 +248,14 @@ impl rustls_server_config_builder {
         certified_keys_len: size_t,
     ) -> rustls_result {
         ffi_panic_boundary! {
-        let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
-        let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
-        let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
-        for &key_ptr in keys_ptrs {
-            let certified_key: Arc<CertifiedKey> = try_clone_arc!(key_ptr);
-            keys.push(certified_key);
-        }
+            let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
+            let keys_ptrs: &[*const rustls_certified_key] =
+                try_slice!(certified_keys, certified_keys_len);
+            let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
+            for &key_ptr in keys_ptrs {
+                let certified_key: Arc<CertifiedKey> = try_clone_arc!(key_ptr);
+                keys.push(certified_key);
+            }
             builder.cert_resolver = Some(Arc::new(ResolvesServerCertFromChoices::new(&keys)));
             rustls_result::Ok
         }
@@ -344,10 +346,10 @@ pub extern "C" fn rustls_server_connection_get_server_name(
     ffi_panic_boundary! {
         let conn: &Connection = try_ref_from_ptr!(conn);
         if buf.is_null() {
-            return NullParameter
+            return NullParameter;
         }
         if out_n.is_null() {
-            return NullParameter
+            return NullParameter;
         }
         let server_connection = match conn.as_server() {
             Some(s) => s,
@@ -359,14 +361,12 @@ pub extern "C" fn rustls_server_connection_get_server_name(
                 unsafe {
                     *out_n = 0;
                 }
-                return rustls_result::Ok
-            },
+                return rustls_result::Ok;
+            }
         };
         let len: usize = sni_hostname.len();
         if len > count {
-            unsafe {
-                *out_n = 0
-            }
+            unsafe { *out_n = 0 }
             return rustls_result::InsufficientSize;
         }
         unsafe {
@@ -561,9 +561,7 @@ impl rustls_server_config_builder {
                 None => return rustls_result::NullParameter,
             };
             let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
-            builder.cert_resolver = Some(Arc::new(ClientHelloResolver::new(
-                callback
-            )));
+            builder.cert_resolver = Some(Arc::new(ClientHelloResolver::new(callback)));
             rustls_result::Ok
         }
     }
@@ -597,11 +595,15 @@ pub extern "C" fn rustls_client_hello_select_certified_key(
 ) -> rustls_result {
     ffi_panic_boundary! {
         let hello = try_ref_from_ptr!(hello);
-        let schemes: Vec<SignatureScheme> = sigschemes(try_slice!(hello.signature_schemes.data, hello.signature_schemes.len));
+        let schemes: Vec<SignatureScheme> = sigschemes(try_slice!(
+            hello.signature_schemes.data,
+            hello.signature_schemes.len
+        ));
         if out_key.is_null() {
-            return NullParameter
+            return NullParameter;
         }
-        let keys_ptrs: &[*const rustls_certified_key] = try_slice!(certified_keys, certified_keys_len);
+        let keys_ptrs: &[*const rustls_certified_key] =
+            try_slice!(certified_keys, certified_keys_len);
         for &key_ptr in keys_ptrs {
             let key_ref: &CertifiedKey = try_ref_from_ptr!(key_ptr);
             if key_ref.key.choose_scheme(&schemes).is_some() {
@@ -639,9 +641,7 @@ impl rustls_server_config_builder {
                 None => return rustls_result::NullParameter,
             };
             let builder: &mut ServerConfigBuilder = try_mut_from_ptr!(builder);
-            builder.session_storage = Some(Arc::new(SessionStoreBroker::new(
-                get_cb, put_cb
-            )));
+            builder.session_storage = Some(Arc::new(SessionStoreBroker::new(get_cb, put_cb)));
             rustls_result::Ok
         }
     }


### PR DESCRIPTION
This is a one-off, because I don't want to make CI require it (with the knock-on that people have to run random scripts wrapping `cargo fmt` in their workflow).

But even as a one-off I think it's a strict improvement?

The script is:

```shell
sed -i -e 's/ffi_panic_boundary! {/if true {/g' src/*.rs
cargo fmt
sed -i -e 's/if true {/ffi_panic_boundary! {/g' src/*.rs
```