### PR TITLE
Avoid ASAN for release builds, use w/ GCC or clang in debug builds

### DIFF
--- a/.github/workflows/pkg-config.yaml
+++ b/.github/workflows/pkg-config.yaml
@@ -39,7 +39,7 @@ jobs:
         run: make --file=Makefile.pkg-config PREFIX=${PREFIX} install
 
       - name: Build the client/server examples
-        run: PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig make --file=Makefile.pkg-config
+        run: PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig make --file=Makefile.pkg-config PROFILE=debug
 
       - name: Verify client is dynamically linked
         run: LD_LIBRARY_PATH=$PREFIX/lib ldd target/client | grep "rustls"
@@ -48,4 +48,4 @@ jobs:
         run: LD_LIBRARY_PATH=$PREFIX/lib ldd target/server | grep "rustls"
 
       - name: Run the integration tests
-        run: LD_LIBRARY_PATH=$PREFIX/lib make --file=Makefile.pkg-config integration
+        run: LD_LIBRARY_PATH=$PREFIX/lib make --file=Makefile.pkg-config PROFILE=debug integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,9 +43,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - env:
           CARGO_UNSTABLE_HTTP_REGISTRY: true
-        run: make CC=${{ matrix.cc }} PROFILE=release test integration
+        run: make CC=${{ matrix.cc }} PROFILE=debug test integration
       - name: Platform verifier connect test
-        run: make connect-test
+        run: make PROFILE=debug connect-test
 
   valgrind:
     name: Valgrind
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
-      - run: VALGRIND=valgrind make test integration
+      - run: VALGRIND=valgrind make PROFILE=release test integration
 
   test-windows-cmake-debug:
     name: Windows CMake, Debug configuration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,20 @@ jobs:
         run: make CC=${{ matrix.cc }} PROFILE=debug test integration
       - name: Platform verifier connect test
         run: make PROFILE=debug connect-test
+      - name: Verify debug builds were using ASAN
+        if: runner.os == 'Linux' # For 'nm'
+        run: |
+          nm target/client | grep '__asan_init'
+          nm target/server | grep '__asan_init'
+      - name: Build release binaries
+        run: |
+          make clean
+          make CC=${{ matrix.cc }} PROFILE=release
+      - name: Verify release builds were not using ASAN
+        if: runner.os == 'Linux' # For 'nm'
+        run: |
+          nm target/client | grep -v '__asan_init'
+          nm target/server | grep -v '__asan_init'
 
   valgrind:
     name: Valgrind

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,8 @@ PROFILE := release
 DESTDIR=/usr/local
 
 ifeq ($(PROFILE), debug)
-ifeq ($(CC), clang)
 	CFLAGS += -fsanitize=address -fsanitize=undefined
-	LDFLAGS += -fsanitize=address
-endif
+	LDFLAGS += -fsanitize=address -fsanitize=undefined
 endif
 
 ifeq ($(PROFILE), release)

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,11 @@ CFLAGS := -Werror -Wall -Wextra -Wpedantic -g -I src/
 PROFILE := release
 DESTDIR=/usr/local
 
+ifeq ($(PROFILE), debug)
 ifeq ($(CC), clang)
 	CFLAGS += -fsanitize=address -fsanitize=undefined
 	LDFLAGS += -fsanitize=address
+endif
 endif
 
 ifeq ($(PROFILE), release)

--- a/Makefile.pkg-config
+++ b/Makefile.pkg-config
@@ -16,10 +16,8 @@ PROFILE := release
 PREFIX=/usr/local
 
 ifeq ($(PROFILE), debug)
-ifeq ($(CC), clang)
 	CFLAGS += -fsanitize=address -fsanitize=undefined
-	LDFLAGS += -fsanitize=address
-endif
+	LDFLAGS += -fsanitize=address -fsanitize=undefined
 endif
 
 ifeq ($(PROFILE), release)

--- a/Makefile.pkg-config
+++ b/Makefile.pkg-config
@@ -15,9 +15,11 @@ CFLAGS := -Werror -Wall -Wextra -Wpedantic -g -I src/
 PROFILE := release
 PREFIX=/usr/local
 
+ifeq ($(PROFILE), debug)
 ifeq ($(CC), clang)
 	CFLAGS += -fsanitize=address -fsanitize=undefined
 	LDFLAGS += -fsanitize=address
+endif
 endif
 
 ifeq ($(PROFILE), release)


### PR DESCRIPTION
This branch resolves https://github.com/rustls/rustls-ffi/issues/423 by:

* Making sure we only use ASAN with debug builds, and switching most of CI to run tests with that profile. Valgrind is left using release builds because ASAN + Valgrind conflict without more care.
* Enabling ASAN for GCC in addition to Clang. GCC has also had ASAN support built-in for a long time. We might as well use it for more builds.
* Adding simple checks in CI that debug builds _are_ using ASAN and release builds _aren't_. Presently this isn't comprehensive, but a quick safety check on Linux hosts using `nm`.