### PR TITLE
ci: pin cargo-c version in pkg-config workflow

### DIFF
--- a/.github/workflows/pkg-config.yaml
+++ b/.github/workflows/pkg-config.yaml
@@ -33,10 +33,13 @@ jobs:
         if: runner.os == 'macos-latest'
         run: brew install pkg-config
 
+      - name: Show pkg-config version
+        run: pkg-config --version
+
       - name: Install cargo-c (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         env:
-          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          LINK: https://github.com/lu-zero/cargo-c/releases/download/v0.9.32
           CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
         run: |
           curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin


### PR DESCRIPTION
The recent 0.10.0 release seems to be causing a regression. Until we've had a chance to dig into the root cause let's pin the version in-use in CI to keep the build passing.

I also snuck in an update to print the pkg-config version in-use. I was interested in that data when I wasn't sure if it was the cargo-c update that changed things or if there was an unrelated system image update that bork'd it.