### PR TITLE
Cargo: configure cargo-c to use vendored .h

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ regex = "1.9.6"
 [package.metadata.capi.header]
 name = "rustls"
 subdirectory = false
+generation = false # Prefer a vendored .h
 
 [package.metadata.capi.library]
 name = "rustls"
@@ -50,3 +51,6 @@ rustflags = "-Cmetadata=rustls-ffi"
 [package.metadata.capi.pkg_config]
 name = "rustls"
 filename = "rustls"
+
+[package.metadata.capi.install.include]
+asset = [{from = "src/rustls.h", to = "" }]


### PR DESCRIPTION
Presently we pre-generate the rustls.h header file using `cbindgen`, commit the result to `src/rustls.h`, and check that the generated result matches the checked-in result in CI. However, the new experimental cargo-c build regenerates its own header file using `cbindgen` by default unless told to do otherwise. We'd prefer it didn't do this because we're using a `cbindgen` feature that requires nightly rust.

This commit updates the `Cargo.toml` capi metadata to tell cargo-c to skip generation of its own header file. We then configure the pre-generated checked-in header file as an asset to be copied into the install include directory.

This better matches how the `Makefile` build allowed building the static lib without needing nightly rust or `cbindgen` and resolves https://github.com/rustls/rustls-ffi/issues/397.