### PR TITLE
client: NoneVerifier UnknownIssuer instead of BadSignature

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -76,7 +76,7 @@ impl ServerCertVerifier for NoneVerifier {
         _now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
         Err(rustls::Error::InvalidCertificate(
-            CertificateError::BadSignature,
+            CertificateError::UnknownIssuer,
         ))
     }
 


### PR DESCRIPTION
The `NoneVerifier` that's used by default if a rustls client config builder is built without a verifier being specified was configured to return `Error::InvalidCertificate(CertificateError::BadSignature)` from all of its trait methods.

This branch updates the `verify_server_cert()` trait method to instead return `Error::InvalidCertificate(CertificateError::UnknownIssuer)`. This will better match what would happen if you configured an empty root certificate store with a real verifier and is perhaps less confusing to debug than an error indicating a cryptographic signature validation error. `BadSignature` is still used for `verify_tls12_signature()` and `verify_tls13_signature()` where it feels like an appropriate default error. In practice neither of these trait methods come into play in `NoneVerifier` use.

Resolves https://github.com/rustls/rustls-ffi/issues/409