### PR TITLE
0.12.1 prep

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install rust toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.12.1 (2024-03-21)
+
+### Added
+
+* Initial support for building with [cargo-c].
+* Experimental support for building `rustls-ffi` as a dynamic library (`cdylib`).
+
+[cargo-c]: https://github.com/lu-zero/cargo-c
+
 ## 0.12.0 (2023-12-03)
 
 This release updates to [Rustls 0.22], but does not yet expose support for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
 dependencies = [
  "base64",
  "rustls-pki-types",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.0.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README-crates.io.md"

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::sync::Arc;
 
 use libc::{c_void, size_t, EINVAL, EIO};
@@ -438,7 +437,6 @@ mod tests {
 
     use crate::cipher::rustls_certified_key;
     use crate::client::{rustls_client_config, rustls_client_config_builder};
-    use crate::connection::rustls_connection;
     use crate::server::rustls_server_config_builder;
 
     use super::*;

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -1,5 +1,4 @@
 use libc::{c_char, size_t};
-use std::convert::TryFrom;
 use std::ffi::{CStr, OsStr};
 use std::fs::File;
 use std::io::{BufReader, Cursor};
@@ -210,7 +209,6 @@ pub static RUSTLS_DEFAULT_CIPHER_SUITES_LEN: usize = unsafe { RUSTLS_DEFAULT_CIP
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::slice;
     use std::str;
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::ffi::CStr;
 use std::fmt::{Debug, Formatter};
 use std::slice;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use libc::c_void;
 use log::Level;
 

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -1,12 +1,9 @@
 use libc::{c_char, size_t};
 use std::fmt;
 use std::marker::PhantomData;
+use std::ptr::null;
 use std::slice;
 use std::str;
-use std::{
-    convert::{TryFrom, TryInto},
-    ptr::null,
-};
 
 /// A read-only view on a Rust byte slice.
 ///
@@ -249,7 +246,6 @@ fn test_rustls_str() {
 #[cfg(test)]
 mod tests {
     use crate::rslice::*;
-    use std::convert::TryInto;
 
     #[test]
     fn test_rustls_str_debug() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::ffi::c_void;
 use std::fmt::{Debug, Formatter};
 use std::ptr::null;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ IF(WIN32)
         client
         debug "${CMAKE_SOURCE_DIR}/target/debug/rustls_ffi.lib"
         optimized "${CMAKE_SOURCE_DIR}/target/release/rustls_ffi.lib"
-        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib ntdll.lib
+        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib ntdll.lib Synchronization.lib
     )
     set_property(TARGET client PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 ENDIF(WIN32)
@@ -34,7 +34,7 @@ IF(WIN32)
         server
         debug "${CMAKE_SOURCE_DIR}/target/debug/rustls_ffi.lib"
         optimized "${CMAKE_SOURCE_DIR}/target/release/rustls_ffi.lib"
-        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib ntdll.lib
+        advapi32.lib credui.lib kernel32.lib secur32.lib legacy_stdio_definitions.lib kernel32.lib advapi32.lib userenv.lib kernel32.lib kernel32.lib ws2_32.lib bcrypt.lib msvcrt.lib legacy_stdio_definitions.lib userenv.lib kernel32.lib msvcrt.lib ntdll.lib Synchronization.lib
     )
     set_property(TARGET server PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 ENDIF(WIN32)


### PR DESCRIPTION
Pulling some work out of https://github.com/rustls/rustls-ffi/pull/389 to facilitate doing a v0.12.1 release w/ cargo-c support from main ahead of a breaking release for the Rustls update (and to fix `main`'s CI).

I populated the CHANGELOG update [based on this diff](https://github.com/rustls/rustls-ffi/compare/v0.12.0...main) - I think only the cargo-c support is notable for consumers of this project.