### PR TITLE
docs: fix mod_tls link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ need further evaluation and will most likely change significantly in the future.
 
 The `rustls_server_config_builder_set_hello_callback` and its provided information
 in `rustls_client_hello` will change. The current design is a snapshot of the
-implementation efforts in [mod_tls](https://github.com/icing/mod_tls) to provide
+implementation efforts in
+[mod_tls](https://httpd.apache.org/docs/2.4/mod/mod_tls.html) to provide
 `rustls`-based TLS as module for the Apache webserver.
 
 For a webserver hosting multiple domains on the same endpoint, it is highly desirable


### PR DESCRIPTION
Previously the README linked to `https://github.com/icing/mod_tls`, but this repo has been removed and the code is now upstreamed into Apache HTTPD.

This commit replaces it with a pointer to the docs for `mod_tls`, which in turn lists the relevant source file.

Resolves https://github.com/rustls/rustls-ffi/issues/406