### PR TITLE
Prepare 0.13.0 release with Rustls 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.13.0 (XXXX-XX-XX)
+
+This release updates to [Rustls 0.23.1] and continues to use `*ring*` as the
+only cryptographic provider.
+
+[Rustls 0.23.1]: https://github.com/rustls/rustls/releases/tag/v%2F0.23.1
+
+### Added
+
+* A new `rustls_accepted_alert` type is added. Calling
+  `rustls_accepted_alert_bytes` on this type produces TLS data to write
+  in the case where a server acceptor encountered an error accepting a client.
+  The returned TLS data should be written to the connection before freeing 
+  the `rustls_accepted_alert` by calling `rustls_accepted_alert_write_tls` with
+  a `rustls_write_callback` implementation.
+
+## Changed
+
+* The `rustls_acceptor_accept` and `rustls_accepted_into_connection` API
+  functions now require an extra `rustls_accepted_alert` out parameter. This
+  parameter will only be set when an error occurs accepting a client connection
+  and can be used to write any generated alerts to the connection to signal
+  the accept error to the peer.
+
 ## 0.12.1 (2024-03-21)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "regex"
 version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,11 +112,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc238b76c51bbc449c55ffbc39d03772a057cc8cf783c49d4af4c2537b74a8b"
+checksum = "e153fc89608e0515660ca656fd7f2fa05ca6690f3fd6ad1b0a46e24a8130d838"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -150,9 +156,9 @@ checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ capi = []
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.22", features = [ "ring" ]}
+rustls = { version = "0.23.1", default-features = false, features = [ "ring", "std", "tls12" ]}
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
-webpki = { package = "rustls-webpki", version = "0.102.0", features = ["std"] }
+webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [ "ring", "std" ] }
 libc = "0.2"
 rustls-pemfile = "2"
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README-crates.io.md"

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::{env, fs, path::PathBuf};
 
 // Keep in sync with Cargo.toml.
-const RUSTLS_CRATE_VERSION: &str = "0.22";
+const RUSTLS_CRATE_VERSION: &str = "0.23.1";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
 use libc::{c_void, size_t, EINVAL, EIO};
-use rustls::server::{Accepted, Acceptor};
+use rustls::server::{Accepted, AcceptedAlert, Acceptor};
 use rustls::ServerConfig;
 
 use crate::connection::rustls_connection;
 use crate::error::{map_error, rustls_io_result};
