### PR TITLE
pkg-config.yml: fix typo

### DIFF
--- a/.github/workflows/pkg-config.yaml
+++ b/.github/workflows/pkg-config.yaml
@@ -29,10 +29,6 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install pkg-config (macOS)
-        if: runner.os == 'macos-latest'
-        run: brew install pkg-config
-
       - name: Show pkg-config version
         run: pkg-config --version
 


### PR DESCRIPTION
The "Install pkg-config (macOS)" step was always skipped (see eg https://github.com/rustls/rustls-ffi/actions/runs/10701958885/job/29669050520) because "runner.os" has possible values "Linux", "Windows", "macOS". I think `matrix.os` was intended here.

(However the job worked anyway, so maybe this step could be removed?)