### PR TITLE
0.12.2 release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.12.2 (2024-03-28)
+
+### Changed
+
+* The experimental cargo-c build support has been updated to use a vendored
+  header file. This avoids the need for nightly rust or `cbindgen` when using
+  this build method.
+
 ## 0.12.1 (2024-03-21)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ regex = "1.9.6"
 [package.metadata.capi.header]
 name = "rustls"
 subdirectory = false
+generation = false # Prefer a vendored .h
 
 [package.metadata.capi.library]
 name = "rustls"
@@ -50,3 +51,6 @@ rustflags = "-Cmetadata=rustls-ffi"
 [package.metadata.capi.pkg_config]
 name = "rustls"
 filename = "rustls"
+
+[package.metadata.capi.install.include]
+asset = [{from = "src/rustls.h", to = "" }]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README-crates.io.md"


### PR DESCRIPTION
* Targets a `rel-0.12` branch made from the last commit before breaking changes in `main`: c17b5c18bd997827ebd6febd540c611127bc9990
* Backports https://github.com/rustls/rustls-ffi/pull/398
* Updates crate version to 0.12.2
* Updates CHANGELOG