### PR TITLE
server: fix clippy::manual_unwrap_or_default finding

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -482,12 +482,7 @@ impl ClientHelloResolver {
 
 impl ResolvesServerCert for ClientHelloResolver {
     fn resolve(&self, client_hello: ClientHello) -> Option<Arc<CertifiedKey>> {
-        let server_name: &str = {
-            match client_hello.server_name() {
-                Some(c) => c,
-                None => "",
-            }
-        };
+        let server_name = client_hello.server_name().unwrap_or_default();
         let server_name: rustls_str = match server_name.try_into() {
             Ok(r) => r,
             Err(_) => return None,


### PR DESCRIPTION
```
warning: match can be simplified with `.unwrap_or_default()`
   --> src/server.rs:486:13
    |
486 | /             match client_hello.server_name() {
487 | |                 Some(c) => c,
488 | |                 None => "",
489 | |             }
    | |_____________^ help: replace it with: `client_hello.server_name().unwrap_or_default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or_default
    = note: `#[warn(clippy::manual_unwrap_or_default)]` on by default
```