### PR TITLE
client/server: support for KeyLog trait, SSLKEYLOGFILE

### DIFF
--- a/src/keylog.rs
+++ b/src/keylog.rs
@@ -1,0 +1,88 @@
+//! Provides FFI abstractions for the [`rustls::KeyLog`] trait.
+
+use std::ffi::c_int;
+use std::fmt;
+
+use crate::rslice::rustls_str;
+
+/// An optional callback for logging key material.
+///
+/// See the documentation on `rustls_client_config_builder_set_key_log` and
+/// `rustls_server_config_builder_set_key_log` for more information about the
+/// lifetimes of the parameters.
+pub type rustls_keylog_log_callback = Option<
+    unsafe extern "C" fn(
+        label: rustls_str,
+        client_random: *const u8,
+        client_random_len: usize,
+        secret: *const u8,
+        secret_len: usize,
+    ),
+>;
+
+/// An optional callback for deciding if key material will be logged.
+///
+/// See the documentation on `rustls_client_config_builder_set_key_log` and
+/// `rustls_server_config_builder_set_key_log` for more information about the
+/// lifetimes of the parameters.
+pub type rustls_keylog_will_log_callback = Option<unsafe extern "C" fn(label: rustls_str) -> c_int>;
+
+/// A type alias for a keylog log callback that has been extracted from an option.
+pub(crate) type KeylogLogCallback = unsafe extern "C" fn(
+    label: rustls_str,
+    client_random: *const u8,
+    client_random_len: usize,
+    secret: *const u8,
+    secret_len: usize,
+);
+
+/// An implementation of `rustls::KeyLog` based on C callbacks.
+pub(crate) struct CallbackKeyLog {
+    // We use the crate-internal rust type here - it is _not_ Option wrapped.
+    pub(crate) log_cb: KeylogLogCallback,
+    // We use the pub type alias here - it is Option wrapped and may be None.
+    pub(crate) will_log_cb: rustls_keylog_will_log_callback,
+}
+
+impl rustls::KeyLog for CallbackKeyLog {
+    fn log(&self, label: &str, client_random: &[u8], secret: &[u8]) {
+        unsafe {
+            (self.log_cb)(
+                // Safety: Rustls will never give us a label containing NULL.
+                rustls_str::try_from(label).unwrap(),
+                client_random.as_ptr(),
+                client_random.len(),
+                secret.as_ptr(),
+                secret.len(),
+            );
+        }
+    }
+
+    fn will_log(&self, label: &str) -> bool {
+        match self.will_log_cb {
+            Some(cb) => {
+                // Safety: Rustls will never give us a label containing NULL.
+                let label = rustls_str::try_from(label).unwrap();
+                // Log iff the cb returned non-zero.
+                !matches!(unsafe { (cb)(label) }, 0)
+            }
+            // Default to logging everything.
+            None => true,
+        }
+    }
+}
+
+impl fmt::Debug for CallbackKeyLog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CallbackKeyLog").finish()
+    }
+}
+
+/// Safety: `CallbackKeyLog` is Send because we don't allocate or deallocate any of its
+/// fields.
+unsafe impl Send for CallbackKeyLog {}
+
+/// Safety: Verifier is Sync if the C code passes us a callback that
+/// obeys the concurrency safety requirements documented in
+/// `rustls_client_config_builder_set_key_log` and `rustls_server_config_builder_set_key_log`.
+unsafe impl Sync for CallbackKeyLog {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod crypto_provider;
 pub mod enums;
 mod error;
 pub mod io;
+pub mod keylog;
 pub mod log;
 mod panic;
 pub mod rslice;

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,13 +11,14 @@ use rustls::server::{
     WebPkiClientVerifier,
 };
 use rustls::sign::CertifiedKey;
-use rustls::{ProtocolVersion, SignatureScheme, SupportedProtocolVersion};
+use rustls::{KeyLog, KeyLogFile, ProtocolVersion, SignatureScheme, SupportedProtocolVersion};
 
 use crate::cipher::{rustls_certified_key, rustls_client_cert_verifier};
 use crate::connection::{rustls_connection, Connection};
 use crate::crypto_provider::rustls_crypto_provider;
 use crate::error::rustls_result::NullParameter;
 use crate::error::{map_error, rustls_result};
+use crate::keylog::{rustls_keylog_log_callback, rustls_keylog_will_log_callback, CallbackKeyLog};
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_slice_u16, rustls_str};
 use crate::session::{
     rustls_session_store_get_callback, rustls_session_store_put_callback, SessionStoreBroker,
@@ -53,6 +54,7 @@ pub(crate) struct ServerConfigBuilder {
     session_storage: Option<Arc<dyn StoresServerSessions + Send + Sync>>,
     alpn_protocols: Vec<Vec<u8>>,
     ignore_client_order: Option<bool>,
+    key_log: Option<Arc<dyn KeyLog>>,
 }
 
 arc_castable! {
@@ -85,6 +87,7 @@ impl rustls_server_config_builder {
                 session_storage: None,
                 alpn_protocols: vec![],
                 ignore_client_order: None,
+                key_log: None,
             };
             to_boxed_mut_ptr(builder)
         }
@@ -139,6 +142,7 @@ impl rustls_server_config_builder {
                 session_storage: None,
                 alpn_protocols: vec![],
                 ignore_client_order: None,
+                key_log: None,
             };
             set_boxed_mut_ptr(builder_out, builder);
             rustls_result::Ok
@@ -158,6 +162,71 @@ impl rustls_server_config_builder {
             let builder = try_mut_from_ptr!(builder);
             let verifier = try_ref_from_ptr!(verifier);
             builder.verifier = verifier.clone();
+        }
+    }
+
+    /// Log key material to the file specified by the `SSLKEYLOGFILE` environment variable.
+    ///
+    /// The key material will be logged in the NSS key log format,
+    /// <https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format> and is
+    /// compatible with tools like Wireshark.
+    ///
+    /// Secrets logged in this manner are **extremely sensitive** and can break the security
+    /// of past, present and future sessions.
+    ///
+    /// For more control over which secrets are logged, or to customize the format, prefer
+    /// `rustls_server_config_builder_set_key_log`.
+    #[no_mangle]
+    pub extern "C" fn rustls_server_config_builder_set_key_log_file(
+        builder: *mut rustls_server_config_builder,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let builder = try_mut_from_ptr!(builder);
+            builder.key_log = Some(Arc::new(KeyLogFile::new()));
+            rustls_result::Ok
+        }
+    }
+
+    /// Provide callbacks to manage logging key material.
+    ///
+    /// The `log_cb` argument is mandatory and must not be `NULL` or a `NullParameter` error is
+    /// returned. The `log_cb` will be invoked with a `client_random` to identify the relevant session,
+    /// a `label` to identify the purpose of the `secret`, and the `secret` itself. See the
+    /// Rustls documentation of the `KeyLog` trait for more information on possible labels:
+    /// <https://docs.rs/rustls/latest/rustls/trait.KeyLog.html#tymethod.log>
+    ///
+    /// The `will_log_cb` may be `NULL`, in which case all key material will be provided to
+    /// the `log_cb`. By providing a custom `will_log_cb` you may return `0` for labels you don't
+    /// wish to log, and non-zero for labels you _do_ wish to log as a performance optimization.
+    ///
+    /// Both callbacks **must** be thread-safe. Arguments provided to the callback live only for as
+    /// long as the callback is executing and are not valid after the callback returns. The
+    /// callbacks must not retain references to the provided data.
+    ///
+    /// Secrets provided to the `log_cb` are **extremely sensitive** and can break the security
+    /// of past, present and future sessions.
+    ///
+    /// See also `rustls_server_config_builder_set_key_log_file` for a simpler way to log
+    /// to a file specified by the `SSLKEYLOGFILE` environment variable.
+    #[no_mangle]
+    pub extern "C" fn rustls_server_config_builder_set_key_log(
+        builder: *mut rustls_server_config_builder,
+        log_cb: rustls_keylog_log_callback,
+        will_log_cb: rustls_keylog_will_log_callback,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            let builder = try_mut_from_ptr!(builder);
+            let log_cb = match log_cb {
+                Some(cb) => cb,
+                None => return NullParameter,
+            };
+
+            builder.key_log = Some(Arc::new(CallbackKeyLog {
+                log_cb,
+                will_log_cb,
+            }));
+
+            rustls_result::Ok
         }
     }
 
