### PR TITLE
lib: whitespace around Userdata invariants list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,11 @@ pub(crate) struct Userdata {
 /// UserdataGuard pops an entry off the USERDATA stack, restoring the
 /// thread-local state to its value previous to the creation of the UserdataGuard.
 /// Invariants: As long as a UserdataGuard is live:
+///
 ///  - The stack of userdata items for this thread must have at least one item.
 ///  - The top item on that stack must be the one this guard was built with.
 ///  - The `data` field must not be None.
+///
 /// If any of these invariants fails, try_drop will return an error.
 pub(crate) struct UserdataGuard {
     // Keep a copy of the data we expect to be popping off the stack. This allows


### PR DESCRIPTION
This fixes a [nightly clippy finding](https://github.com/cpu/rustls-ffi/actions/runs/9285999940/job/25551743401):

```
error: doc list item missing indentation
  --> src/lib.rs:72:5
   |
72 | /// If any of these invariants fails, try_drop will return an error.
   |     ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
```