### PR TITLE
0.23.x API gap reduction

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,23 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y valgrind
       - run: VALGRIND=valgrind make PROFILE=release test integration
 
+  cert-compression:
+    name: Certificate Compression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install nightly rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Unit tests
+        run: make PROFILE=debug CERT_COMPRESSION=true test
+      - name: Integration tests
+        run: make PROFILE=debug CERT_COMPRESSION=true integration
+
   test-windows-cmake-debug:
     name: Windows CMake, Debug configuration
     runs-on: windows-latest
@@ -126,6 +143,27 @@ jobs:
         run: cmake --build build --config Release
       - name: Integration test, release configuration
         run: cargo test --no-default-features --features="${{ matrix.crypto }}" --locked --test client_server client_server_integration -- --ignored --exact
+        env:
+          CLIENT_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\client.exe
+          SERVER_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\server.exe
+
+  test-windows-cmake-compression:
+    name: Windows CMake, Cert. Compression
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install nightly rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install NASM for aws-lc-rs
+        uses: ilammy/setup-nasm@v1
+      - name: Configure CMake enabling cert compression
+        run: cmake -DCERT_COMPRESSION="true" -S . -B build
+      - name: Build, release configuration, compression
+        run: cmake --build build --config Release
+      - name: Integration test, release configuration, compression
+        run: cargo test --features=cert_compression --locked --test client_server client_server_integration -- --ignored --exact
         env:
           CLIENT_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\client.exe
           SERVER_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\server.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,17 @@ if (NOT (CRYPTO_PROVIDER STREQUAL "aws-lc-rs" OR CRYPTO_PROVIDER STREQUAL "ring"
     message(FATAL_ERROR "Invalid crypto provider specified: ${CRYPTO_PROVIDER}. Must be 'aws-lc-rs' or 'ring'.")
 endif ()
 
+set(CERT_COMPRESSION "false" CACHE STRING "Whether to enable brotli and zlib certificate compression support")
+
 set(CARGO_FEATURES --no-default-features)
 if (CRYPTO_PROVIDER STREQUAL "aws-lc-rs")
     list(APPEND CARGO_FEATURES --features=aws-lc-rs)
 elseif (CRYPTO_PROVIDER STREQUAL "ring")
     list(APPEND CARGO_FEATURES --features=ring)
+endif ()
+
+if (CERT_COMPRESSION STREQUAL "true")
+    list(APPEND CARGO_FEATURES --features=cert_compression)
 endif ()
 
 add_subdirectory(tests)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +93,27 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bytes"
@@ -492,6 +528,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "aws-lc-rs",
+ "brotli",
+ "brotli-decompressor",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -499,6 +537,7 @@ dependencies = [
  "rustversion",
  "subtle",
  "zeroize",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -960,3 +999,9 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zlib-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf919c619da9eaede02291295e9c5ae230fc7b5f2a5f4257ff859b075111faf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ read_buf = ["rustls/read_buf"]
 capi = []
 ring = ["rustls/ring", "webpki/ring"]
 aws-lc-rs = ["rustls/aws-lc-rs", "webpki/aws_lc_rs"]
+cert_compression = ["rustls/brotli", "rustls/zlib"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CARGOFLAGS += --locked
 CFLAGS := -Werror -Wall -Wextra -Wpedantic -g -I src/
 PROFILE := release
 CRYPTO_PROVIDER := aws-lc-rs
+COMPRESSION := false
 DESTDIR=/usr/local
 
 ifeq ($(PROFILE), debug)
@@ -33,6 +34,11 @@ ifeq ($(CRYPTO_PROVIDER), aws-lc-rs)
 else ifeq ($(CRYPTO_PROVIDER), ring)
 	CFLAGS += -D DEFINE_RING
 	CARGOFLAGS += --no-default-features --features ring
+endif
+
+ifeq ($(COMPRESSION), true)
+	CARGOFLAGS += --features cert_compression
+	LDFLAGS += -lm
 endif
 
 all: target/client target/server

--- a/Makefile.pkg-config
+++ b/Makefile.pkg-config
@@ -14,6 +14,7 @@ CARGOFLAGS += --locked
 CFLAGS := -Werror -Wall -Wextra -Wpedantic -g -I src/
 PROFILE := release
 CRYPTO_PROVIDER := aws-lc-rs
+CERT_COMPRESSION := false
 PREFIX=/usr/local
 
 ifeq ($(PROFILE), debug)
@@ -32,6 +33,10 @@ ifeq ($(CRYPTO_PROVIDER), aws-lc-rs)
 else ifeq ($(CRYPTO_PROVIDER), ring)
 	CFLAGS += -D DEFINE_RING
 	CARGOFLAGS += --no-default-features --features ring
+endif
+
+ifeq ($(CERT_COMPRESSION), true)
+	CARGOFLAGS += --features cert_compression
 endif
 
 all: target/client target/server

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -300,6 +300,25 @@ impl rustls_certified_key {
         }
     }
 
+    /// Verify the consistency of this `rustls_certified_key`'s public and private keys.
+    ///
+    /// This is done by performing a comparison of subject public key information (SPKI) bytes
+    /// between the certificate and private key.
+    ///
+    /// If the private key matches the certificate this function returns `RUSTLS_RESULT_OK`,
+    /// otherwise an error `rustls_result` is returned.
+    #[no_mangle]
+    pub extern "C" fn rustls_certified_key_keys_match(
+        key: *const rustls_certified_key,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            match try_ref_from_ptr!(key).keys_match() {
+                Ok(_) => rustls_result::Ok,
+                Err(e) => map_error(e),
+            }
+        }
+    }
+
     /// "Free" a certified_key previously returned from `rustls_certified_key_build`.
     ///
     /// Since certified_key is actually an atomically reference-counted pointer,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -104,8 +104,7 @@ impl rustls_connection {
         conn: *mut rustls_connection,
         userdata: *mut c_void,
     ) {
-        let conn = try_mut_from_ptr!(conn);
-        conn.userdata = userdata;
+        try_mut_from_ptr!(conn).userdata = userdata;
     }
 
     /// Set the logging callback for this connection. The log callback will be invoked
@@ -261,8 +260,7 @@ impl rustls_connection {
     #[no_mangle]
     pub extern "C" fn rustls_connection_wants_read(conn: *const rustls_connection) -> bool {
         ffi_panic_boundary! {
-            let conn = try_ref_from_ptr!(conn);
-            conn.wants_read()
+            try_ref_from_ptr!(conn).wants_read()
         }
     }
 
@@ -270,8 +268,7 @@ impl rustls_connection {
     #[no_mangle]
     pub extern "C" fn rustls_connection_wants_write(conn: *const rustls_connection) -> bool {
         ffi_panic_boundary! {
-            let conn = try_ref_from_ptr!(conn);
-            conn.wants_write()
+            try_ref_from_ptr!(conn).wants_write()
         }
     }
 
@@ -286,8 +283,7 @@ impl rustls_connection {
     #[no_mangle]
     pub extern "C" fn rustls_connection_is_handshaking(conn: *const rustls_connection) -> bool {
         ffi_panic_boundary! {
-            let conn = try_ref_from_ptr!(conn);
-            conn.is_handshaking()
+            try_ref_from_ptr!(conn).is_handshaking()
         }
     }
 
@@ -299,8 +295,7 @@ impl rustls_connection {
     #[no_mangle]
     pub extern "C" fn rustls_connection_set_buffer_limit(conn: *mut rustls_connection, n: usize) {
         ffi_panic_boundary! {
-            let conn = try_mut_from_ptr!(conn);
-            conn.set_buffer_limit(Some(n));
+            try_mut_from_ptr!(conn).set_buffer_limit(Some(n));
         }
     }
 
@@ -309,8 +304,7 @@ impl rustls_connection {
     #[no_mangle]
     pub extern "C" fn rustls_connection_send_close_notify(conn: *mut rustls_connection) {
         ffi_panic_boundary! {
-            let conn = try_mut_from_ptr!(conn);
-            conn.send_close_notify();
+            try_mut_from_ptr!(conn).send_close_notify();
         }
     }
 
@@ -329,8 +323,10 @@ impl rustls_connection {
         i: size_t,
     ) -> *const rustls_certificate<'a> {
         ffi_panic_boundary! {
-            let conn = try_ref_from_ptr!(conn);
-            match conn.peer_certificates().and_then(|c| c.get(i)) {
+            match try_ref_from_ptr!(conn)
+                .peer_certificates()
+                .and_then(|c| c.get(i))
+            {
                 Some(cert) => cert as *const CertificateDer as *const _,
                 None => null(),
             }
@@ -382,11 +378,10 @@ impl rustls_connection {
         conn: *const rustls_connection,
     ) -> u16 {
         ffi_panic_boundary! {
-            let conn = try_ref_from_ptr!(conn);
-            match conn.protocol_version() {
-                Some(p) => u16::from(p),
-                _ => 0,
-            }
+            try_ref_from_ptr!(conn)
+                .protocol_version()
+                .map(u16::from)
+                .unwrap_or_default()
         }
     }
 
@@ -400,10 +395,10 @@ impl rustls_connection {
         conn: *const rustls_connection,
     ) -> u16 {
         ffi_panic_boundary! {
-            match try_ref_from_ptr!(conn).negotiated_cipher_suite() {
-                Some(cs) => u16::from(cs.suite()),
-                None => u16::from(TLS_NULL_WITH_NULL_NULL),
-            }
+            try_ref_from_ptr!(conn)
+                .negotiated_cipher_suite()
+                .map(|cs| u16::from(cs.suite()))
+                .unwrap_or(u16::from(TLS_NULL_WITH_NULL_NULL))
         }
     }
 
@@ -420,14 +415,10 @@ impl rustls_connection {
         conn: *const rustls_connection,
     ) -> rustls_str<'static> {
         ffi_panic_boundary! {
-            let cs_name = try_ref_from_ptr!(conn)
+            try_ref_from_ptr!(conn)
                 .negotiated_cipher_suite()
-                .and_then(|cs| cs.suite().as_str())
-                .and_then(|name| rustls_str::try_from(name).ok());
-            match cs_name {
-                Some(cs) => cs,
-                None => rustls_str::from_str_unchecked(""),
-            }
+                .and_then(|cs| rustls_str::try_from(cs.suite().as_str().unwrap_or_default()).ok())
+                .unwrap_or(rustls_str::from_str_unchecked(""))
         }
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -308,6 +308,25 @@ impl rustls_connection {
         }
     }
 
+    /// Queues a TLS1.3 key_update message to refresh a connection’s keys.
+    ///
+    /// Rustls internally manages key updates as required and so this function should
+    /// seldom be used. See the Rustls documentation for important caveats and suggestions
+    /// on occasions that merit its use.
+    ///
+    /// <https://docs.rs/rustls/latest/rustls/struct.ConnectionCommon.html#method.refresh_traffic_keys>
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_refresh_traffic_keys(
+        conn: *mut rustls_connection,
+    ) -> rustls_result {
+        ffi_panic_boundary! {
+            match try_mut_from_ptr!(conn).refresh_traffic_keys() {
+                Ok(_) => rustls_result::Ok,
+                Err(e) => map_error(e),
+            }
+        }
+    }
+
     /// Return the i-th certificate provided by the peer.
     /// Index 0 is the end entity certificate. Higher indexes are certificates
     /// in the chain. Requesting an index higher than what is available returns

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,6 +20,7 @@ use crate::{
     try_slice, try_slice_mut, userdata_push,
 };
 
+use crate::enums::rustls_handshake_kind;
 use rustls_result::NullParameter;
 
 pub(crate) struct Connection {
@@ -284,6 +285,18 @@ impl rustls_connection {
     pub extern "C" fn rustls_connection_is_handshaking(conn: *const rustls_connection) -> bool {
         ffi_panic_boundary! {
             try_ref_from_ptr!(conn).is_handshaking()
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_handshake_kind(
+        conn: *const rustls_connection,
+    ) -> rustls_handshake_kind {
+        ffi_panic_boundary! {
+            try_ref_from_ptr!(conn)
+                .handshake_kind()
+                .map(Into::into)
+                .unwrap_or(rustls_handshake_kind::Unknown)
         }
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -422,6 +422,41 @@ impl rustls_connection {
         }
     }
 
+    /// Retrieves the [IANA registered supported group identifier][IANA] agreed with the peer.
+    ///
+    /// This returns Reserved (0x0000) until the key exchange group is agreed.
+    ///
+    /// [IANA]: <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8>
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_get_negotiated_key_exchange_group(
+        conn: *const rustls_connection,
+    ) -> u16 {
+        ffi_panic_boundary! {
+            try_ref_from_ptr!(conn)
+                .negotiated_key_exchange_group()
+                .map(|kxg| u16::from(kxg.name()))
+                .unwrap_or_default()
+        }
+    }
+
+    /// Retrieves the key exchange group name agreed with the peer.
+    ///
+    /// This returns "" until the key exchange group is agreed.
+    ///
+    /// The lifetime of the `rustls_str` is the lifetime of the program, it does not
+    /// need to be freed.
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_get_negotiated_key_exchange_group_name(
+        conn: *const rustls_connection,
+    ) -> rustls_str<'static> {
+        ffi_panic_boundary! {
+            try_ref_from_ptr!(conn)
+                .negotiated_key_exchange_group()
+                .and_then(|kxg| rustls_str::try_from(kxg.name().as_str().unwrap_or_default()).ok())
+                .unwrap_or(rustls_str::from_str_unchecked(""))
+        }
+    }
+
     /// Write up to `count` plaintext bytes from `buf` into the `rustls_connection`.
     /// This will increase the number of output bytes available to
     /// `rustls_connection_write_tls`.

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,6 +1,6 @@
 use libc::EINVAL;
 
-use crate::enums::rustls_tls_version;
+use crate::enums::{rustls_handshake_kind, rustls_tls_version};
 use crate::error::{rustls_io_result, rustls_result};
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 
@@ -37,6 +37,8 @@ impl Defaultable for bool {}
 impl Defaultable for () {}
 
 impl Defaultable for rustls_tls_version {}
+
+impl Defaultable for rustls_handshake_kind {}
 
 impl<T> Defaultable for Option<T> {}
 

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1899,6 +1899,25 @@ uint16_t rustls_connection_get_negotiated_ciphersuite(const struct rustls_connec
 struct rustls_str rustls_connection_get_negotiated_ciphersuite_name(const struct rustls_connection *conn);
 
 /**
+ * Retrieves the [IANA registered supported group identifier][IANA] agreed with the peer.
+ *
+ * This returns Reserved (0x0000) until the key exchange group is agreed.
+ *
+ * [IANA]: <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8>
+ */
+uint16_t rustls_connection_get_negotiated_key_exchange_group(const struct rustls_connection *conn);
+
+/**
+ * Retrieves the key exchange group name agreed with the peer.
+ *
+ * This returns "" until the key exchange group is agreed.
+ *
+ * The lifetime of the `rustls_str` is the lifetime of the program, it does not
+ * need to be freed.
+ */
+struct rustls_str rustls_connection_get_negotiated_key_exchange_group_name(const struct rustls_connection *conn);
+
+/**
  * Write up to `count` plaintext bytes from `buf` into the `rustls_connection`.
  * This will increase the number of output bytes available to
  * `rustls_connection_write_tls`.

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1148,6 +1148,17 @@ rustls_result rustls_certified_key_clone_with_ocsp(const struct rustls_certified
                                                    const struct rustls_certified_key **cloned_key_out);
 
 /**
+ * Verify the consistency of this `rustls_certified_key`'s public and private keys.
+ *
+ * This is done by performing a comparison of subject public key information (SPKI) bytes
+ * between the certificate and private key.
+ *
+ * If the private key matches the certificate this function returns `RUSTLS_RESULT_OK`,
+ * otherwise an error `rustls_result` is returned.
+ */
+rustls_result rustls_certified_key_keys_match(const struct rustls_certified_key *key);
+
+/**
  * "Free" a certified_key previously returned from `rustls_certified_key_build`.
  *
  * Since certified_key is actually an atomically reference-counted pointer,

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1424,7 +1424,8 @@ struct rustls_web_pki_server_cert_verifier_builder *rustls_web_pki_server_cert_v
  * `rustls_web_pki_server_cert_verifier_only_check_end_entity_revocation` is used. Unknown
  * revocation status for certificates considered for revocation status will be treated as
  * an error unless `rustls_web_pki_server_cert_verifier_allow_unknown_revocation_status` is
- * used.
+ * used. Expired CRLs will not be treated as an error unless
+ * `rustls_web_pki_server_cert_verifier_enforce_revocation_expiry` is used.
  *
  * This copies the contents of the `rustls_root_cert_store`. It does not take
  * ownership of the pointed-to data.
@@ -1461,6 +1462,14 @@ rustls_result rustls_web_pki_server_cert_verifier_only_check_end_entity_revocati
  * Overrides the default behavior where unknown revocation status is considered an error.
  */
 rustls_result rustls_web_pki_server_cert_verifier_allow_unknown_revocation_status(struct rustls_web_pki_server_cert_verifier_builder *builder);
+
+/**
+ * When CRLs are provided with `rustls_web_pki_server_cert_verifier_builder_add_crl`, and the
+ * CRL nextUpdate field is in the past, treat it as an error condition.
+ *
+ * Overrides the default behavior where CRL expiration is ignored.
+ */
+rustls_result rustls_web_pki_server_cert_verifier_enforce_revocation_expiry(struct rustls_web_pki_server_cert_verifier_builder *builder);
 
 /**
  * Create a new server certificate verifier from the builder.

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1838,6 +1838,17 @@ void rustls_connection_set_buffer_limit(struct rustls_connection *conn, size_t n
 void rustls_connection_send_close_notify(struct rustls_connection *conn);
 
 /**
+ * Queues a TLS1.3 key_update message to refresh a connection’s keys.
+ *
+ * Rustls internally manages key updates as required and so this function should
+ * seldom be used. See the Rustls documentation for important caveats and suggestions
+ * on occasions that merit its use.
+ *
+ * <https://docs.rs/rustls/latest/rustls/struct.ConnectionCommon.html#method.refresh_traffic_keys>
+ */
+rustls_result rustls_connection_refresh_traffic_keys(struct rustls_connection *conn);
+
+/**
  * Return the i-th certificate provided by the peer.
  * Index 0 is the end entity certificate. Higher indexes are certificates
  * in the chain. Requesting an index higher than what is available returns

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -7,6 +7,41 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * Describes which sort of handshake happened.
+ */
+typedef enum rustls_handshake_kind {
+  /**
+   * The type of handshake could not be determined.
+   *
+   * This variant should not be used.
+   */
+  RUSTLS_HANDSHAKE_KIND_UNKNOWN = 0,
+  /**
+   * A full TLS handshake.
+   *
+   * This is the typical TLS connection initiation process when resumption is
+   * not yet unavailable, and the initial client hello was accepted by the server.
+   */
+  RUSTLS_HANDSHAKE_KIND_FULL = 1,
+  /**
+   * A full TLS handshake, with an extra round-trip for a hello retry request.
+   *
+   * The server can respond with a hello retry request (HRR) if the initial client
+   * hello is unacceptable for several reasons, the most likely if no supported key
+   * shares were offered by the client.
+   */
+  RUSTLS_HANDSHAKE_KIND_FULL_WITH_HELLO_RETRY_REQUEST = 2,
+  /**
+   * A resumed TLS handshake.
+   *
+   * Resumed handshakes involve fewer round trips and less cryptography than
+   * full ones, but can only happen when the peers have previously done a full
+   * handshake together, and then remember data about it.
+   */
+  RUSTLS_HANDSHAKE_KIND_RESUMED = 3,
+} rustls_handshake_kind;
+
 enum rustls_result {
   RUSTLS_RESULT_OK = 7000,
   RUSTLS_RESULT_IO = 7001,
@@ -1842,6 +1877,8 @@ bool rustls_connection_wants_write(const struct rustls_connection *conn);
  */
 bool rustls_connection_is_handshaking(const struct rustls_connection *conn);
 
+enum rustls_handshake_kind rustls_connection_handshake_kind(const struct rustls_connection *conn);
+
 /**
  * Sets a limit on the internal buffers used to buffer unsent plaintext (prior
  * to completing the TLS handshake) and unsent TLS records. By default, there
@@ -2234,6 +2271,15 @@ rustls_result rustls_default_crypto_provider_random(uint8_t *buff, size_t len);
  * must not be called twice with the same value.
  */
 void rustls_signing_key_free(struct rustls_signing_key *signing_key);
+
+/**
+ * Convert a `rustls_handshake_kind` to a string with a friendly description of the kind
+ * of handshake.
+ *
+ * The returned `rustls_str` has a static lifetime equal to that of the program and does
+ * not need to be manually freed.
+ */
+struct rustls_str rustls_handshake_kind_str(enum rustls_handshake_kind kind);
 
 /**
  * After a rustls function returns an error, you may call

--- a/tests/client.c
+++ b/tests/client.c
@@ -170,8 +170,8 @@ send_request_and_read_response(struct conndata *conn,
   unsigned long content_length = 0;
   size_t headers_len = 0;
   struct rustls_str version;
-  int ciphersuite_id;
-  struct rustls_str ciphersuite_name;
+  int ciphersuite_id, kex_id;
+  struct rustls_str ciphersuite_name, kex_name;
 
   version = rustls_version();
   memset(buf, '\0', sizeof(buf));
@@ -298,6 +298,13 @@ send_request_and_read_response(struct conndata *conn,
   LOG_SIMPLE("send_request_and_read_response: loop fell through");
 
 drain_plaintext:
+  kex_id = rustls_connection_get_negotiated_key_exchange_group(rconn);
+  kex_name = rustls_connection_get_negotiated_key_exchange_group_name(rconn);
+  LOG("negotiated key exchange: %.*s (%#x)",
+      (int)kex_name.len,
+      kex_name.data,
+      kex_id);
+
   result = copy_plaintext_to_buffer(conn);
   if(result != DEMO_OK && result != DEMO_EOF) {
     goto cleanup;

--- a/tests/client.c
+++ b/tests/client.c
@@ -170,8 +170,9 @@ send_request_and_read_response(struct conndata *conn,
   unsigned long content_length = 0;
   size_t headers_len = 0;
   struct rustls_str version;
+  rustls_handshake_kind hs_kind;
   int ciphersuite_id, kex_id;
-  struct rustls_str ciphersuite_name, kex_name;
+  struct rustls_str ciphersuite_name, kex_name, hs_kind_name;
 
   version = rustls_version();
   memset(buf, '\0', sizeof(buf));
@@ -298,6 +299,10 @@ send_request_and_read_response(struct conndata *conn,
   LOG_SIMPLE("send_request_and_read_response: loop fell through");
 
 drain_plaintext:
+  hs_kind = rustls_connection_handshake_kind(rconn);
+  hs_kind_name = rustls_handshake_kind_str(hs_kind);
+  LOG("handshake kind: %.*s", (int)hs_kind_name.len, hs_kind_name.data);
+
   kex_id = rustls_connection_get_negotiated_key_exchange_group(rconn);
   kex_name = rustls_connection_get_negotiated_key_exchange_group_name(rconn);
   LOG("negotiated key exchange: %.*s (%#x)",

--- a/tests/common.c
+++ b/tests/common.c
@@ -383,6 +383,16 @@ load_cert_and_key(const char *certfile, const char *keyfile)
     print_error("parsing certificate and key", result);
     return NULL;
   }
+
+  if(rustls_certified_key_keys_match(certified_key) != RUSTLS_RESULT_OK) {
+    fprintf(stderr,
+            "private key %s does not match certificate %s public key\n",
+            keyfile,
+            certfile);
+    rustls_certified_key_free(certified_key);
+    return NULL;
+  }
+
   return certified_key;
 }
 

--- a/tests/server.c
+++ b/tests/server.c
@@ -127,8 +127,8 @@ handle_conn(struct conndata *conn)
   int sockfd = conn->fd;
   struct timeval tv;
   enum exchange_state state = READING_REQUEST;
-  int ciphersuite_id;
-  struct rustls_str ciphersuite_name;
+  int ciphersuite_id, kex_id;
+  struct rustls_str ciphersuite_name, kex_name;
 
   LOG("acccepted conn on fd %d", conn->fd);
 
@@ -198,6 +198,13 @@ handle_conn(struct conndata *conn)
           (int)ciphersuite_name.len,
           ciphersuite_name.data,
           ciphersuite_id);
+      kex_id = rustls_connection_get_negotiated_key_exchange_group(rconn);
+      kex_name =
+        rustls_connection_get_negotiated_key_exchange_group_name(rconn);
+      LOG("negotiated key exchange: %.*s (%#x)",
+          (int)kex_name.len,
+          kex_name.data,
+          kex_id);
 
       rustls_connection_get_alpn_protocol(
         rconn, &negotiated_alpn, &negotiated_alpn_len);

--- a/tests/server.c
+++ b/tests/server.c
@@ -127,8 +127,9 @@ handle_conn(struct conndata *conn)
   int sockfd = conn->fd;
   struct timeval tv;
   enum exchange_state state = READING_REQUEST;
+  rustls_handshake_kind hs_kind;
   int ciphersuite_id, kex_id;
-  struct rustls_str ciphersuite_name, kex_name;
+  struct rustls_str ciphersuite_name, kex_name, hs_kind_name;
 
   LOG("acccepted conn on fd %d", conn->fd);
 
@@ -191,6 +192,9 @@ handle_conn(struct conndata *conn)
     if(state == READING_REQUEST && body_beginning(&conn->data) != NULL) {
       state = SENT_RESPONSE;
       LOG_SIMPLE("writing response");
+      hs_kind = rustls_connection_handshake_kind(rconn);
+      hs_kind_name = rustls_handshake_kind_str(hs_kind);
+      LOG("handshake kind: %.*s", (int)hs_kind_name.len, hs_kind_name.data);
       ciphersuite_id = rustls_connection_get_negotiated_ciphersuite(rconn);
       ciphersuite_name =
         rustls_connection_get_negotiated_ciphersuite_name(rconn);


### PR DESCRIPTION
Trying to narrow the gap between features `rustls` has added upstream and what we expose in `rustls-ffi`. This brings us close to having covered all the major additions from the past year or two of releases. 

I think there are three main gaps remaining (besides those mentioned in https://github.com/rustls/rustls-ffi/issues/214): 

1. client side ECH
2. FIPS compatibility
3. the unbuffered API. 

I will probably knock out the first two in the coming weeks. I'd prefer to hold off on the unbuffered API for the moment.

From the [0.23.11](https://github.com/rustls/rustls/releases/tag/v%2F0.23.11) release we get:
* `rustls_connection_get_negotiated_key_exchange_group()` and `rustls_connection_get_negotiated_key_exchange_group_name()` to match [`negotiated_key_exchange_group()`](https://rustls.github.io/rustls/prerelease/server/struct.ServerConnection.html#method.negotiated_key_exchange_group).
* `rustls_connection_refresh_traffic_keys()` to match [`refresh_traffic_keys()`](https://rustls.github.io/rustls/prerelease/client/struct.ClientConnection.html#method.refresh_traffic_keys)
* `rustls_certified_key_keys_match()` to match [`keys_match()`](https://rustls.github.io/rustls/prerelease/sign/struct.CertifiedKey.html#method.keys_match)

From the [0.23.9](https://github.com/rustls/rustls/releases/tag/v%2F0.23.9) release we get:
* A new crate feature, `cert_compression`, that activates `rustls/brotli` and `rustls/zlib`. This feature is **off-by-default** due to MSRV reasons but can be toggled with the `CERT_COMPRESSION` build var.

From the [0.23.8](https://github.com/rustls/rustls/releases/tag/v%2F0.23.8) release we get:
* `rustls_web_pki_server_cert_verifier_enforce_revocation_expiry()` to match [`enforce_revocation_expiration()`](https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html#method.enforce_revocation_expiration)

From the [0.23.5](https://github.com/rustls/rustls/releases/tag/v%2F0.23.5) release we get:
* `rustls_connection_handshake_kind()` and `rustls_handshake_kind_str()` to match [`handshake_kind()`](https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.handshake_kind).
