### PR TITLE
0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 0.14.0-rc1 (pending)
+## 0.14.0 (2024-09-12)
 
 This release updates to [Rustls 0.23.13][] and changes the rustls-ffi API to allow
-choosing a cryptography provider to use with Rustls. 
+choosing a cryptography provider to use with Rustls.
 
 The default provider has been changed to match the Rustls default,
 [`aws-lc-rs`][]. Users that wish to continue using `*ring*` as the provider may

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.14.0-rc1"
+version = "0.14.0"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.14.0-rc1"
+version = "0.14.0"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README-crates.io.md"
 description = "Rustls bindings for non-Rust languages"


### PR DESCRIPTION
This branch updates the Cargo version to prepare for the finalized 0.14.0 release. See `CHANGELOG.md` for release notes.