### PR TITLE
run clippy on tests, fix findings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -181,7 +181,7 @@ jobs:
         # (below) will have a new lint that we want to suppress.
         # If we suppress (e.g. #![allow(clippy::arc_with_non_send_sync)]),
         # we would get an unknown-lint error from older clippy versions.
-        run: cargo clippy --locked --workspace -- -D warnings -A unknown-lints
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings -A unknown-lints
 
   clippy-nightly-optional:
     name: Clippy nightly (optional)
@@ -196,7 +196,7 @@ jobs:
         with:
           components: clippy
       - name: Check clippy
-        run: cargo clippy --locked --workspace -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
   clang-tidy:
     name: Clang Tidy

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ endif
 all: target/client target/server
 
 test: all
-	${CARGO} test --locked
+	${CARGO} test ${CARGOFLAGS}
 
 integration: all
-	${CARGO} test --locked -- --ignored
+	${CARGO} test ${CARGOFLAGS} -- --ignored
 
 target:
 	mkdir -p $@

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -207,56 +207,6 @@ pub static mut RUSTLS_DEFAULT_CIPHER_SUITES: [*const rustls_supported_ciphersuit
 #[no_mangle]
 pub static RUSTLS_DEFAULT_CIPHER_SUITES_LEN: usize = unsafe { RUSTLS_DEFAULT_CIPHER_SUITES.len() };
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::str;
-
-    #[test]
-    fn all_cipher_suites_arrays() {
-        assert_eq!(RUSTLS_ALL_CIPHER_SUITES_LEN, ALL_CIPHER_SUITES.len());
-        for (original, ffi) in ALL_CIPHER_SUITES
-            .iter()
-            .zip(unsafe { RUSTLS_ALL_CIPHER_SUITES }.iter().copied())
-        {
-            let ffi_cipher_suite = try_ref_from_ptr!(ffi);
-            assert_eq!(original, ffi_cipher_suite);
-        }
-    }
-
-    #[test]
-    fn default_cipher_suites_arrays() {
-        assert_eq!(
-            RUSTLS_DEFAULT_CIPHER_SUITES_LEN,
-            DEFAULT_CIPHER_SUITES.len()
-        );
-        for (original, ffi) in DEFAULT_CIPHER_SUITES
-            .iter()
-            .zip(unsafe { RUSTLS_DEFAULT_CIPHER_SUITES }.iter().copied())
-        {
-            let ffi_cipher_suite = try_ref_from_ptr!(ffi);
-            assert_eq!(original, ffi_cipher_suite);
-        }
-    }
-
-    #[test]
-    fn ciphersuite_get_name() {
-        let suite = rustls_all_ciphersuites_get_entry(0);
-        let s = rustls_supported_ciphersuite_get_name(suite);
-        let want = "TLS13_AES_256_GCM_SHA384";
-        unsafe {
-            let got = str::from_utf8(slice::from_raw_parts(s.data as *const u8, s.len)).unwrap();
-            assert_eq!(want, got)
-        }
-    }
-
-    #[test]
-    fn test_all_ciphersuites_len() {
-        let len = rustls_all_ciphersuites_len();
-        assert!(len > 2);
-    }
-}
-
 /// The complete chain of certificates to send during a TLS handshake,
 /// plus a private key that matches the end-entity (leaf) certificate.
 /// Corresponds to `CertifiedKey` in the Rust API.
