### PR TITLE
Makefile: limit scope of format/format-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,17 +62,15 @@ clean:
 	rm -rf target
 
 format:
-	find . \
+	find src tests \
 		-name '*.[c|h]' \
-		! -path "./target/*" \
-		! -wholename './src/rustls.h' | \
+		! -wholename 'src/rustls.h' | \
 			xargs clang-format -i
 
 format-check:
-	find . \
+	find src tests \
 		-name '*.[c|h]' \
-		! -path "./target/*" \
-		! -wholename './src/rustls.h' | \
+		! -wholename 'src/rustls.h' | \
 			xargs clang-format --dry-run -Werror -i
 
 .PHONY: all clean test integration format format-check


### PR DESCRIPTION
We don't want `.git` or `target/` or other misc dirs to be subject to these phony targets.

Inspired by [ctz fixing the same](https://github.com/rustls/rustls-openssl-compat/pull/3/files/5c795fedea8801a6b0f6ff8e345bb11857831b13..1ef23d04bbcdf95b40c85ad1aba159a1f9956150#diff-f8c0f426bd38bf5be300f7bfe6b623a7742d7977625ece5ac664d9233ed3b69b) in the compat repo.