### PR TITLE
cmake: don't run cbindgen for build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ ExternalProject_Add(
 	rustls-ffi
 	DOWNLOAD_COMMAND ""
 	CONFIGURE_COMMAND ""
-	BUILD_COMMAND cbindgen --lang C --output "${CMAKE_SOURCE_DIR}/src/rustls.h" "${CMAKE_SOURCE_DIR}"
+	BUILD_COMMAND ""
 	COMMAND cargo build --locked "$<IF:$<CONFIG:Release>,--release,-->"
 	# Rely on cargo checking timestamps, rather than tell CMake where every
 	# output is.


### PR DESCRIPTION
Similar to https://github.com/rustls/rustls-ffi/pull/398, we vendor a `src/rustls.h` and prefer builds use this to avoid the need for a nightly rust compiler. This branch adjusts the `CMakeLists.txt` build config to avoid regenerating the header file.