-use crate::io::{rustls_read_callback, CallbackReader, ReadCallback};
+use crate::io::{
+    rustls_read_callback, rustls_write_callback, CallbackReader, CallbackWriter, ReadCallback,
+};
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::server::rustls_server_config;
 use crate::{
@@ -148,7 +150,15 @@ impl rustls_acceptor {
     /// out_accepted: An output parameter. The pointed-to pointer will be set
     ///   to a new rustls_accepted only when the function returns
     ///   RUSTLS_RESULT_OK. The memory is owned by the caller and must eventually
-    ///   be freed.
+    ///   be freed
+    /// out_alert: An output parameter. The pointed-to pointer will be set
+    ///   to a new rustls_accepted_alert only when the function returns
+    ///   a non-OK result. The memory is owned by the caller and must eventually
+    ///   be freed with rustls_accepted_alert_free. The caller should call
+    ///   rustls_accepted_alert_write_tls to write the alert bytes to the TLS
+    ///   connection before freeing the rustls_accepted_alert.
+    ///
+    /// At most one of out_accepted or out_alert will be set.
     ///
     /// Returns:
     ///
@@ -173,19 +183,26 @@ impl rustls_acceptor {
     pub extern "C" fn rustls_acceptor_accept(
         acceptor: *mut rustls_acceptor,
         out_accepted: *mut *mut rustls_accepted,
+        out_alert: *mut *mut rustls_accepted_alert,
     ) -> rustls_result {
         ffi_panic_boundary! {
             let acceptor: &mut Acceptor = try_mut_from_ptr!(acceptor);
             if out_accepted.is_null() {
                 return NullParameter;
             }
+            if out_alert.is_null() {
+                return NullParameter;
+            }
             match acceptor.accept() {
                 Ok(None) => rustls_result::AcceptorNotReady,
-                Err(e) => map_error(e),
                 Ok(Some(accepted)) => {
                     set_boxed_mut_ptr(out_accepted, Some(accepted));
                     rustls_result::Ok
                 }
+                Err((e, accepted_alert)) => {
+                    set_boxed_mut_ptr(out_alert, accepted_alert);
+                    map_error(e)
+                },
             }
         }
     }
@@ -266,7 +283,7 @@ impl rustls_accepted {
             let hello = accepted.client_hello();
             let signature_schemes = hello.signature_schemes();
             match signature_schemes.get(i) {
-                Some(s) => s.get_u16(),
+                Some(s) => u16::from(*s),
                 None => 0,
             }
         }
@@ -304,7 +321,7 @@ impl rustls_accepted {
             let hello = accepted.client_hello();
             let cipher_suites = hello.cipher_suites();
             match cipher_suites.get(i) {
-                Some(cs) => cs.get_u16(),
+                Some(cs) => u16::from(*cs),
                 None => 0,
             }
         }
@@ -365,6 +382,14 @@ impl rustls_accepted {
     /// out_conn: An output parameter. The pointed-to pointer will be set
     ///   to a new rustls_connection only when the function returns
     ///   RUSTLS_RESULT_OK.
+    /// out_alert: An output parameter. The pointed-to pointer will be set
+    ///   to a new rustls_accepted_alert when, and only when, the function returns
+    ///   a non-OK result. The memory is owned by the caller and must eventually
+    ///   be freed with rustls_accepted_alert_free. The caller should call
+    ///   rustls_accepted_alert_write_tls to write the alert bytes to
+    ///   the TLS connection before freeing the rustls_accepted_alert.
+    ///
+    /// At most one of out_conn or out_alert will be set.
     ///
     /// Returns:
     ///
@@ -395,18 +420,25 @@ impl rustls_accepted {
         accepted: *mut rustls_accepted,
         config: *const rustls_server_config,
         out_conn: *mut *mut rustls_connection,
+        out_alert: *mut *mut rustls_accepted_alert,
     ) -> rustls_result {
         ffi_panic_boundary! {
             let accepted: &mut Option<Accepted> = try_mut_from_ptr!(accepted);
             let accepted = try_take!(accepted);
             let config: Arc<ServerConfig> = try_clone_arc!(config);
+            if out_alert.is_null() {
+                return NullParameter;
+            }
             match accepted.into_connection(config) {
                 Ok(built) => {
                     let wrapped = crate::connection::Connection::from_server(built);
                     set_boxed_mut_ptr(out_conn, wrapped);
                     rustls_result::Ok
                 }
-                Err(e) => map_error(e),
+                Err((e, accepted_alert)) => {
+                    set_boxed_mut_ptr(out_alert, accepted_alert);
+                    map_error(e)
+                },
             }
         }
     }
@@ -426,6 +458,66 @@ impl rustls_accepted {
     }
 }
 
+/// Represents a TLS alert resulting from accepting a client.
+pub struct rustls_accepted_alert {
+    _private: [u8; 0],
+}
+
+impl Castable for rustls_accepted_alert {
+    type Ownership = OwnershipBox;
+    type RustType = AcceptedAlert;
+}
+
+impl rustls_accepted_alert {
+    /// Write some TLS bytes (an alert) to the network. The actual network I/O is
+    /// performed by `callback`, which you provide. Rustls will invoke your callback with a
+    /// suitable buffer containing TLS bytes to send. You don't have to write them
+    /// all, just as many as you can in one syscall.
+    /// The `userdata` parameter is passed through directly to `callback`. Note that
+    /// this is distinct from the `userdata` parameter set with
+    /// `rustls_connection_set_userdata`.
+    /// Returns 0 for success, or an errno value on error. Passes through return values
+    /// from callback. See [`rustls_write_callback`] or [`AcceptedAlert`] for
+    /// more details.
+    #[no_mangle]
+    pub extern "C" fn rustls_accepted_alert_write_tls(
+        accepted_alert: *mut rustls_accepted_alert,
+        callback: rustls_write_callback,
+        userdata: *mut c_void,
+        out_n: *mut size_t,
+    ) -> rustls_io_result {
+        ffi_panic_boundary! {
+            if out_n.is_null() {
+                return rustls_io_result(EINVAL);
+            }
+            let accepted_alert: &mut AcceptedAlert = try_mut_from_ptr!(accepted_alert);
+            let mut writer = CallbackWriter { callback: try_callback!(callback), userdata };
+            let n_written: usize = match accepted_alert.write(&mut writer) {
+                Ok(n) => n,
+                Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
+            };
+            unsafe {
+                *out_n = n_written;
+            }
+            rustls_io_result(0)
+        }
+    }
+
+    /// Free a rustls_accepted_alert.
+    ///
+    /// Parameters:
+    ///
+    /// accepted_alert: The rustls_accepted_alert to free.
+    ///
+    /// Calling with NULL is fine. Must not be called twice with the same value.
+    #[no_mangle]
+    pub extern "C" fn rustls_accepted_alert_free(accepted_alert: *mut rustls_accepted_alert) {
+        ffi_panic_boundary! {
+            free_box(accepted_alert);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::cmp::min;
@@ -434,6 +526,9 @@ mod tests {
     use std::slice;
 
     use libc::c_char;
+    use rustls::internal::msgs::codec::Codec;
+    use rustls::internal::msgs::enums::AlertLevel;
+    use rustls::{AlertDescription, ContentType, ProtocolVersion};
 
     use crate::cipher::rustls_certified_key;
     use crate::client::{rustls_client_config, rustls_client_config_builder};
@@ -487,6 +582,7 @@ mod tests {
         let acceptor = make_acceptor();
 
         let mut accepted: *mut rustls_accepted = null_mut();
+        let mut accepted_alert: *mut rustls_accepted_alert = null_mut();
         let mut n: usize = 0;
         let mut data = VecDeque::new();
         for _ in 0..1024 {
@@ -502,9 +598,40 @@ mod tests {
         assert_eq!(data.len(), 0);
         assert_eq!(n, 1024);
 
-        let result = rustls_acceptor::rustls_acceptor_accept(acceptor, &mut accepted);
+        let result =
+            rustls_acceptor::rustls_acceptor_accept(acceptor, &mut accepted, &mut accepted_alert);
         assert_eq!(result, rustls_result::MessageInvalidContentType);
         assert_eq!(accepted, null_mut());
+        assert_ne!(accepted_alert, null_mut());
+
+        unsafe extern "C" fn expected_alert_callback(
+            _userdata: *mut c_void,
+            buf: *const u8,
+            n: size_t,
+            _out_n: *mut size_t,
+        ) -> rustls_io_result {
+            let mut expected = vec![ContentType::Alert.into()];
+            ProtocolVersion::TLSv1_2.encode(&mut expected);
+            (2_u16).encode(&mut expected);
+            AlertLevel::Fatal.encode(&mut expected);
+            AlertDescription::DecodeError.encode(&mut expected);
+
+            let alert_bytes = slice::from_raw_parts(buf, n);
+            assert_eq!(alert_bytes, &expected);
+            rustls_io_result(0)
+        }
+
+        // We expect that an accepted alert was generated, and that its bytes match a fatal level
+        // TLS alert indicating a decode error.
+        let res = rustls_accepted_alert::rustls_accepted_alert_write_tls(
+            accepted_alert,
+            Some(expected_alert_callback),
+            null_mut(),
+            &mut n,
+        );
+        assert_eq!(res, rustls_io_result(0));
+
+        rustls_accepted_alert::rustls_accepted_alert_free(accepted_alert);
         rustls_acceptor::rustls_acceptor_free(acceptor);
     }
 
@@ -582,6 +709,7 @@ mod tests {
         let acceptor = make_acceptor();
 
         let mut accepted: *mut rustls_accepted = null_mut();
+        let mut accepted_alert: *mut rustls_accepted_alert = null_mut();
         let mut n: usize = 0;
         let mut data = client_hello_bytes();
         let data_len = data.len();
@@ -596,9 +724,11 @@ mod tests {
         assert_eq!(data.len(), 0);
         assert_eq!(n, data_len);
 
-        let result = rustls_acceptor::rustls_acceptor_accept(acceptor, &mut accepted);
+        let result =
+            rustls_acceptor::rustls_acceptor_accept(acceptor, &mut accepted, &mut accepted_alert);
         assert_eq!(result, rustls_result::Ok);
         assert_ne!(accepted, null_mut());
+        assert_eq!(accepted_alert, null_mut());
 
         let sni = rustls_accepted::rustls_accepted_server_name(accepted);
         let sni_as_slice = unsafe { std::slice::from_raw_parts(sni.data as *const u8, sni.len) };
@@ -638,13 +768,19 @@ mod tests {
 
         let server_config = make_server_config();
         let mut conn: *mut rustls_connection = null_mut();
-        let result =
-            rustls_accepted::rustls_accepted_into_connection(accepted, server_config, &mut conn);
+        let result = rustls_accepted::rustls_accepted_into_connection(
+            accepted,
+            server_config,
+            &mut conn,
+            &mut accepted_alert,
+        );
         assert_eq!(result, rustls_result::Ok);
+        assert_eq!(accepted_alert, null_mut());
         assert!(!rustls_connection::rustls_connection_wants_read(conn));
         assert!(rustls_connection::rustls_connection_wants_write(conn));
         assert!(rustls_connection::rustls_connection_is_handshaking(conn));
 
+        rustls_accepted_alert::rustls_accepted_alert_free(accepted_alert);
         rustls_acceptor::rustls_acceptor_free(acceptor);
         rustls_accepted::rustls_accepted_free(accepted);
         rustls_connection::rustls_connection_free(conn);

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -426,6 +426,9 @@ impl rustls_accepted {
             let accepted: &mut Option<Accepted> = try_mut_from_ptr!(accepted);
             let accepted = try_take!(accepted);
             let config: Arc<ServerConfig> = try_clone_arc!(config);
+            if out_conn.is_null() {
+                return NullParameter;
+            }
             if out_alert.is_null() {
                 return NullParameter;
             }

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -81,12 +81,13 @@ impl rustls_supported_ciphersuite {
         supported_ciphersuite: *const rustls_supported_ciphersuite,
     ) -> u16 {
         let supported_ciphersuite = try_ref_from_ptr!(supported_ciphersuite);
-        match supported_ciphersuite {
-            rustls::SupportedCipherSuite::Tls12(sc) => &sc.common,
-            rustls::SupportedCipherSuite::Tls13(sc) => &sc.common,
-        }
-        .suite
-        .get_u16()
+        u16::from(
+            match supported_ciphersuite {
+                rustls::SupportedCipherSuite::Tls12(sc) => &sc.common,
+                rustls::SupportedCipherSuite::Tls13(sc) => &sc.common,
+            }
+            .suite,
+        )
     }
 }
 
@@ -890,7 +891,10 @@ impl rustls_web_pki_client_cert_verifier_builder {
                 try_mut_from_ptr!(builder);
             let client_verifier_builder = try_take!(client_verifier_builder);
 
-            let mut builder = WebPkiClientVerifier::builder(client_verifier_builder.roots)
+            let mut builder = WebPkiClientVerifier::builder_with_provider(
+                    client_verifier_builder.roots,
+                    rustls::crypto::ring::default_provider().into(),
+                )
                 .with_crls(client_verifier_builder.crls);
             match client_verifier_builder.revocation_depth {
                 RevocationCheckDepth::EndEntity => {
@@ -1094,7 +1098,10 @@ impl ServerCertVerifierBuilder {
                 try_mut_from_ptr!(builder);
             let server_verifier_builder = try_take!(server_verifier_builder);
 
-            let mut builder = WebPkiServerVerifier::builder(server_verifier_builder.roots)
+            let mut builder = WebPkiServerVerifier::builder_with_provider(
+                    server_verifier_builder.roots,
+                    rustls::crypto::ring::default_provider().into(),
+                )
                 .with_crls(server_verifier_builder.crls);
             match server_verifier_builder.revocation_depth {
                 RevocationCheckDepth::EndEntity => {

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -887,6 +887,9 @@ impl rustls_web_pki_client_cert_verifier_builder {
         verifier_out: *mut *mut rustls_client_cert_verifier,
     ) -> rustls_result {
         ffi_panic_boundary! {
+            if verifier_out.is_null() {
+                return NullParameter;
+            }
             let client_verifier_builder: &mut Option<ClientCertVerifierBuilder> =
                 try_mut_from_ptr!(builder);
             let client_verifier_builder = try_take!(client_verifier_builder);
@@ -1094,6 +1097,9 @@ impl ServerCertVerifierBuilder {
         verifier_out: *mut *mut rustls_server_cert_verifier,
     ) -> rustls_result {
         ffi_panic_boundary! {
+            if verifier_out.is_null() {
+                return NullParameter;
+            }
             let server_verifier_builder: &mut Option<ServerCertVerifierBuilder> =
                 try_mut_from_ptr!(builder);
             let server_verifier_builder = try_take!(server_verifier_builder);

--- a/src/client.rs
+++ b/src/client.rs
@@ -117,8 +117,14 @@ impl rustls_client_config_builder {
     #[no_mangle]
     pub extern "C" fn rustls_client_config_builder_new() -> *mut rustls_client_config_builder {
         ffi_panic_boundary! {
+            // Unwrap safety: *ring* default provider always has ciphersuites compatible with the
+            // default protocol versions.
+            let base =
+                ClientConfig::builder_with_provider(rustls::crypto::ring::default_provider().into())
+                    .with_safe_default_protocol_versions()
+                    .unwrap();
             let builder = ClientConfigBuilder {
-                base: rustls::ClientConfig::builder(),
+                base,
                 verifier: Arc::new(NoneVerifier),
                 cert_resolver: None,
                 alpn_protocols: vec![],

--- a/src/client.rs
+++ b/src/client.rs
@@ -159,6 +159,9 @@ impl rustls_client_config_builder {
         builder_out: *mut *mut rustls_client_config_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
+            if builder_out.is_null() {
+                return NullParameter;
+            }
             let cipher_suites: &[*const rustls_supported_ciphersuite] =
                 try_slice!(cipher_suites, cipher_suites_len);
             let mut cs_vec: Vec<SupportedCipherSuite> = Vec::new();
@@ -562,6 +565,9 @@ impl rustls_client_config {
         conn_out: *mut *mut rustls_connection,
     ) -> rustls_result {
         ffi_panic_boundary! {
+            if conn_out.is_null() {
+                return NullParameter;
+            }
             let server_name: &CStr = unsafe {
                 if server_name.is_null() {
                     return NullParameter;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -384,7 +384,7 @@ impl rustls_connection {
         ffi_panic_boundary! {
             let conn: &Connection = try_ref_from_ptr!(conn);
             match conn.protocol_version() {
-                Some(p) => p.get_u16(),
+                Some(p) => u16::from(p),
                 _ => 0,
             }
         }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -44,7 +44,7 @@ mod tests {
     fn all_versions_arrays() {
         assert_eq!(RUSTLS_ALL_VERSIONS_LEN, ALL_VERSIONS.len());
         for (original, ffi) in ALL_VERSIONS.iter().zip(RUSTLS_ALL_VERSIONS.iter()) {
-            assert_eq!(original.version.get_u16(), *ffi);
+            assert_eq!(u16::from(original.version), *ffi);
         }
     }
 
@@ -52,7 +52,7 @@ mod tests {
     fn default_versions_arrays() {
         assert_eq!(RUSTLS_DEFAULT_VERSIONS_LEN, DEFAULT_VERSIONS.len());
         for (original, ffi) in DEFAULT_VERSIONS.iter().zip(RUSTLS_DEFAULT_VERSIONS.iter()) {
-            assert_eq!(original.version.get_u16(), *ffi);
+            assert_eq!(u16::from(original.version), *ffi);
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -49,7 +49,7 @@ impl Read for CallbackReader {
     }
 }
 
-/// A callback for rustls_connection_write_tls.
+/// A callback for rustls_connection_write_tls or rustls_accepted_alert_write_tls.
 /// An implementation of this callback should attempt to write the `n` bytes in buf
 /// to the network. If any bytes were written, the implementation should
 /// set out_n to the number of bytes stored and return 0. If there was an error,

--- a/src/server.rs
+++ b/src/server.rs
@@ -116,6 +116,9 @@ impl rustls_server_config_builder {
         builder_out: *mut *mut rustls_server_config_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
+            if builder_out.is_null() {
+                return NullParameter;
+            }
             let cipher_suites: &[*const rustls_supported_ciphersuite] =
                 try_slice!(cipher_suites, cipher_suites_len);
             let mut cs_vec: Vec<SupportedCipherSuite> = Vec::new();
@@ -318,6 +321,9 @@ impl rustls_server_config {
         conn_out: *mut *mut rustls_connection,
     ) -> rustls_result {
         ffi_panic_boundary! {
+            if conn_out.is_null() {
+                return NullParameter;
+            }
             let config: Arc<ServerConfig> = try_clone_arc!(config);
 
             let server_connection = match ServerConnection::new(config) {


### PR DESCRIPTION
Addresses upstream breaking API changes and updates associated Rustls dependencies to use the newest Rustls release.

Most notable for rustls-ffi are the changes in the `rustls_acceptor_accept` and `rustls_accepted_into_connection`
functions where a new `rustls_accepted_alert` out parameter is added.

This type wraps the upstream `AcceptedAlert` type and allows the caller to gather any to-be-written TLS data (most notably, TLS alerts) that was produced while trying to accept the client connection. The caller should handle the to-be-written alert bytes by calling `rustls_accepted_alert_write_tls` with the `rustls_accepted_alert` and a `rustls_write_callback` implementation to write the returned bytes to the connection before calling `rustls_accepted_alert_free`.


