### PR TITLE
chore: update to use spdx license identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls-ffi"
 version = "0.13.0"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
-license = "Apache-2.0/ISC/MIT"
+license = "Apache-2.0 OR ISC OR MIT"
 readme = "README-crates.io.md"
 description = "Rustls bindings for non-Rust languages"
 homepage = "https://github.com/rustls/rustls-ffi"


### PR DESCRIPTION
Update to use SPDX license format, same as [rusttls](https://github.com/rustls/rustls/blob/0c85c0199f479e71c8c4811684fd8de779fb8c21/rustls/Cargo.toml#L6).

also relates to https://github.com/Homebrew/homebrew-core/pull/173482