### PR TITLE
tests: fix maybe-uninitialized warning

### DIFF
--- a/tests/client.c
+++ b/tests/client.c
@@ -44,7 +44,7 @@ make_conn(const char *hostname, const char *port)
     goto cleanup;
   }
 
-  int connect_result;
+  int connect_result = -1;
   for(int attempts = 0; attempts < 10; attempts++) {
     LOG("connect attempt %d", attempts);
     sockfd = socket(getaddrinfo_output->ai_family,


### PR DESCRIPTION
I noticed there was a build warning in the test code while checking if there are any required updates to support building with rustls 0.23.0-alpha.0 (_there aren't_).

```
[daniel@blanc:~/Code/Rust/rustls-ffi]$ make test
gcc -o target/client.o -c tests/client.c -Werror -Wall -Wextra -Wpedantic -g -I src/ -O3
tests/client.c: In function ‘make_conn’:
tests/client.c:70:5: error: ‘connect_result’ may be used uninitialized [-Werror=maybe-uninitialized]
   70 |   if(connect_result < 0) {
      |     ^
tests/client.c:47:7: note: ‘connect_result’ was declared here
   47 |   int connect_result;
      |       ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:47: target/client.o] Error 1
```
