### PR TITLE
ci: add Linux pkg-config/.so test coverage

### DIFF
--- a/.github/workflows/pkg-config.yaml
+++ b/.github/workflows/pkg-config.yaml
@@ -1,0 +1,51 @@
+name: pkg-config
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '15 12 * * 3'
+
+jobs:
+  build:
+    name: Build+test
+    runs-on: ubuntu-latest
+    env:
+      PREFIX: /tmp/librustls
+    strategy:
+      matrix:
+        cc: [clang, gcc]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-c
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
+        run: |
+          curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
+
+      - name: Install the library
+        run: make --file=Makefile.pkg-config PREFIX=${PREFIX} install
+
+      - name: Build the client/server examples
+        run: PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig make --file=Makefile.pkg-config
+
+      - name: Verify client is dynamically linked
+        run: LD_LIBRARY_PATH=$PREFIX/lib ldd target/client | grep "rustls"
+
+      - name: Verify server is dynamically linked
+        run: LD_LIBRARY_PATH=$PREFIX/lib ldd target/server | grep "rustls"
+
+      - name: Run the integration tests
+        run: LD_LIBRARY_PATH=$PREFIX/lib make --file=Makefile.pkg-config integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,14 +220,7 @@ jobs:
           persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - name: Install cargo-c
-        env:
-          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
-          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
-        run: |
-          curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
-      - name: Build and test with cargo-c
-        run: cargo capi test
+
 
   miri:
     name: Miri

--- a/Makefile.pkg-config
+++ b/Makefile.pkg-config
@@ -1,0 +1,51 @@
+# Makefile for building & testing the client/server examples using pkg-config
+# and dynamically linking. For static linking see the default 'Makefile'.
+# This Makefile is for testing only. For install instructions, see the README.
+#
+# Example usage:
+#   PREFIX=/tmp/librustls
+#   make --file Makefile.pkg-config install PREFIX=$PREFIX
+#   PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig/ make --file Makefile.pkg-config
+#   LD_LIBRARY_PATH=$PREFIX/lib make --file Makefile.pkg-config integration
+
+CARGO ?= cargo
+CARGOFLAGS += --locked
+
+CFLAGS := -Werror -Wall -Wextra -Wpedantic -g -I src/
+PROFILE := release
+PREFIX=/usr/local
+
+ifeq ($(CC), clang)
+	CFLAGS += -fsanitize=address -fsanitize=undefined
+	LDFLAGS += -fsanitize=address
+endif
+
+ifeq ($(PROFILE), release)
+	CFLAGS += -O3
+	CARGOFLAGS += --release
+endif
+
+all: target/client target/server
+
+integration: all
+	${CARGO} test --locked --test client_server -- --ignored
+
+target:
+	mkdir -p $@
+
+install:
+	cargo cinstall $(CARGOFLAGS) --prefix=$(PREFIX)
+
+target/%.o: tests/%.c tests/common.h | target
+	$(CC) -o $@ -c $< $(CFLAGS) $(shell pkg-config --cflags rustls)
+
+target/client: target/client.o target/common.o
+	$(CC) -o $@ $^ $(LDFLAGS) $(shell pkg-config --libs rustls)
+
+target/server: target/server.o target/common.o
+	$(CC) -o $@ $^ $(LDFLAGS) $(shell pkg-config --libs rustls)
+
+clean:
+	rm -rf target
+
+.PHONY: all install clean integration


### PR DESCRIPTION
This is follow-up to https://github.com/rustls/rustls-ffi/pull/274 that adds test coverage for using rustls with pkg-config and dynamic linking. A new `Makefile.pkg-config` is added that can be used on UNIX machines with `pkg-config`. It is a slimmed down copy of `Makefile` that:

* Removes the development targets (`format`, etc).
* Removes details specific to static linking.
* Uses `cargo cinstall` for the install target.
* Adds the correct `CFLAGS`/`LDFLAGS` that `pkg-config` tells us are necessary based on the `.pc` file that `cargo-c` writes.
* Runs the integration tests with the dynamically linked client/server examples.

A new CI workflow (`pkg-config.yaml`) is added that only runs on ubuntu-latest (with both `clang` and `gcc`) that:

* Installs stable rust.
* Installs `cargo-c`.
* Installs the lib to a tmp dir using `cargo-c`.
* Builds the client/server examples using `pkg-config` to dynamically link `rustls`.
* Verify the binaries aren't statically linking `rustls`.
* Run the client/server integration tests.

The existing `cargo-c` coverage is removed from the `test.yaml` workflow since it's now duplicative with this new workflow.