### PR TITLE
docs: add 0.12.2 release to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ only cryptographic provider.
   header file. This avoids the need for nightly rust or `cbindgen` when using
   this build method.
 
+## 0.12.2 (2024-03-28)
+
+### Changed
+
+* The experimental cargo-c build support has been updated to use a vendored
+  header file. This avoids the need for nightly rust or `cbindgen` when using
+  this build method.
+
 ## 0.12.1 (2024-03-21)
 
 ### Added


### PR DESCRIPTION
This branch backports the 0.12.2 release notes from `rel-0.12` into `main`. This is one of the awkward aspects of keeping a `CHANGELOG.md` in-repo instead of only relying on our GitHub releases like we do in the main Rustls repo :face_exhaling: 