### PR TITLE
lib: fix false positive dead_code trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,7 @@ pub(crate) struct OwnershipRef;
 /// that is provided to C code, either a [`OwnershipBox`] when it is a pointer to a `Box<_>`,
 /// a [`OwnershipArc`] when it is a pointer to an `Arc<_>`, or a [`OwnershipRef`] when it is a
 /// pointer to a `&_`.
+#[allow(dead_code)] // This trait is only used as a marker.
 trait OwnershipMarker {}
 
 impl OwnershipMarker for OwnershipBox {}


### PR DESCRIPTION
The `OwnershipMarker` trait is used as an associated type in other traits, serving as a marker. [Clippy nightly thinks it is unused](https://github.com/cpu/rustls-ffi/actions/runs/7901109531/job/21564022185). This commit adds an allow dead_code annotation to fix that finding.

Possible this should be raised upstream but for now let's fix our build with the annotation.