### PR TITLE
Makefile: adjust default target, broaden all target

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Build release binaries
         run: |
           make clean
-          make CC=${{ matrix.cc }} CRYPTO_PROVIDER=${{ matrix.crypto }} PROFILE=release
+          make CC=${{ matrix.cc }} CRYPTO_PROVIDER=${{ matrix.crypto }} PROFILE=release test
       - name: Verify release builds were not using ASAN
         if: runner.os == 'Linux' # For 'nm'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,14 @@ ifeq ($(COMPRESSION), true)
 	LDFLAGS += -lm
 endif
 
-all: target/client target/server
+default: target/$(PROFILE)/librustls_ffi.a
 
-test: all
+all: default test integration connect-test
+
+test: target/client target/server
 	${CARGO} test ${CARGOFLAGS}
 
-integration: all
+integration: test
 	${CARGO} test ${CARGOFLAGS} -- --ignored
 
 connect-test: target/client
@@ -97,4 +99,4 @@ format-check:
 	cargo fmt --check
 	sed -i -e 's/if true {/ffi_panic_boundary! {/g' src/*.rs
 
-.PHONY: all clean test integration format format-check
+.PHONY: default all clean test integration format format-check


### PR DESCRIPTION
Previously the default target ('all') built the rustls-ffi static library and the client/server example binaries.

This commit adds a new default target ('default') that only builds the static lib. It also updates 'all' to include integration and connect-tests to truly be all the things.

I've left the `Makefile.pkg-config` as-is since the purpose of that Makefile is largely to be an example of using cargo-c and pkg-config with the client/server binaries.

Updates https://github.com/rustls/rustls-ffi/issues/318