@@ -295,6 +364,10 @@ impl rustls_server_config_builder {
             config.alpn_protocols = builder.alpn_protocols;
             if let Some(ignore_client_order) = builder.ignore_client_order {
                 config.ignore_client_order = ignore_client_order;
+            }
+
+            if let Some(key_log) = builder.key_log {
+                config.key_log = key_log;
             }
 
             set_arc_mut_ptr(config_out, config);

--- a/tests/client.c
+++ b/tests/client.c
@@ -506,6 +506,22 @@ main(int argc, const char **argv)
     goto cleanup;
   }
 
+  if(getenv("SSLKEYLOGFILE")) {
+    result = rustls_client_config_builder_set_key_log_file(config_builder);
+    if(result != RUSTLS_RESULT_OK) {
+      print_error("enabling keylog", result);
+      goto cleanup;
+    }
+  }
+  else if(getenv("STDERRKEYLOG")) {
+    result = rustls_client_config_builder_set_key_log(
+      config_builder, stderr_key_log_cb, NULL);
+    if(result != RUSTLS_RESULT_OK) {
+      print_error("enabling keylog", result);
+      goto cleanup;
+    }
+  }
+
   char *auth_cert = getenv("AUTH_CERT");
   char *auth_key = getenv("AUTH_KEY");
   if((auth_cert && !auth_key) || (!auth_cert && auth_key)) {

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -33,6 +33,24 @@ fn client_server_integration() {
         client_tests: standard_client_tests(valgrind.clone()),
     };
 
+    let keylogfile_server = TestCase {
+        name: "SSLKEYLOG server",
+        server_opts: ServerOptions {
+            valgrind: valgrind.clone(),
+            env: vec![("SSLKEYLOGFILE", "/tmp/rustls-ffi.server.key")],
+        },
+        client_tests: standard_client_tests(valgrind.clone()),
+    };
+
+    let stderrkeylog_server = TestCase {
+        name: "STDERRKEYLOG server",
+        server_opts: ServerOptions {
+            valgrind: valgrind.clone(),
+            env: vec![("STDERRKEYLOG", "1")],
+        },
+        client_tests: standard_client_tests(valgrind.clone()),
+    };
+
     let mandatory_client_auth_server = TestCase {
         name: "Mandatory client auth tests",
         server_opts: ServerOptions {
@@ -123,6 +141,8 @@ fn client_server_integration() {
     TestCases(vec![
         standard_server,
         vectored_server,
+        keylogfile_server,
+        stderrkeylog_server,
         mandatory_client_auth_server,
         mandatory_client_auth_server_with_crls,
         custom_ciphersuites,
@@ -164,6 +184,21 @@ fn standard_client_tests(valgrind: Option<String>) -> Vec<ClientTest> {
                 ("AUTH_CERT", "testdata/localhost/cert.pem"),
                 ("AUTH_KEY", "testdata/localhost/key.pem"),
             ],
+            expect_error: false,
+        },
+        ClientTest {
+            name: "SSLKEYLOGFILE",
+            valgrind: valgrind.clone(),
+            env: vec![
+                ("CA_FILE", "testdata/minica.pem"),
+                ("SSLKEYLOGFILE", "/tmp/rustls-ffi.client.key"),
+            ],
+            expect_error: false,
+        },
+        ClientTest {
+            name: "STDERRKEYLOG",
+            valgrind: valgrind.clone(),
+            env: vec![("CA_FILE", "testdata/minica.pem"), ("STDERRKEYLOG", "1")],
             expect_error: false,
         },
     ]

--- a/tests/common.h
+++ b/tests/common.h
@@ -136,6 +136,10 @@ const struct rustls_certified_key *load_cert_and_key(const char *certfile,
 const struct rustls_crypto_provider *default_provider_with_custom_ciphersuite(
   const char *custom_ciphersuite_name);
 
+void stderr_key_log_cb(rustls_str label, const unsigned char *client_random,
+                       size_t client_random_len, const unsigned char *secret,
+                       size_t secret_len);
+
 extern const uint16_t default_tls_versions[];
 extern const size_t default_tls_versions_len;
 

--- a/tests/server.c
+++ b/tests/server.c
@@ -360,6 +360,22 @@ main(int argc, const char **argv)
                                                      client_cert_verifier);
   }
 
+  if(getenv("SSLKEYLOGFILE")) {
+    result = rustls_server_config_builder_set_key_log_file(config_builder);
+    if(result != RUSTLS_RESULT_OK) {
+      print_error("enabling keylog", result);
+      goto cleanup;
+    }
+  }
+  else if(getenv("STDERRKEYLOG")) {
+    result = rustls_server_config_builder_set_key_log(
+      config_builder, stderr_key_log_cb, NULL);
+    if(result != RUSTLS_RESULT_OK) {
+      print_error("enabling keylog", result);
+      goto cleanup;
+    }
+  }
+
   result = rustls_server_config_builder_build(config_builder, &server_config);
   if(result != RUSTLS_RESULT_OK) {
     print_error("building server config", result);


### PR DESCRIPTION
For debugging purposes it's quite helpful to be able to log session secrets to a file specified by the `SSLKEYLOGFILE` env var, for example to use with Wireshark to decrypt session traffic.

This commit adds two methods to rustls-ffi for both client and server configurations to facilitate this:

1. `rustls_server_config_builder_set_key_log_file()` and `rustls_client_config_builder_set_key_log_file()` enable using the Rustls `KeyLogFile` implementation of the `KeyLog` trait. This option simply honours the `SSLKEYLOGFILE` env var and spits out a NSS formatted key log file appropriate for use with Wireshark and other tools that support this format.

2. `rustls_server_config_builder_set_key_log()` and `rustls_client_config_builder_set_key_log()` enable providing C callbacks that will be invoked to decide which secrets are logged, and to do the logging. This allows for fine-grained control over how secrets are logged and may be more appropriate for applications that already handle this task for other TLS backends ([e.g. curl](https://github.com/curl/curl/blob/master/lib/vtls/keylog.c)).

The client and server examples are updated to optionally use these new features. If the `SSLKEYLOG` env. var is set, both will use the `_set_key_log_file()` fns to set up the standard file based key logging. If the `STDERRKEYLOG` env var is set then both will use the `_set_key_log()` fns to set up custom callbacks that will print the hex-encoded secret data to stderr as a simple demonstration.

See the upstream [`rustls::KeyLog` trait](https://docs.rs/rustls/latest/rustls/trait.KeyLog.html#) and [`rustls::KeyLogFile`](https://docs.rs/rustls/latest/rustls/struct.KeyLogFile.html) implementation for more detail.