@@ -1169,5 +1119,55 @@ impl rustls_server_cert_verifier {
         ffi_panic_boundary! {
             free_box(verifier);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str;
+
+    #[test]
+    fn all_cipher_suites_arrays() {
+        assert_eq!(RUSTLS_ALL_CIPHER_SUITES_LEN, ALL_CIPHER_SUITES.len());
+        for (original, ffi) in ALL_CIPHER_SUITES
+            .iter()
+            .zip(unsafe { RUSTLS_ALL_CIPHER_SUITES }.iter().copied())
+        {
+            let ffi_cipher_suite = try_ref_from_ptr!(ffi);
+            assert_eq!(original, ffi_cipher_suite);
+        }
+    }
+
+    #[test]
+    fn default_cipher_suites_arrays() {
+        assert_eq!(
+            RUSTLS_DEFAULT_CIPHER_SUITES_LEN,
+            DEFAULT_CIPHER_SUITES.len()
+        );
+        for (original, ffi) in DEFAULT_CIPHER_SUITES
+            .iter()
+            .zip(unsafe { RUSTLS_DEFAULT_CIPHER_SUITES }.iter().copied())
+        {
+            let ffi_cipher_suite = try_ref_from_ptr!(ffi);
+            assert_eq!(original, ffi_cipher_suite);
+        }
+    }
+
+    #[test]
+    fn ciphersuite_get_name() {
+        let suite = rustls_all_ciphersuites_get_entry(0);
+        let s = rustls_supported_ciphersuite_get_name(suite);
+        let want = "TLS13_AES_256_GCM_SHA384";
+        unsafe {
+            let got = str::from_utf8(slice::from_raw_parts(s.data as *const u8, s.len)).unwrap();
+            assert_eq!(want, got)
+        }
+    }
+
+    #[test]
+    fn test_all_ciphersuites_len() {
+        let len = rustls_all_ciphersuites_len();
+        assert!(len > 2);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -620,7 +620,7 @@ mod tests {
         let config = rustls_client_config_builder::rustls_client_config_builder_build(builder);
         {
             let config2 = try_ref_from_ptr!(config);
-            assert_eq!(config2.enable_sni, false);
+            assert!(!config2.enable_sni);
             assert_eq!(config2.alpn_protocols, vec![h1, h2]);
         }
         rustls_client_config::rustls_client_config_free(config)
@@ -642,12 +642,9 @@ mod tests {
         if !matches!(result, rustls_result::Ok) {
             panic!("expected RUSTLS_RESULT_OK, got {:?}", result);
         }
-        assert_eq!(rustls_connection::rustls_connection_wants_read(conn), false);
-        assert_eq!(rustls_connection::rustls_connection_wants_write(conn), true);
-        assert_eq!(
-            rustls_connection::rustls_connection_is_handshaking(conn),
-            true
-        );
+        assert!(!rustls_connection::rustls_connection_wants_read(conn));
+        assert!(rustls_connection::rustls_connection_wants_write(conn));
+        assert!(rustls_connection::rustls_connection_is_handshaking(conn));
 
         let some_byte = 42u8;
         let mut alpn_protocol: *const u8 = &some_byte;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ mod tests {
         let mut guard = userdata_push(data_ptr, None).unwrap();
         assert_eq!(userdata_get().unwrap(), data_ptr);
         guard.try_pop().unwrap();
-        assert!(matches!(guard.try_pop(), Err(_)));
+        assert!(guard.try_pop().is_err())
     }
 
     #[test]
@@ -213,7 +213,7 @@ mod tests {
         let guard = userdata_push(data_ptr, None).unwrap();
         assert_eq!(userdata_get().unwrap(), data_ptr);
         guard.try_drop().unwrap();
-        assert!(matches!(userdata_get(), Err(_)));
+        assert!(userdata_get().is_err())
     }
 
     #[test]
@@ -224,7 +224,7 @@ mod tests {
             let _guard = userdata_push(data_ptr, None).unwrap();
             assert_eq!(userdata_get().unwrap(), data_ptr);
         }
-        assert!(matches!(userdata_get(), Err(_)));
+        assert!(userdata_get().is_err())
     }
 
     #[test]
@@ -244,7 +244,7 @@ mod tests {
             assert_eq!(userdata_get().unwrap(), hello_ptr);
             guard.try_drop().unwrap();
         }
-        assert!(matches!(userdata_get(), Err(_)));
+        assert!(userdata_get().is_err())
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -729,15 +729,9 @@ mod tests {
         if !matches!(result, rustls_result::Ok) {
             panic!("expected RUSTLS_RESULT_OK, got {:?}", result);
         }
-        assert_eq!(rustls_connection::rustls_connection_wants_read(conn), true);
-        assert_eq!(
-            rustls_connection::rustls_connection_wants_write(conn),
-            false
-        );
-        assert_eq!(
-            rustls_connection::rustls_connection_is_handshaking(conn),
-            true
-        );
+        assert!(rustls_connection::rustls_connection_wants_read(conn));
+        assert!(!rustls_connection::rustls_connection_wants_write(conn));
+        assert!(rustls_connection::rustls_connection_is_handshaking(conn));
 
         let some_byte = 42u8;
         let mut alpn_protocol: *const u8 = &some_byte;

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -158,7 +158,7 @@ impl ClientTest {
             .output()
             .unwrap_or_else(|_| panic!("failed to run client binary {client_binary}"));
 
-        let passed = result.status.success() == !self.expect_error;
+        let passed = result.status.success() != self.expect_error;
         if !passed {
             println!(
                 "client test failed. Failed process output:\n {}",

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -156,7 +156,7 @@ impl ClientTest {
             .args(args)
             .envs(self.env.clone())
             .output()
-            .expect(&format!("failed to run client binary {client_binary}"));
+            .unwrap_or_else(|_| panic!("failed to run client binary {client_binary}"));
 
         let passed = result.status.success() == !self.expect_error;
         if !passed {
@@ -189,7 +189,7 @@ impl ServerOptions {
             .args(args)
             .envs(self.env.clone())
             .spawn()
-            .expect(&format!("failed to run server binary {server_binary}"))
+            .unwrap_or_else(|_| panic!("failed to run server binary {server_binary}"))
     }
 }
 


### PR DESCRIPTION
Over in the rustls-openssl-compat repo that we bootstrapped from this repo's settings I noticed we weren't linting test code (https://github.com/rustls/rustls-openssl-compat/pull/6). It looks like that's true for this repo as well. 

This branch updates the clippy jobs to do so and fixes the findings that were present. 