### PR TITLE
cipher: allow getting the proto of a ciphersuite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ requirements.
       a `rustls_client_config_builder` with
       `rustls_client_config_builder_set_server_verifier()`.
 
+* A new `rustls_supported_ciphersuite_protocol_version()` function was added for
+  getting the `rustls_tls_version` IANA registered protocol version identifier
+  supported by a given `rustls_supported_ciphersuite`.
+
 * When using `aws-lc-rs` as the crypto provider, NIST P-521 signatures are now
   supported.
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,13 +1,31 @@
+use rustls::{ProtocolVersion, SupportedProtocolVersion};
+
+#[derive(Debug, Default)]
 #[repr(C)]
-#[allow(dead_code)]
 /// Definitions of known TLS protocol versions.
 pub enum rustls_tls_version {
+    #[default]
+    Unknown = 0x0000,
     Sslv2 = 0x0200,
     Sslv3 = 0x0300,
     Tlsv1_0 = 0x0301,
     Tlsv1_1 = 0x0302,
     Tlsv1_2 = 0x0303,
     Tlsv1_3 = 0x0304,
+}
+
+impl From<&SupportedProtocolVersion> for rustls_tls_version {
+    fn from(version: &SupportedProtocolVersion) -> Self {
+        match version.version {
+            ProtocolVersion::SSLv2 => rustls_tls_version::Sslv2,
+            ProtocolVersion::SSLv3 => rustls_tls_version::Sslv3,
+            ProtocolVersion::TLSv1_0 => rustls_tls_version::Tlsv1_0,
+            ProtocolVersion::TLSv1_1 => rustls_tls_version::Tlsv1_1,
+            ProtocolVersion::TLSv1_2 => rustls_tls_version::Tlsv1_2,
+            ProtocolVersion::TLSv1_3 => rustls_tls_version::Tlsv1_3,
+            _ => rustls_tls_version::Unknown,
+        }
+    }
 }
 
 /// Rustls' list of supported protocol versions. The length of the array is

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,5 +1,6 @@
 use libc::EINVAL;
 
+use crate::enums::rustls_tls_version;
 use crate::error::{rustls_io_result, rustls_result};
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 
@@ -28,9 +29,15 @@ pub(crate) trait NullParameterOrDefault {
 pub(crate) trait Defaultable: Default {}
 
 impl Defaultable for u16 {}
+
 impl Defaultable for usize {}
+
 impl Defaultable for bool {}
+
 impl Defaultable for () {}
+
+impl Defaultable for rustls_tls_version {}
+
 impl<T> Defaultable for Option<T> {}
 
 impl<'a> Defaultable for rustls_slice_bytes<'a> {}

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -128,6 +128,7 @@ typedef uint32_t rustls_result;
  * Definitions of known TLS protocol versions.
  */
 typedef enum rustls_tls_version {
+  RUSTLS_TLS_VERSION_UNKNOWN = 0,
   RUSTLS_TLS_VERSION_SSLV2 = 512,
   RUSTLS_TLS_VERSION_SSLV3 = 768,
   RUSTLS_TLS_VERSION_TLSV1_0 = 769,
@@ -1017,6 +1018,13 @@ uint16_t rustls_supported_ciphersuite_get_suite(const struct rustls_supported_ci
  * it does not need to be freed.
  */
 struct rustls_str rustls_supported_ciphersuite_get_name(const struct rustls_supported_ciphersuite *supported_ciphersuite);
+
+/**
+ * Returns the `rustls_tls_version` of the ciphersuite.
+ *
+ * See also `RUSTLS_ALL_VERSIONS`.
+ */
+enum rustls_tls_version rustls_supported_ciphersuite_protocol_version(const struct rustls_supported_ciphersuite *supported_ciphersuite);
 
 /**
  * Build a `rustls_certified_key` from a certificate chain and a private key


### PR DESCRIPTION
This commit adds a `rustls_supported_ciphersuite_protocol_version()` fn for getting the IANA registered protocol version identifier supported by a given `rustls_supported_ciphersuite`. This avoids downstream users having to use `rustls_supported_ciphersuite_get_name()` and then matching on the protocol version prefix in that identifier (e.g. https://github.com/curl/curl/pull/14840). This is equivalent to the upstream [`SupportedCipherSuite.version()`](https://docs.rs/rustls/latest/rustls/enum.SupportedCipherSuite.html#method.version) fn, but tailored to FFI users.