### PR TITLE
ci: remove unneeded cargo-c job in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -258,18 +258,6 @@ jobs:
       - name: Clang tidy
         run: clang-tidy tests/*.c -- -I src/
 
-  cargo-c:
-    name: cargo-c
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-
   miri:
     name: Miri
     runs-on: ubuntu-latest


### PR DESCRIPTION
We test cargo-c in the `pkg-config.yaml` workflow now. Additionally what was left of the `cargo-c` job was simply checking out the src and installing Rust but doing no actual work/testing of `rustls-ffi`... Oops! :sweat_smile: 