### PR TITLE
Fix valgrind job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,8 +52,7 @@ jobs:
           persist-credentials: false
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
-      - run: export VALGRIND="valgrind -q"
-      - run: make test integration
+      - run: VALGRIND=valgrind make test integration
 
   test-windows-cmake-debug:
     name: Windows CMake, Debug configuration


### PR DESCRIPTION
`export VALGRIND="valgrind -q"` doesn't work as intended:

- in GH actions, environment alterations don't affect subsequent `run` steps
- in `tests/client_server.rs`, we require `VALGRIND` to be a single command to execute: no shell expansion takes place so no arguments are allowed