### PR TITLE
ci: revert cargo-c pin, set libdir explicitly

### DIFF
--- a/.github/workflows/pkg-config.yaml
+++ b/.github/workflows/pkg-config.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install cargo-c (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         env:
-          LINK: https://github.com/lu-zero/cargo-c/releases/download/v0.9.32
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
           CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
         run: |
           curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin

--- a/.github/workflows/pkg-config.yaml
+++ b/.github/workflows/pkg-config.yaml
@@ -54,7 +54,11 @@ jobs:
           unzip cargo-c-macos.zip -d ~/.cargo/bin
 
       - name: Install the library
-        run: make --file=Makefile.pkg-config PREFIX=${PREFIX} install
+        # NOTE: We set --libdir explicitly to avoid per-system/distro path components
+        #       that will complicate setting PKG_CONFIG_PATH/LD_LIBRARY_PATH.
+        run: >
+          CARGOFLAGS=--libdir=lib
+          make --file=Makefile.pkg-config PREFIX=${PREFIX} install
 
       - name: Build the client/server examples
         run: PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig make --file=Makefile.pkg-config PROFILE=debug


### PR DESCRIPTION
This undoes (https://github.com/rustls/rustls-ffi/pull/435) (_but leaves the `pkg-config --version` print_). 

The root cause of the behaviour change is now better understood and documented upstream in the changelog (https://github.com/lu-zero/cargo-c/pull/380). We take the recommendation documented there and set `--libdir` explicitly so our CI job can continue to treat Ubuntu/MacOS the same w.r.t `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH`. 