### PR TITLE
0.13 prep (cont'd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## 0.13.0 (XXXX-XX-XX)
+## 0.13.0 (2024-03-28)
 
-This release updates to [Rustls 0.23.1] and continues to use `*ring*` as the
+This release updates to [Rustls 0.23.4] and continues to use `*ring*` as the
 only cryptographic provider.
 
-[Rustls 0.23.1]: https://github.com/rustls/rustls/releases/tag/v%2F0.23.1
+[Rustls 0.23.4]: https://github.com/rustls/rustls/releases/tag/v%2F0.23.4
 
 ### Added
 
@@ -16,13 +16,17 @@ only cryptographic provider.
   the `rustls_accepted_alert` by calling `rustls_accepted_alert_write_tls` with
   a `rustls_write_callback` implementation.
 
-## Changed
+### Changed
 
 * The `rustls_acceptor_accept` and `rustls_accepted_into_connection` API
   functions now require an extra `rustls_accepted_alert` out parameter. This
   parameter will only be set when an error occurs accepting a client connection
   and can be used to write any generated alerts to the connection to signal
   the accept error to the peer.
+
+* The experimental cargo-c build support has been updated to use a vendored
+  header file. This avoids the need for nightly rust or `cbindgen` when using
+  this build method.
 
 ## 0.12.1 (2024-03-21)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e153fc89608e0515660ca656fd7f2fa05ca6690f3fd6ad1b0a46e24a8130d838"
+checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
 dependencies = [
  "once_cell",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ capi = []
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.1", default-features = false, features = [ "ring", "std", "tls12" ]}
+rustls = { version = "0.23.4", default-features = false, features = [ "ring", "std", "tls12" ]}
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [ "ring", "std" ] }
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::{env, fs, path::PathBuf};
 
 // Keep in sync with Cargo.toml.
-const RUSTLS_CRATE_VERSION: &str = "0.23.1";
+const RUSTLS_CRATE_VERSION: &str = "0.23.4";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());


### PR DESCRIPTION
A couple of things I noticed before cutting the release:

* We should jump straight to Rustls 0.23.4, not 0.23.1.
* The CHANGELOG needs the correct date.
* We can mention the cargo-c fix that just landed.
* One of the markdown headers was at the wrong header level