### PR TITLE
crypto_provider: expose a way to get CSRNG data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.14.0 (2024-08-01)
+## 0.14.0-rc1 (2024-09-09)
 
 This release updates to [Rustls 0.23.12][] and changes the rustls-ffi API to allow
 choosing a cryptography provider to use with Rustls. 
@@ -30,6 +30,9 @@ requirements.
   * Ciphersuites supported by the current process-wide default crypto provider (if any) can
     be retrieved with `rustls_default_crypto_provider_ciphersuites_len()` and 
     `rustls_default_crypto_provider_ciphersuites_get()`.
+  * A buffer can be filled with cryptographically secure random data from
+    a specific `rustls_crypto_provider` using `rustls_crypto_provider_random()`,
+    or the process-wide default provider using `rustls_default_crypto_provider_random()`.
 
 * A new `RUSTLS_RESULT_NO_DEFAULT_CRYPTO_PROVIDER` `rustls_result` was added to
   indicate when an operation that requires a process-wide default crypto

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,7 @@ u32_enum_builder! {
         CertificateRevocationListParseError => 7014,
         NoServerCertVerifier => 7015,
         NoDefaultCryptoProvider => 7016,
+        GetRandomFailed => 7017,
 
         // From https://docs.rs/rustls/latest/rustls/enum.Error.html
         NoCertificatesPresented => 7101,
@@ -494,6 +495,9 @@ impl Display for rustls_result {
                     f,
                     "no default process-wide crypto provider has been installed"
                 )
+            }
+            GetRandomFailed => {
+                write!(f, "failed to get random bytes from the crypto provider")
             }
 
             CertEncodingBad => Error::InvalidCertificate(CertificateError::BadEncoding).fmt(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,6 +679,18 @@ macro_rules! try_slice {
 
 pub(crate) use try_slice;
 
+macro_rules! try_slice_mut {
+    ( $ptr:expr, $count:expr ) => {
+        if $ptr.is_null() {
+            return $crate::panic::NullParameterOrDefault::value();
+        } else {
+            unsafe { slice::from_raw_parts_mut($ptr, $count) }
+        }
+    };
+}
+
+pub(crate) use try_slice_mut;
+
 macro_rules! try_callback {
     ( $var:ident ) => {
         match $var {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ macro_rules! try_slice {
         if $ptr.is_null() {
             return $crate::panic::NullParameterOrDefault::value();
         } else {
-            unsafe { slice::from_raw_parts($ptr, $count as usize) }
+            unsafe { slice::from_raw_parts($ptr, $count) }
         }
     };
 }

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -25,6 +25,7 @@ enum rustls_result {
   RUSTLS_RESULT_CERTIFICATE_REVOCATION_LIST_PARSE_ERROR = 7014,
   RUSTLS_RESULT_NO_SERVER_CERT_VERIFIER = 7015,
   RUSTLS_RESULT_NO_DEFAULT_CRYPTO_PROVIDER = 7016,
+  RUSTLS_RESULT_GET_RANDOM_FAILED = 7017,
   RUSTLS_RESULT_NO_CERTIFICATES_PRESENTED = 7101,
   RUSTLS_RESULT_DECRYPT_ERROR = 7102,
   RUSTLS_RESULT_FAILED_TO_GET_CURRENT_TIME = 7103,
@@ -2054,6 +2055,18 @@ rustls_result rustls_crypto_provider_load_key(const struct rustls_crypto_provide
                                               struct rustls_signing_key **signing_key_out);
 
 /**
+ * Write `len` bytes of cryptographically secure random data to `buff` using the crypto provider.
+ *
+ * `buff` must point to a buffer of at least `len` bytes. The caller maintains ownership
+ * of the buffer.
+ *
+ * Returns `RUSTLS_RESULT_OK` on success, or `RUSTLS_RESULT_GET_RANDOM_FAILED` on failure.
+ */
+rustls_result rustls_crypto_provider_random(const struct rustls_crypto_provider *provider,
+                                            uint8_t *buff,
+                                            size_t len);
+
+/**
  * Frees the `rustls_crypto_provider`.
  *
  * Calling with `NULL` is fine.
@@ -2081,6 +2094,18 @@ size_t rustls_default_crypto_provider_ciphersuites_len(void);
  * default provider lives for as long as the process.
  */
 const struct rustls_supported_ciphersuite *rustls_default_crypto_provider_ciphersuites_get(size_t index);
+
+/**
+ * Write `len` bytes of cryptographically secure random data to `buff` using the process-wide
+ * default crypto provider.
+ *
+ * `buff` must point to a buffer of at least `len` bytes. The caller maintains ownership
+ * of the buffer.
+ *
+ * Returns `RUSTLS_RESULT_OK` on success, and one of `RUSTLS_RESULT_NO_DEFAULT_CRYPTO_PROVIDER`
+ * or `RUSTLS_RESULT_GET_RANDOM_FAILED` on failure.
+ */
+rustls_result rustls_default_crypto_provider_random(uint8_t *buff, size_t len);
 
 /**
  * Frees the `rustls_signing_key`. This is safe to call with a `NULL` argument, but


### PR DESCRIPTION
This branch adds a `rustls_crypto_provider_random()` fn for filling a buffer with cryptographically secure random data using a  specific `rustls_crypto_provider`, and `rustls_default_crypto_provider_random()` for the same with the process-wide default. Doing so requires adding a `try_slice_mut!` macro to accompany the existing `try_slice!` macro. It's similar in function but returns a `&mut` slice using `slice::from_raw_parts_mut()` instead of `slice::from_raw_parts()`.

This should help with downstream issues like https://github.com/curl/curl/pull/14770 where `rustls-ffi` stands out as the only TLS `vtls` backend in `curl` that can't provide this functionality.