### PR TITLE
connection: more docs for rustls_connection_is_handshaking

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -277,6 +277,13 @@ impl rustls_connection {
         }
     }
 
+    /// Returns true if the connection is currently performing the TLS handshake.
+    ///
+    /// Note: This may return `false` while there are still handshake packets waiting
+    /// to be extracted and transmitted with `rustls_connection_write_tls()`.
+    ///
+    /// See the rustls documentation for more information.
+    ///
     /// <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.is_handshaking>
     #[no_mangle]
     pub extern "C" fn rustls_connection_is_handshaking(conn: *const rustls_connection) -> bool {

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1508,6 +1508,13 @@ bool rustls_connection_wants_read(const struct rustls_connection *conn);
 bool rustls_connection_wants_write(const struct rustls_connection *conn);
 
 /**
+ * Returns true if the connection is currently performing the TLS handshake.
+ *
+ * Note: This may return `false` while there are still handshake packets waiting
+ * to be extracted and transmitted with `rustls_connection_write_tls()`.
+ *
+ * See the rustls documentation for more information.
+ *
  * <https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.is_handshaking>
  */
 bool rustls_connection_is_handshaking(const struct rustls_connection *conn);


### PR DESCRIPTION
Previously the rustls-ffi `rustls_connection_is_handshaking` fn only pointed at the upstream Rustls documentation. This seems fine in general, but since there was confusion in #427 it felt fair to lift some details down into our own docs.

This commit adds a bit of the detail present there, customizing it for rustls-ffi (e.g. by ref'ing `rustls_connection_write_tls()`).

Resolves https://github.com/rustls/rustls-ffi/issues/427