### PR TITLE
Fix two incompatible types warnings in example code

### DIFF
--- a/tests/client.c
+++ b/tests/client.c
@@ -360,7 +360,7 @@ cleanup:
   return ret;
 }
 
-enum rustls_result
+uint32_t
 verify(void *userdata, const rustls_verify_server_cert_params *params)
 {
   size_t i = 0;

--- a/tests/server.c
+++ b/tests/server.c
@@ -339,7 +339,9 @@ main(int argc, const char **argv)
   }
 
   int enable = 1;
-  if(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+  if(setsockopt(
+       sockfd, SOL_SOCKET, SO_REUSEADDR, (const char *)&enable, sizeof(int)) <
+     0) {
     print_error("setsockopt(SO_REUSEADDR) failed", 7001);
   }
 


### PR DESCRIPTION
Resolves https://github.com/rustls/rustls-ffi/issues/235

### client.c

The `rustls_verify_server_cert_callback` type is [defined as returning `uint32_t`](https://github.com/rustls/rustls-ffi/blob/1dec438490266ccad18db3477555759face1c080/src/rustls.h#L429-L430). 

In `client.c` we were mistakenly typing the `verify` callback as [returning `enum rustls_result`](https://github.com/rustls/rustls-ffi/blob/1dec438490266ccad18db3477555759face1c080/tests/client.c#L363-L364) when it should be `uint32_t`. This commit makes the required adjustment, silencing the warning.

### server.c

[On Linux](https://linux.die.net/man/2/setsockopt), `man 2 setsockopt` shows the `optval` argument as being `const void *`. [On Windows](
https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-setsockopt), `setsockopt`'s `optval` argument is `const char*`. This mismatch produces an incompatible types warning when building the `server.c` example on Windows. 

The solution is straight-forward. Explicitly cast `optval` to `const char*`. On Windows this is the correct type. On Linux it will be implicitly converted to `const void *` and everyone is happy. 


