### PR TITLE
arc_castable!, box_castable!, ref_castable! macros

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -12,53 +12,43 @@ use crate::io::{
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::server::rustls_server_config;
 use crate::{
-    ffi_panic_boundary, free_box, rustls_result, set_boxed_mut_ptr, to_box, to_boxed_mut_ptr,
-    try_callback, try_clone_arc, try_mut_from_ptr, try_mut_from_ptr_ptr, try_ref_from_ptr,
-    try_take, Castable, OwnershipBox,
+    box_castable, ffi_panic_boundary, free_box, rustls_result, set_boxed_mut_ptr, to_box,
+    to_boxed_mut_ptr, try_callback, try_clone_arc, try_mut_from_ptr, try_mut_from_ptr_ptr,
+    try_ref_from_ptr, try_take,
 };
 
-/// A buffer and parser for ClientHello bytes. This allows reading ClientHello
-/// before choosing a rustls_server_config. It's useful when the server
-/// config will be based on parameters in the ClientHello: server name
-/// indication (SNI), ALPN protocols, signature schemes, and cipher suites. In
-/// particular, if a server wants to do some potentially expensive work to load a
-/// certificate for a given hostname, rustls_acceptor allows doing that asynchronously,
-/// as opposed to rustls_server_config_builder_set_hello_callback(), which doesn't
-/// work well for asynchronous I/O.
-///
-/// The general flow is:
-///  - rustls_acceptor_new()
-///  - Loop:
-///    - Read bytes from the network it with rustls_acceptor_read_tls().
-///    - If successful, parse those bytes with rustls_acceptor_accept().
-///    - If that returns RUSTLS_RESULT_ACCEPTOR_NOT_READY, continue.
-///    - Otherwise, break.
-///  - If rustls_acceptor_accept() returned RUSTLS_RESULT_OK:
-///    - Examine the resulting rustls_accepted.
-///    - Create or select a rustls_server_config.
-///    - Call rustls_accepted_into_connection().
-///  - Otherwise, there was a problem with the ClientHello data and the
-///    connection should be rejected.
-pub struct rustls_acceptor {
-    _private: [u8; 0],
+box_castable! {
+    /// A buffer and parser for ClientHello bytes. This allows reading ClientHello
+    /// before choosing a rustls_server_config. It's useful when the server
+    /// config will be based on parameters in the ClientHello: server name
+    /// indication (SNI), ALPN protocols, signature schemes, and cipher suites. In
+    /// particular, if a server wants to do some potentially expensive work to load a
+    /// certificate for a given hostname, rustls_acceptor allows doing that asynchronously,
+    /// as opposed to rustls_server_config_builder_set_hello_callback(), which doesn't
+    /// work well for asynchronous I/O.
+    ///
+    /// The general flow is:
+    ///  - rustls_acceptor_new()
+    ///  - Loop:
+    ///    - Read bytes from the network it with rustls_acceptor_read_tls().
+    ///    - If successful, parse those bytes with rustls_acceptor_accept().
+    ///    - If that returns RUSTLS_RESULT_ACCEPTOR_NOT_READY, continue.
+    ///    - Otherwise, break.
+    ///  - If rustls_acceptor_accept() returned RUSTLS_RESULT_OK:
+    ///    - Examine the resulting rustls_accepted.
+    ///    - Create or select a rustls_server_config.
+    ///    - Call rustls_accepted_into_connection().
+    ///  - Otherwise, there was a problem with the ClientHello data and the
+    ///    connection should be rejected.
+    pub struct rustls_acceptor(Acceptor);
 }
 
-impl Castable for rustls_acceptor {
-    type Ownership = OwnershipBox;
-    type RustType = Acceptor;
-}
-
-/// A parsed ClientHello produced by a rustls_acceptor. It is used to check
-/// server name indication (SNI), ALPN protocols, signature schemes, and
-/// cipher suites. It can be combined with a rustls_server_config to build a
-/// rustls_connection.
-pub struct rustls_accepted {
-    _private: [u8; 0],
-}
-
-impl Castable for rustls_accepted {
-    type Ownership = OwnershipBox;
-    type RustType = Option<Accepted>;
+box_castable! {
+    /// A parsed ClientHello produced by a rustls_acceptor. It is used to check
+    /// server name indication (SNI), ALPN protocols, signature schemes, and
+    /// cipher suites. It can be combined with a rustls_server_config to build a
+    /// rustls_connection.
+    pub struct rustls_accepted(Option<Accepted>);
 }
 
 impl rustls_acceptor {
@@ -452,14 +442,9 @@ impl rustls_accepted {
     }
 }
 
-/// Represents a TLS alert resulting from accepting a client.
-pub struct rustls_accepted_alert {
-    _private: [u8; 0],
-}
-
-impl Castable for rustls_accepted_alert {
-    type Ownership = OwnershipBox;
-    type RustType = AcceptedAlert;
+box_castable! {
+    /// Represents a TLS alert resulting from accepting a client.
+    pub struct rustls_accepted_alert(AcceptedAlert);
 }
 
 impl rustls_accepted_alert {

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,20 +22,20 @@ use crate::error::{self, rustls_result};
 use crate::rslice::NulByte;
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_str};
 use crate::{
-    ffi_panic_boundary, free_arc, free_box, set_boxed_mut_ptr, to_arc_const_ptr, to_boxed_mut_ptr,
-    try_box_from_ptr, try_clone_arc, try_mut_from_ptr, try_mut_from_ptr_ptr, try_ref_from_ptr,
-    try_slice, userdata_get, Castable, OwnershipArc, OwnershipBox,
+    arc_castable, box_castable, ffi_panic_boundary, free_arc, free_box, set_boxed_mut_ptr,
+    to_arc_const_ptr, to_boxed_mut_ptr, try_box_from_ptr, try_clone_arc, try_mut_from_ptr,
+    try_mut_from_ptr_ptr, try_ref_from_ptr, try_slice, userdata_get,
 };
 
-/// A client config being constructed. A builder can be modified by,
-/// e.g. rustls_client_config_builder_load_roots_from_file. Once you're
-/// done configuring settings, call rustls_client_config_builder_build
-/// to turn it into a *rustls_client_config. This object is not safe
-/// for concurrent mutation. Under the hood, it corresponds to a
-/// `Box<ClientConfig>`.
-/// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
-pub struct rustls_client_config_builder {
-    _private: [u8; 0],
+box_castable! {
+    /// A client config being constructed. A builder can be modified by,
+    /// e.g. rustls_client_config_builder_load_roots_from_file. Once you're
+    /// done configuring settings, call rustls_client_config_builder_build
+    /// to turn it into a *rustls_client_config. This object is not safe
+    /// for concurrent mutation. Under the hood, it corresponds to a
+    /// `Box<ClientConfig>`.
+    /// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
+    pub struct rustls_client_config_builder(ClientConfigBuilder);
 }
 
 pub(crate) struct ClientConfigBuilder {
@@ -46,21 +46,11 @@ pub(crate) struct ClientConfigBuilder {
     cert_resolver: Option<Arc<dyn rustls::client::ResolvesClientCert>>,
 }
 
-impl Castable for rustls_client_config_builder {
-    type Ownership = OwnershipBox;
-    type RustType = ClientConfigBuilder;
-}
-
-/// A client config that is done being constructed and is now read-only.
-/// Under the hood, this object corresponds to an `Arc<ClientConfig>`.
-/// <https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html>
-pub struct rustls_client_config {
-    _private: [u8; 0],
-}
-
-impl Castable for rustls_client_config {
-    type Ownership = OwnershipArc;
-    type RustType = ClientConfig;
+arc_castable! {
+    /// A client config that is done being constructed and is now read-only.
+    /// Under the hood, this object corresponds to an `Arc<ClientConfig>`.
+    /// <https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html>
+    pub struct rustls_client_config(ClientConfig);
 }
 
 #[derive(Debug)]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -14,12 +14,12 @@ use crate::io::{
 use crate::log::{ensure_log_registered, rustls_log_callback};
 
 use crate::{
+    box_castable,
     cipher::{rustls_certificate, rustls_supported_ciphersuite},
     error::{map_error, rustls_io_result, rustls_result},
     ffi_panic_boundary, free_box,
     io::{rustls_read_callback, rustls_write_callback},
-    try_callback, try_mut_from_ptr, try_ref_from_ptr, try_slice, userdata_push, Castable,
-    OwnershipBox,
+    try_callback, try_mut_from_ptr, try_ref_from_ptr, try_slice, userdata_push,
 };
 
 use rustls_result::NullParameter;
@@ -93,13 +93,8 @@ impl std::ops::DerefMut for Connection {
     }
 }
 
-pub struct rustls_connection {
-    _private: [u8; 0],
-}
-
-impl Castable for rustls_connection {
-    type Ownership = OwnershipBox;
-    type RustType = Connection;
+box_castable! {
+    pub struct rustls_connection(Connection);
 }
 
 impl rustls_connection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,9 +619,9 @@ macro_rules! try_ref_from_ptr_ptr {
 pub(crate) use try_ref_from_ptr_ptr;
 
 /// If the provided pointer to a [`Castable`] is non-null, convert it to a reference to an `Arc` over
-/// the underlying rust type using [`try_arc_from`]. Otherwise, return
+/// the underlying rust type using [`clone_arc`]. Otherwise, return
 /// [`rustls_result::NullParameter`], or an appropriate default (`false`, `0`, `NULL`) based on the
-/// context. See [`try_arc_from`] for more information.
+/// context. See [`clone_arc`] for more information.
 macro_rules! try_clone_arc {
     ( $var:ident ) => {
         match $crate::clone_arc($var) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,19 +26,19 @@ use crate::session::{
     SessionStoreGetCallback, SessionStorePutCallback,
 };
 use crate::{
-    ffi_panic_boundary, free_arc, free_box, set_boxed_mut_ptr, to_arc_const_ptr, to_boxed_mut_ptr,
-    try_box_from_ptr, try_clone_arc, try_mut_from_ptr, try_mut_from_ptr_ptr, try_ref_from_ptr,
-    try_slice, userdata_get, Castable, OwnershipArc, OwnershipBox, OwnershipRef,
+    arc_castable, box_castable, ffi_panic_boundary, free_arc, free_box, set_boxed_mut_ptr,
+    to_arc_const_ptr, to_boxed_mut_ptr, try_box_from_ptr, try_clone_arc, try_mut_from_ptr,
+    try_mut_from_ptr_ptr, try_ref_from_ptr, try_slice, userdata_get, Castable, OwnershipRef,
 };
 
-/// A server config being constructed. A builder can be modified by,
-/// e.g. rustls_server_config_builder_load_native_roots. Once you're
-/// done configuring settings, call rustls_server_config_builder_build
-/// to turn it into a *const rustls_server_config. This object is not safe
-/// for concurrent mutation.
-/// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
-pub struct rustls_server_config_builder {
-    _private: [u8; 0],
+box_castable! {
+    /// A server config being constructed. A builder can be modified by,
+    /// e.g. rustls_server_config_builder_load_native_roots. Once you're
+    /// done configuring settings, call rustls_server_config_builder_build
+    /// to turn it into a *const rustls_server_config. This object is not safe
+    /// for concurrent mutation.
+    /// <https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html>
+    pub struct rustls_server_config_builder(ServerConfigBuilder);
 }
 
 pub(crate) struct ServerConfigBuilder {
@@ -50,21 +50,11 @@ pub(crate) struct ServerConfigBuilder {
     ignore_client_order: Option<bool>,
 }
 
-impl Castable for rustls_server_config_builder {
-    type Ownership = OwnershipBox;
-    type RustType = ServerConfigBuilder;
-}
-
-/// A server config that is done being constructed and is now read-only.
-/// Under the hood, this object corresponds to an `Arc<ServerConfig>`.
-/// <https://docs.rs/rustls/latest/rustls/struct.ServerConfig.html>
-pub struct rustls_server_config {
-    _private: [u8; 0],
-}
-
-impl Castable for rustls_server_config {
-    type Ownership = OwnershipArc;
-    type RustType = ServerConfig;
+arc_castable! {
+    /// A server config that is done being constructed and is now read-only.
+    /// Under the hood, this object corresponds to an `Arc<ServerConfig>`.
+    /// <https://docs.rs/rustls/latest/rustls/struct.ServerConfig.html>
+    pub struct rustls_server_config(ServerConfig);
 }
 
 impl rustls_server_config_builder {


### PR DESCRIPTION
Throughout the project we follow a pattern of implementing safe bridge types for FFI by:

1. Creating a `snake_case_named` [opaque struct](https://github.com/rustls/rustls-ffi/blob/main/CONTRIBUTING.md#opaque-struct-pattern).
2. Implementing `Castable` for the struct:
  a. specifying a `RustType` (some native Rust type).
  b. specifying an `Ownership` (`OwnershipBox`, `OwnershipArc`, `OwnershipRef`).

In the case of `OwnershipRef` we may also need to add a `PhantomData` field referencing a lifetime to the opaque struct.

To reduce the boilerplate of doing all of the above over and over this commit adds three new macros (loosely inspired by the Rustls [`enum_builder!` macro](https://github.com/rustls/rustls/blob/d8d438aecc2f06ddc1e4975822580dd6b2f4c64a/rustls/src/msgs/macros.rs#L2)) that accomplish the task with less ceremony (as suggested in https://github.com/rustls/rustls-ffi/issues/151):  `arc_castable!`, `box_castable!`, and `ref_castable!`.

Care has been taken to avoid the downside [mentioned in 151](https://github.com/rustls/rustls-ffi/issues/151#issuecomment-963751363) about rustdoc comments. The macros ensure the doc comments we add are associated with the correct type and not the macro itself. We can verify this fact by noting that the generated `rustls.h` header file that contains these comments has not changed with the introduction of the macros.

Existing instances of the pattern are updated to use these macros with one exception: the [`rustls_client_hello` type](https://github.com/rustls/rustls-ffi/blob/1dec438490266ccad18db3477555759face1c080/src/server.rs#L422-L448) implements `Castable` with `OwnershipRef` for `rustls_client_hello<'a>`, but it isn't the same opaque struct pattern as used elsewhere and so is best implemented by hand.

I've spot checked the expansion of the macros against my expectations and was happy with the results. If you want to do the same thing, here's [a `cargo expand` of 10c5324](https://gist.github.com/cpu/888f13381ef86f084f447d7133791e69).

Resolves https://github.com/rustls/rustls-ffi/issues/151
