### PR TITLE
doc: fix comment on WebPKI and platform verifier

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -1055,8 +1055,9 @@ box_castable! {
 }
 
 impl rustls_server_cert_verifier {
-    /// Create a new server certificate verifier that uses the system's root store and WebPKI via
-    /// [`rustls-platform-verifier`][].
+    /// Create a verifier that uses the default behavior for the current platform.
+    ///
+    /// This uses [`rustls-platform-verifier`][].
     ///
     /// The verifier can be used in several `rustls_client_config` instances and must be freed by
     /// the application using `rustls_server_cert_verifier_free` when no longer needed.

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1257,8 +1257,9 @@ rustls_result rustls_web_pki_server_cert_verifier_builder_build(struct rustls_we
 void rustls_web_pki_server_cert_verifier_builder_free(struct rustls_web_pki_server_cert_verifier_builder *builder);
 
 /**
- * Create a new server certificate verifier that uses the system's root store and WebPKI via
- * [`rustls-platform-verifier`][].
+ * Create a verifier that uses the default behavior for the current platform.
+ *
+ * This uses [`rustls-platform-verifier`][].
  *
  * The verifier can be used in several `rustls_client_config` instances and must be freed by
  * the application using `rustls_server_cert_verifier_free` when no longer needed.


### PR DESCRIPTION
Since the webpki crate is a specific implementation (which is chosen by the platform verifier crate on some platforms), it was confusing to call it out by name. Instead, simplify the comment to say it uses "the default behavior for the current platform."