### PR TITLE
`rustls_version()` integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +146,15 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-bigint"
@@ -260,6 +285,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "rustls-webpki",
+ "toml",
 ]
 
 [[package]]
@@ -378,6 +404,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c68e921cef53841b8925c2abadd27c9b891d9613bdc43d6b823062866df38e8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +473,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb9d890e4dc9298b70f740f615f2e05b9db37dce531f6b24fb77ac993f9f217"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ capi = []
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.4", default-features = false, features = [ "ring", "std", "tls12" ]}
+rustls = { version = "0.23.4", default-features = false, features = ["ring", "std", "tls12"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
-webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [ "ring", "std" ] }
+webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["ring", "std"] }
 libc = "0.2"
 rustls-pemfile = "2"
 log = "0.4.17"
@@ -54,4 +54,4 @@ name = "rustls"
 filename = "rustls"
 
 [package.metadata.capi.install.include]
-asset = [{from = "src/rustls.h", to = "" }]
+asset = [{ from = "src/rustls.h", to = "" }]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ crate-type = ["lib", "staticlib"]
 
 [dev-dependencies]
 regex = "1.9.6"
+toml = { version = "0.6.0", default-features = false, features = ["parse"] }
 
 [package.metadata.capi.header]
 name = "rustls"

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,11 @@ use std::io::Write;
 use std::{env, fs, path::PathBuf};
 
 // Keep in sync with Cargo.toml.
+//
+// We don't populate this automatically from the Cargo.toml at build time
+// because doing so would require a heavy-weight deserialization lib dependency
+// (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
+// by-hand parsing.
 const RUSTLS_CRATE_VERSION: &str = "0.23.4";
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,15 +705,6 @@ pub extern "C" fn rustls_version() -> rustls_str<'static> {
     rustls_str::from_str_unchecked(RUSTLS_FFI_VERSION)
 }
 
-#[test]
-fn test_rustls_version() {
-    // very rough check that the version number is being interpolated into the
-    // variable
-    assert!(RUSTLS_FFI_VERSION.contains("/0."));
-    let vsn = rustls_version();
-    assert!(vsn.len > 4)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/rustls_version.rs
+++ b/tests/rustls_version.rs
@@ -1,0 +1,70 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use std::{slice, str};
+
+use toml::Table;
+
+use rustls_ffi::rustls_version;
+
+/// Test that the output of `rustls_version()` matches what we expect based on Cargo.toml state.
+///
+/// In particular this ensures that the Rustls version reported in the rustls-ffi version string
+/// matches the version of the Rustls dependency that rustls-ffi was built with.
+///
+/// If this test starts to fail, you probably forgot to update `RUSTLS_CRATE_VERSION` in
+/// `build.rs`.
+#[cfg_attr(miri, ignore)] // Requires file I/O
+#[test]
+fn rustls_version_match() {
+    // Parse Cargo.toml as a generic TOML Table.
+    let mut metadata_file =
+        File::open(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+            .expect("failed to open Cargo.toml");
+    let mut metadata_content = String::new();
+    metadata_file
+        .read_to_string(&mut metadata_content)
+        .expect("failed to read Cargo.toml");
+    let metadata = metadata_content.parse::<Table>().unwrap();
+
+    // Find the crate version specified in Cargo.toml
+    let package_metadata = metadata["package"]
+        .as_table()
+        .expect("missing package metadata");
+    let crate_version = package_metadata["version"]
+        .as_str()
+        .expect("missing crate version");
+
+    // Find the rustls dependency version specified in Cargo.toml
+    let deps = metadata["dependencies"].as_table().unwrap();
+    let rustls_dep = &deps["rustls"];
+    let rustls_dep_version = match rustls_dep.as_table() {
+        // Handle the `rustls = { version = "x.y.z", ... }` case
+        Some(table) => table["version"].as_str(),
+        // Handle the `rustls = "x.y.z"` case
+        None => rustls_dep.as_str(),
+    }
+    .expect("missing rustls dependency version");
+
+    // Assert that rustls_version() returns a string of the form:
+    //   $CRATE_NAME/$CRATE_VERSION/rustls/$RUSTLS_VERSION
+    // E.g.:
+    //   rustls-ffi/0.13.0/rustls/0.23.4
+    let rustls_ffi_version = rustls_version();
+    let rustls_ffi_version = unsafe {
+        str::from_utf8_unchecked(slice::from_raw_parts(
+            rustls_ffi_version.data as *const u8,
+            rustls_ffi_version.len,
+        ))
+    };
+    let rustls_ffi_version_parts = rustls_ffi_version.split('/').collect::<Vec<_>>();
+    assert_eq!(
+        rustls_ffi_version_parts,
+        vec![
+            env!("CARGO_PKG_NAME"),
+            crate_version,
+            "rustls",
+            rustls_dep_version,
+        ]
+    );
+}


### PR DESCRIPTION
Figuring out something to do about the manually sync'd `RUSTLS_CRATE_VERSION` constant in `build.rs` has been on my mind for a while.

As explained in the new `build.rs` comment I was originally thinking about populating the `const` automatically, but I decided against that because it seemed like it would require brittle by-hand parsing, or taking a new dep (_unfortunately, it can't be a development dependency if used in `build.rs`_). Both seemed like bad options so I landed on adding an integration test to catch if we forget to update the constant. This has the added advantage of also replacing an existing looser unit test with one that matches the full expected value from `rustls_version()` without adding any new hardcoded constants to maintain.



