### PR TITLE
fix needless lifetimes clippy findings

### DIFF
--- a/src/panic.rs
+++ b/src/panic.rs
@@ -40,7 +40,7 @@ impl Defaultable for rustls_tls_version {}
 
 impl<T> Defaultable for Option<T> {}
 
-impl<'a> Defaultable for rustls_slice_bytes<'a> {}
+impl Defaultable for rustls_slice_bytes<'_> {}
 
 impl<T: Defaultable> PanicOrDefault for T {
     fn value() -> Self {
@@ -66,7 +66,7 @@ impl PanicOrDefault for rustls_result {
     }
 }
 
-impl<'a> PanicOrDefault for rustls_str<'a> {
+impl PanicOrDefault for rustls_str<'_> {
     fn value() -> Self {
         rustls_str::from_str_unchecked("")
     }
@@ -108,7 +108,7 @@ impl NullParameterOrDefault for rustls_io_result {
     }
 }
 
-impl<'a> NullParameterOrDefault for rustls_str<'a> {
+impl NullParameterOrDefault for rustls_str<'_> {
     fn value() -> Self {
         rustls_str::from_str_unchecked("")
     }

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -175,7 +175,7 @@ impl<'a> TryFrom<&'a str> for rustls_str<'a> {
     }
 }
 
-impl<'a> Default for rustls_str<'a> {
+impl Default for rustls_str<'_> {
     fn default() -> rustls_str<'static> {
         Self::from_str_unchecked("")
     }
@@ -186,7 +186,7 @@ impl<'a> Default for rustls_str<'a> {
 /// The string should not have any internal NUL bytes and is not NUL terminated.
 /// C code should not create rustls_str objects, they should only be created in Rust
 /// code.
-impl<'a> rustls_str<'a> {
+impl rustls_str<'_> {
     pub fn from_str_unchecked(s: &'static str) -> rustls_str<'static> {
         rustls_str {
             data: s.as_ptr() as *const _,
@@ -226,7 +226,7 @@ impl<'a> rustls_str<'a> {
 // If the assertion about Rust code being the only creator of rustls_str objects
 // changes, you must change this Debug impl, since the assertion in it no longer
 // holds.
-impl<'a> fmt::Debug for rustls_str<'a> {
+impl fmt::Debug for rustls_str<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let raw = unsafe {
             // Despite the use of "unsafe", we know that this is safe because:


### PR DESCRIPTION
Fixes errors from [clippy nightly](https://github.com/rustls/rustls-ffi/actions/runs/11182656985/job/31089423033) of the form:

```
error: the following explicit lifetimes could be elided: 'a
  --> src/panic.rs:43:6
   |
43 | impl<'a> Defaultable for rustls_slice_bytes<'a> {}
   |      ^^                                     ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
```