### PR TITLE
lib: allow renamed_and_removed_lints for now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![crate_type = "staticlib"]
 #![allow(non_camel_case_types)]
+// TODO(XXX): Remove `renamed_and_removed_lints` once stable renames `thread_local_initializer_can_be_made_const`
+#![allow(renamed_and_removed_lints)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 // TODO(#333): Fix this clippy warning.
 #![allow(clippy::arc_with_non_send_sync)]
@@ -54,7 +56,9 @@ include!(concat!(env!("OUT_DIR"), "/version.rs"));
 // Rust code, we model these thread locals as a stack, so we can always
 // restore the previous version.
 thread_local! {
-    #[allow(clippy::thread_local_initializer_can_be_made_const)]
+    // TODO(XXX): Remove 'thread_local_initializer_can_be_made_const' in the future
+    //            once stable has renamed.
+    #[allow(clippy::thread_local_initializer_can_be_made_const, clippy::missing_const_for_thread_local)]
     pub(crate) static USERDATA: RefCell<Vec<Userdata>> = RefCell::new(Vec::new());
 }
 


### PR DESCRIPTION
Nightly clippy renamed `thread_local_initializer_can_be_made_const` to `missing_const_for_thread_local`. E.g [see this clippy failure](https://github.com/rustls/rustls-ffi/actions/runs/10014109447/job/27683120699?pr=441).

We can't use the new name on stable; we must keep using the old name to suppress the finding. If we don't allow `renamed_and_removed_lints`, we can't use the old name on nightly; it generates a warning about the new name... Using _both_ names won't work for the same reason, and our setting to allow _unknown_ lints won't help.

There's no convenient way to change which name we use based on whether we're building with nightly or not so, for now, let's just allow `renamed_and_removed_lints` :-( The only alternative I could think of is to ignore the failing nightly clippy task (since it's optional), but that seems crummy too. Alternate ideas welcome!