### PR TITLE
build(deps): bump rustls from 0.23.4 to 0.23.5，fix CVE-2024-32650

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
+checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
 dependencies = [
  "once_cell",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ capi = []
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.4", default-features = false, features = ["ring", "std", "tls12"] }
+rustls = { version = "=0.23.5", default-features = false, features = ["ring", "std", "tls12"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["ring", "std"] }
 libc = "0.2"


### PR DESCRIPTION
rustls-0.23.5 fix CVE-2024-32650, see https://nvd.nist.gov/vuln/detail/CVE-2024-32650

We need to bump it for security!