### PR TITLE
project-wide tidying, style updates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -194,7 +194,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Check clippy
+      - name: Check clippy (default features)
         # We allow unknown lints here because sometimes the nightly job
         # (below) will have a new lint that we want to suppress.
         # If we suppress (e.g. #![allow(clippy::arc_with_non_send_sync)]),
@@ -213,8 +213,12 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
-      - name: Check clippy
+      - name: Check clippy (default features)
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
+      - name: Check clippy (all features)
+        # We only test --all-features on nightly, because two of the features
+        # (read_buf, core_io_borrowed_buf) require nightly.
+        run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
 
   clang-tidy:
     name: Clang Tidy

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,17 @@ format:
 		-name '*.[c|h]' \
 		! -wholename 'src/rustls.h' | \
 			xargs clang-format -i
+	sed -i -e 's/ffi_panic_boundary! {/if true {/g' src/*.rs
+	cargo fmt
+	sed -i -e 's/if true {/ffi_panic_boundary! {/g' src/*.rs
 
 format-check:
 	find src tests \
 		-name '*.[c|h]' \
 		! -wholename 'src/rustls.h' | \
 			xargs clang-format --dry-run -Werror -i
+	sed -i -e 's/ffi_panic_boundary! {/if true {/g' src/*.rs
+	cargo fmt --check
+	sed -i -e 's/if true {/ffi_panic_boundary! {/g' src/*.rs
 
 .PHONY: all clean test integration format format-check

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -707,7 +707,7 @@ mod tests {
         assert_eq!(accepted_alert, null_mut());
 
         let sni = rustls_accepted::rustls_accepted_server_name(accepted);
-        let sni_as_slice = unsafe { std::slice::from_raw_parts(sni.data as *const u8, sni.len) };
+        let sni_as_slice = unsafe { slice::from_raw_parts(sni.data as *const u8, sni.len) };
         let sni_as_str = std::str::from_utf8(sni_as_slice).unwrap_or("%!(ERROR)");
         assert_eq!(sni_as_str, "example.com");
 
@@ -737,8 +737,8 @@ mod tests {
 
         assert_eq!(alpn.len(), 2);
         // No need to sort ALPN because order is determine by what the client sent.
-        let alpn0 = unsafe { std::slice::from_raw_parts(alpn[0].data, alpn[0].len) };
-        let alpn1 = unsafe { std::slice::from_raw_parts(alpn[1].data, alpn[1].len) };
+        let alpn0 = unsafe { slice::from_raw_parts(alpn[0].data, alpn[0].len) };
+        let alpn1 = unsafe { slice::from_raw_parts(alpn[1].data, alpn[1].len) };
         assert_eq!(alpn0, "zarp".as_bytes());
         assert_eq!(alpn1, "yuun".as_bytes());
 

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -3,9 +3,7 @@ use rustls::server::{Accepted, AcceptedAlert, Acceptor};
 
 use crate::connection::rustls_connection;
 use crate::error::{map_error, rustls_io_result};
-use crate::io::{
-    rustls_read_callback, rustls_write_callback, CallbackReader, CallbackWriter,
-};
+use crate::io::{rustls_read_callback, rustls_write_callback, CallbackReader, CallbackWriter};
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::server::rustls_server_config;
 use crate::{
@@ -184,7 +182,7 @@ impl rustls_acceptor {
                 Err((e, accepted_alert)) => {
                     set_boxed_mut_ptr(out_alert, accepted_alert);
                     map_error(e)
-                },
+                }
             }
         }
     }
@@ -338,7 +336,7 @@ impl rustls_accepted {
         i: usize,
     ) -> rustls_slice_bytes<'static> {
         ffi_panic_boundary! {
-            let accepted= try_ref_from_ptr!(accepted);
+            let accepted = try_ref_from_ptr!(accepted);
             let accepted = match accepted {
                 Some(a) => a,
                 None => return Default::default(),
@@ -419,7 +417,7 @@ impl rustls_accepted {
                 Err((e, accepted_alert)) => {
                     set_boxed_mut_ptr(out_alert, accepted_alert);
                     map_error(e)
-                },
+                }
             }
         }
     }
@@ -467,8 +465,11 @@ impl rustls_accepted_alert {
                 return rustls_io_result(EINVAL);
             }
             let accepted_alert = try_mut_from_ptr!(accepted_alert);
-            let mut writer = CallbackWriter { callback: try_callback!(callback), userdata };
-            let n_written= match accepted_alert.write(&mut writer) {
+            let mut writer = CallbackWriter {
+                callback: try_callback!(callback),
+                userdata,
+            };
+            let n_written = match accepted_alert.write(&mut writer) {
                 Ok(n) => n,
                 Err(e) => return rustls_io_result(e.raw_os_error().unwrap_or(EIO)),
             };
@@ -652,8 +653,7 @@ mod tests {
     }
 
     fn make_server_config() -> *const rustls_server_config {
-        let builder =
-            rustls_server_config_builder::rustls_server_config_builder_new();
+        let builder = rustls_server_config_builder::rustls_server_config_builder_new();
         let cert_pem = include_str!("../testdata/example.com/cert.pem").as_bytes();
         let key_pem = include_str!("../testdata/example.com/key.pem").as_bytes();
         let mut certified_key = null();

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -365,7 +365,7 @@ impl rustls_certified_key {
             Err(_) => return Err(rustls_result::CertificateParseError),
         };
 
-        Ok(rustls::sign::CertifiedKey::new(parsed_chain, signing_key))
+        Ok(CertifiedKey::new(parsed_chain, signing_key))
     }
 }
 
@@ -468,7 +468,7 @@ impl rustls_root_cert_store_builder {
 
             let filename = unsafe {
                 if filename.is_null() {
-                    return rustls_result::NullParameter;
+                    return NullParameter;
                 }
                 CStr::from_ptr(filename)
             };
@@ -485,8 +485,7 @@ impl rustls_root_cert_store_builder {
             };
 
             let mut bufreader = BufReader::new(&mut cafile);
-            let certs: Result<Vec<CertificateDer>, _> =
-                rustls_pemfile::certs(&mut bufreader).collect();
+            let certs: Result<Vec<CertificateDer>, _> = certs(&mut bufreader).collect();
             let certs = match certs {
                 Ok(certs) => certs,
                 Err(_) => return rustls_result::Io,

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -293,13 +293,13 @@ impl rustls_certified_key {
         cloned_key_out: *mut *const rustls_certified_key,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let cloned_key_out= unsafe {
+            let cloned_key_out = unsafe {
                 match cloned_key_out.as_mut() {
                     Some(c) => c,
                     None => return NullParameter,
                 }
             };
-            let certified_key= try_ref_from_ptr!(certified_key);
+            let certified_key = try_ref_from_ptr!(certified_key);
             let mut new_key = certified_key.clone();
             if !ocsp_response.is_null() {
                 let ocsp_slice = unsafe { &*ocsp_response };
@@ -657,8 +657,7 @@ impl rustls_web_pki_client_cert_verifier_builder {
         crl_pem_len: size_t,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let client_verifier_builder = try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -688,8 +687,7 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let client_verifier_builder = try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -710,8 +708,7 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let client_verifier_builder = try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -729,8 +726,7 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let client_verifier_builder = try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -752,8 +748,7 @@ impl rustls_web_pki_client_cert_verifier_builder {
         builder: *mut rustls_web_pki_client_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let client_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let client_verifier_builder = try_mut_from_ptr!(builder);
             let client_verifier_builder = match client_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -803,16 +798,15 @@ impl rustls_web_pki_client_cert_verifier_builder {
             if verifier_out.is_null() {
                 return NullParameter;
             }
-            let client_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let client_verifier_builder = try_mut_from_ptr!(builder);
             let client_verifier_builder = try_take!(client_verifier_builder);
             let verifier_out = try_mut_from_ptr_ptr!(verifier_out);
 
             let mut builder = WebPkiClientVerifier::builder_with_provider(
-                    client_verifier_builder.roots,
-                    rustls::crypto::ring::default_provider().into(),
-                )
-                .with_crls(client_verifier_builder.crls);
+                client_verifier_builder.roots,
+                rustls::crypto::ring::default_provider().into(),
+            )
+            .with_crls(client_verifier_builder.crls);
             match client_verifier_builder.revocation_depth {
                 RevocationCheckDepth::EndEntity => {
                     builder = builder.only_check_end_entity_revocation()
@@ -926,8 +920,7 @@ impl ServerCertVerifierBuilder {
         crl_pem_len: size_t,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let server_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let server_verifier_builder = try_mut_from_ptr!(builder);
             let server_verifier_builder = match server_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -958,8 +951,7 @@ impl ServerCertVerifierBuilder {
         builder: *mut rustls_web_pki_server_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let server_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let server_verifier_builder = try_mut_from_ptr!(builder);
             let server_verifier_builder = match server_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -980,8 +972,7 @@ impl ServerCertVerifierBuilder {
         builder: *mut rustls_web_pki_server_cert_verifier_builder,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let server_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let server_verifier_builder = try_mut_from_ptr!(builder);
             let server_verifier_builder = match server_verifier_builder {
                 None => return AlreadyUsed,
                 Some(v) => v,
@@ -1008,16 +999,15 @@ impl ServerCertVerifierBuilder {
             if verifier_out.is_null() {
                 return NullParameter;
             }
-            let server_verifier_builder =
-                try_mut_from_ptr!(builder);
+            let server_verifier_builder = try_mut_from_ptr!(builder);
             let server_verifier_builder = try_take!(server_verifier_builder);
             let verifier_out = try_mut_from_ptr_ptr!(verifier_out);
 
             let mut builder = WebPkiServerVerifier::builder_with_provider(
-                    server_verifier_builder.roots,
-                    rustls::crypto::ring::default_provider().into(),
-                )
-                .with_crls(server_verifier_builder.crls);
+                server_verifier_builder.roots,
+                rustls::crypto::ring::default_provider().into(),
+            )
+            .with_crls(server_verifier_builder.crls);
             match server_verifier_builder.revocation_depth {
                 RevocationCheckDepth::EndEntity => {
                     builder = builder.only_check_end_entity_revocation()

--- a/src/client.rs
+++ b/src/client.rs
@@ -595,7 +595,7 @@ mod tests {
         let builder = rustls_client_config_builder::rustls_client_config_builder_new();
         let h1 = "http/1.1".as_bytes();
         let h2 = "h2".as_bytes();
-        let alpn = vec![h1.into(), h2.into()];
+        let alpn = [h1.into(), h2.into()];
         rustls_client_config_builder::rustls_client_config_builder_set_alpn_protocols(
             builder,
             alpn.as_ptr(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,9 +65,7 @@ impl ServerCertVerifier for NoneVerifier {
         _ocsp_response: &[u8],
         _now: UnixTime,
     ) -> Result<ServerCertVerified, Error> {
-        Err(Error::InvalidCertificate(
-            CertificateError::UnknownIssuer,
-        ))
+        Err(Error::InvalidCertificate(CertificateError::UnknownIssuer))
     }
 
     fn verify_tls12_signature(
@@ -109,10 +107,11 @@ impl rustls_client_config_builder {
         ffi_panic_boundary! {
             // Unwrap safety: *ring* default provider always has ciphersuites compatible with the
             // default protocol versions.
-            let base =
-                ClientConfig::builder_with_provider(rustls::crypto::ring::default_provider().into())
-                    .with_safe_default_protocol_versions()
-                    .unwrap();
+            let base = ClientConfig::builder_with_provider(
+                rustls::crypto::ring::default_provider().into(),
+            )
+            .with_safe_default_protocol_versions()
+            .unwrap();
             let builder = ClientConfigBuilder {
                 base,
                 verifier: Arc::new(NoneVerifier),
@@ -152,8 +151,7 @@ impl rustls_client_config_builder {
             if builder_out.is_null() {
                 return NullParameter;
             }
-            let cipher_suites =
-                try_slice!(cipher_suites, cipher_suites_len);
+            let cipher_suites = try_slice!(cipher_suites, cipher_suites_len);
             let mut cs_vec = Vec::new();
             for &cs in cipher_suites.iter() {
                 let cs = try_ref_from_ptr!(cs);
@@ -279,9 +277,8 @@ impl ServerCertVerifier for Verifier {
             server_name,
             ocsp_response: ocsp_response.into(),
         };
-        let userdata = userdata_get().map_err(|_| {
-            Error::General("internal error with thread-local storage".to_string())
-        })?;
+        let userdata = userdata_get()
+            .map_err(|_| Error::General("internal error with thread-local storage".to_string()))?;
         let result = unsafe { cb(userdata, &params) };
         match rustls_result::from(result) {
             rustls_result::Ok => Ok(ServerCertVerified::assertion()),
@@ -451,9 +448,8 @@ impl rustls_client_config_builder {
         certified_keys_len: size_t,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let config= try_mut_from_ptr!(builder);
-            let keys_ptrs =
-                try_slice!(certified_keys, certified_keys_len);
+            let config = try_mut_from_ptr!(builder);
+            let keys_ptrs = try_slice!(certified_keys, certified_keys_len);
             let mut keys = Vec::new();
             for &key_ptr in keys_ptrs {
                 let certified_key = try_clone_arc!(key_ptr);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -242,7 +242,7 @@ impl rustls_connection {
         conn: *mut rustls_connection,
     ) -> rustls_result {
         ffi_panic_boundary! {
-            let conn= try_mut_from_ptr!(conn);
+            let conn = try_mut_from_ptr!(conn);
             let guard = match userdata_push(conn.userdata, conn.log_callback) {
                 Ok(g) => g,
                 Err(_) => return rustls_result::Panic,
@@ -356,7 +356,7 @@ impl rustls_connection {
         protocol_out_len: *mut usize,
     ) {
         ffi_panic_boundary! {
-            let conn= try_ref_from_ptr!(conn);
+            let conn = try_ref_from_ptr!(conn);
             if protocol_out.is_null() || protocol_out_len.is_null() {
                 return;
             }
@@ -523,8 +523,7 @@ impl rustls_connection {
             if buf.is_null() || out_n.is_null() {
                 return NullParameter;
             }
-            let read_buf =
-                unsafe { slice::from_raw_parts_mut(buf, count) };
+            let read_buf = unsafe { slice::from_raw_parts_mut(buf, count) };
 
             let mut read_buf: std::io::BorrowedBuf<'_> = read_buf.into();
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -409,7 +409,6 @@ impl rustls_connection {
                 // This type annotation is here to enforce the lifetime stated
                 // in the doccomment - that the returned pointer lives as long
                 // as the program.
-                let cs = cs;
                 if negotiated == *cs {
                     return cs as *const SupportedCipherSuite as *const _;
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -209,7 +209,7 @@ impl rustls_result {
                 return;
             }
             let error_str = rustls_result::from(result).to_string();
-            let out_len: usize = min(len - 1, error_str.len());
+            let out_len = min(len - 1, error_str.len());
             unsafe {
                 std::ptr::copy_nonoverlapping(error_str.as_ptr() as *mut c_char, buf, out_len);
                 *out_n = out_len;
@@ -270,15 +270,15 @@ fn test_rustls_error() {
     let mut buf = [0 as c_char; 512];
     let mut n = 0;
     rustls_result::rustls_error(0, &mut buf as *mut _, buf.len(), &mut n);
-    let output: String = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
+    let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
     assert_eq!(&output, "a parameter had an invalid value");
 
     rustls_result::rustls_error(7000, &mut buf as *mut _, buf.len(), &mut n);
-    let output: String = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
+    let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
     assert_eq!(&output, "OK");
 
     rustls_result::rustls_error(7101, &mut buf as *mut _, buf.len(), &mut n);
-    let output: String = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
+    let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
     assert_eq!(&output, "peer sent no certificates");
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -239,7 +239,7 @@ impl rustls_result {
 
 /// For cert-related rustls_results, turn them into a rustls::Error. For other
 /// inputs, including Ok, return rustls::Error::General.
-pub(crate) fn cert_result_to_error(result: rustls_result) -> rustls::Error {
+pub(crate) fn cert_result_to_error(result: rustls_result) -> Error {
     use rustls::Error::*;
     use rustls::OtherError;
     use rustls_result::*;
@@ -293,7 +293,7 @@ fn test_rustls_result_is_cert_error() {
     }
 }
 
-pub(crate) fn map_error(input: rustls::Error) -> rustls_result {
+pub(crate) fn map_error(input: Error) -> rustls_result {
     use rustls::AlertDescription as alert;
     use rustls_result::*;
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -39,7 +39,7 @@ pub(crate) struct CallbackReader {
 
 impl Read for CallbackReader {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let mut out_n: usize = 0;
+        let mut out_n = 0;
         let cb = self.callback;
         let result = unsafe { cb(self.userdata, buf.as_mut_ptr(), buf.len(), &mut out_n) };
         match result.0 {
@@ -84,7 +84,7 @@ pub(crate) struct CallbackWriter {
 
 impl Write for CallbackWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        let mut out_n: usize = 0;
+        let mut out_n = 0;
         let cb = self.callback;
         let result = unsafe { cb(self.userdata, buf.as_ptr(), buf.len(), &mut out_n) };
         match result.0 {
@@ -149,7 +149,7 @@ impl Write for VectoredCallbackWriter {
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
-        let mut out_n: usize = 0;
+        let mut out_n = 0;
         let cb = self.callback;
         let result = unsafe {
             cb(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn guard_try_pop() {
         let data = "hello";
-        let data_ptr: *mut c_void = data as *const _ as _;
+        let data_ptr = data as *const _ as _;
         let mut guard = userdata_push(data_ptr, None).unwrap();
         assert_eq!(userdata_get().unwrap(), data_ptr);
         guard.try_pop().unwrap();
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn guard_try_drop() {
         let data = "hello";
-        let data_ptr: *mut c_void = data as *const _ as _;
+        let data_ptr = data as *const _ as _;
         let guard = userdata_push(data_ptr, None).unwrap();
         assert_eq!(userdata_get().unwrap(), data_ptr);
         guard.try_drop().unwrap();
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn guard_drop() {
         let data = "hello";
-        let data_ptr: *mut c_void = data as *const _ as _;
+        let data_ptr = data as *const _ as _;
         {
             let _guard = userdata_push(data_ptr, None).unwrap();
             assert_eq!(userdata_get().unwrap(), data_ptr);
@@ -236,13 +236,13 @@ mod tests {
     #[test]
     fn nested_guards() {
         let hello = "hello";
-        let hello_ptr: *mut c_void = hello as *const _ as _;
+        let hello_ptr = hello as *const _ as _;
         {
             let guard = userdata_push(hello_ptr, None).unwrap();
             assert_eq!(userdata_get().unwrap(), hello_ptr);
             {
                 let yo = "yo";
-                let yo_ptr: *mut c_void = yo as *const _ as _;
+                let yo_ptr = yo as *const _ as _;
                 let guard2 = userdata_push(yo_ptr, None).unwrap();
                 assert_eq!(userdata_get().unwrap(), yo_ptr);
                 guard2.try_drop().unwrap();
@@ -256,12 +256,12 @@ mod tests {
     #[test]
     fn out_of_order_drop() {
         let hello = "hello";
-        let hello_ptr: *mut c_void = hello as *const _ as _;
+        let hello_ptr = hello as *const _ as _;
         let guard = userdata_push(hello_ptr, None).unwrap();
         assert_eq!(userdata_get().unwrap(), hello_ptr);
 
         let yo = "yo";
-        let yo_ptr: *mut c_void = yo as *const _ as _;
+        let yo_ptr = yo as *const _ as _;
         let guard2 = userdata_push(yo_ptr, None).unwrap();
         assert_eq!(userdata_get().unwrap(), yo_ptr);
 
@@ -272,18 +272,18 @@ mod tests {
     #[test]
     fn userdata_multi_threads() {
         let hello = "hello";
-        let hello_ptr: *mut c_void = hello as *const _ as _;
+        let hello_ptr = hello as *const _ as _;
         let guard = userdata_push(hello_ptr, None).unwrap();
         assert_eq!(userdata_get().unwrap(), hello_ptr);
 
         let thread1 = thread::spawn(|| {
             let yo = "yo";
-            let yo_ptr: *mut c_void = yo as *const _ as _;
+            let yo_ptr = yo as *const _ as _;
             let guard2 = userdata_push(yo_ptr, None).unwrap();
             assert_eq!(userdata_get().unwrap(), yo_ptr);
 
             let greetz = "greetz";
-            let greetz_ptr: *mut c_void = greetz as *const _ as _;
+            let greetz_ptr = greetz as *const _ as _;
 
             let guard3 = userdata_push(greetz_ptr, None).unwrap();
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,10 +1,15 @@
 use libc::c_void;
 use log::Level;
 
-use crate::{log_callback_get, rslice::rustls_str};
+#[cfg(not(feature = "no_log_capture"))]
+use crate::log_callback_get;
 
+use crate::rslice::rustls_str;
+
+#[cfg(not(feature = "no_log_capture"))]
 struct Logger {}
 
+#[cfg(not(feature = "no_log_capture"))]
 impl log::Log for Logger {
     fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
         true

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -89,7 +89,7 @@ pub extern "C" fn rustls_slice_slice_bytes_get(
     input: *const rustls_slice_slice_bytes,
     n: size_t,
 ) -> rustls_slice_bytes {
-    let input: &rustls_slice_slice_bytes = {
+    let input = {
         match unsafe { input.as_ref() } {
             Some(c) => c,
             None => {
@@ -378,7 +378,7 @@ impl<'a> From<&'a [u16]> for rustls_slice_u16<'a> {
 
 #[test]
 fn test_rustls_slice_u16() {
-    let u16s: Vec<u16> = vec![101, 314, 2718];
+    let u16s = vec![101, 314, 2718];
     let rsu: rustls_slice_u16 = (&*u16s).into();
     assert_eq!(rsu.len, 3);
     unsafe {

--- a/src/server.rs
+++ b/src/server.rs
@@ -556,7 +556,7 @@ impl rustls_server_config_builder {
         ffi_panic_boundary! {
             let callback = match callback {
                 Some(cb) => cb,
-                None => return rustls_result::NullParameter,
+                None => return NullParameter,
             };
             let builder = try_mut_from_ptr!(builder);
             builder.cert_resolver = Some(Arc::new(ClientHelloResolver::new(callback)));
@@ -632,11 +632,11 @@ impl rustls_server_config_builder {
         ffi_panic_boundary! {
             let get_cb = match get_cb {
                 Some(cb) => cb,
-                None => return rustls_result::NullParameter,
+                None => return NullParameter,
             };
             let put_cb = match put_cb {
                 Some(cb) => cb,
-                None => return rustls_result::NullParameter,
+                None => return NullParameter,
             };
             let builder = try_mut_from_ptr!(builder);
             builder.session_storage = Some(Arc::new(SessionStoreBroker::new(get_cb, put_cb)));

--- a/src/server.rs
+++ b/src/server.rs
@@ -654,7 +654,7 @@ mod tests {
         let builder = rustls_server_config_builder::rustls_server_config_builder_new();
         let h1 = "http/1.1".as_bytes();
         let h2 = "h2".as_bytes();
-        let alpn = vec![h1.into(), h2.into()];
+        let alpn = [h1.into(), h2.into()];
         rustls_server_config_builder::rustls_server_config_builder_set_alpn_protocols(
             builder,
             alpn.as_ptr(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -66,10 +66,11 @@ impl rustls_server_config_builder {
         ffi_panic_boundary! {
             // Unwrap safety: *ring* default provider always has ciphersuites compatible with the
             // default protocol versions.
-            let base =
-                ServerConfig::builder_with_provider(rustls::crypto::ring::default_provider().into())
-                    .with_safe_default_protocol_versions()
-                    .unwrap();
+            let base = ServerConfig::builder_with_provider(
+                rustls::crypto::ring::default_provider().into(),
+            )
+            .with_safe_default_protocol_versions()
+            .unwrap();
             let builder = ServerConfigBuilder {
                 base,
                 verifier: WebPkiClientVerifier::no_client_auth(),
@@ -108,8 +109,7 @@ impl rustls_server_config_builder {
             if builder_out.is_null() {
                 return NullParameter;
             }
-            let cipher_suites =
-                try_slice!(cipher_suites, cipher_suites_len);
+            let cipher_suites = try_slice!(cipher_suites, cipher_suites_len);
             let mut cs_vec = Vec::new();
             for &cs in cipher_suites.iter() {
                 let cs = try_ref_from_ptr!(cs);
@@ -248,8 +248,7 @@ impl rustls_server_config_builder {
     ) -> rustls_result {
         ffi_panic_boundary! {
             let builder = try_mut_from_ptr!(builder);
-            let keys_ptrs=
-                try_slice!(certified_keys, certified_keys_len);
+            let keys_ptrs = try_slice!(certified_keys, certified_keys_len);
             let mut keys = Vec::new();
             for &key_ptr in keys_ptrs {
                 let certified_key = try_clone_arc!(key_ptr);
@@ -600,8 +599,7 @@ pub extern "C" fn rustls_client_hello_select_certified_key(
         if out_key.is_null() {
             return NullParameter;
         }
-        let keys_ptrs=
-            try_slice!(certified_keys, certified_keys_len);
+        let keys_ptrs = try_slice!(certified_keys, certified_keys_len);
         for &key_ptr in keys_ptrs {
             let key_ref = try_ref_from_ptr!(key_ptr);
             if key_ref.key.choose_scheme(&schemes).is_some() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -95,8 +95,8 @@ impl SessionStoreBroker {
         // This is excessive in size, but the returned data in rustls is
         // only read once and then dropped.
         // See <https://github.com/rustls/rustls-ffi/pull/64#issuecomment-800766940>
-        let mut data: Vec<u8> = vec![0; 65 * 1024];
-        let mut out_n: size_t = 0;
+        let mut data = vec![0; 65 * 1024];
+        let mut out_n = 0;
 
         let cb = self.get_cb;
         let result = unsafe {
@@ -119,8 +119,8 @@ impl SessionStoreBroker {
     }
 
     fn store(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
-        let key: rustls_slice_bytes = key.as_slice().into();
-        let value: rustls_slice_bytes = value.as_slice().into();
+        let key = key.as_slice().into();
+        let value = value.as_slice().into();
         let cb = self.put_cb;
         let userdata = match userdata_get() {
             Ok(u) => u,


### PR DESCRIPTION
It might be best to review this commit-by-commit. The total overall changeset should have no functional effect - it's exclusively stylistic changes.

* Removes explicit typing throughout, whenever the compiler can successfully infer the types on its own
* Fixes redundant prefixing throughout, whenever an item was already in-scope without the prefix
* Fixes a couple clippy findings that fell out of ^
* Applies a project-wide formatting pass, including within the `ffi_panic_boundary!` macro bodies (using the approach ctz used in https://github.com/rustls/rustls-ffi/pull/383 and that we're using [in rustls-openssl-compat](https://github.com/rustls/rustls-openssl-compat/blob/main/rustls-libssl/admin/format)).
* Updates `make format` and `make format-check` to enforce rust formatting within the `ffi_panic_boundary!` macros

Resolves https://github.com/rustls/rustls-ffi/issues/31