### PR TITLE
tests: fix clippy::zombie_processes finding

### DIFF
--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -292,6 +292,7 @@ impl TestCase {
         });
 
         server.kill().expect("failed to kill server");
+        server.wait().expect("failed to wait on server");
         result
     }
 }


### PR DESCRIPTION
Nightly clippy's `clippy::zombie_processes` lint [flagged the following](https://github.com/rustls/rustls-ffi/actions/runs/11053612732/job/30708397080):

```
error: spawned process is never `wait()`ed on
   --> tests/client_server.rs:285:26
    |
285 |         let mut server = self.server_opts.run_server();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: consider calling `.wait()`
    = note: not doing so might leave behind zombie processes
    = note: see https://doc.rust-lang.org/stable/std/process/struct.Child.html#warning
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#zombie_processes
```

While we _do_ call `kill()` on the process, we weren't `wait()`ing it. The [`process::Child`](https://doc.rust-lang.org/std/process/struct.Child.html) docs have a warning:

    On some systems, calling wait or similar is necessary for the OS to
    release resources. A process that terminated but has not been waited on
    is still around as a “zombie”. Leaving too many zombies around may
    exhaust global resources (for example process IDs).

So it seems it may not be sufficient on all systems to `kill()` without `wait()`.

Let's add a `wait()` just to be sure. Nobody likes zombies.