### PR TITLE
Migrate to pki-types PEM decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,6 @@ dependencies = [
  "log",
  "regex",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "rustls-webpki",
@@ -579,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,9 @@ cert_compression = ["rustls/brotli", "rustls/zlib"]
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
 rustls = { version = "0.23.13", default-features = false, features = ["std", "tls12"] }
-pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
+pki-types = { package = "rustls-pki-types", version = "1.10", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["std"] }
 libc = "0.2"
-rustls-pemfile = "2"
 log = "0.4.22"
 rustls-platform-verifier = "0.3"
 

--- a/src/crypto_provider.rs
+++ b/src/crypto_provider.rs
@@ -1,6 +1,10 @@
+use std::slice;
+use std::sync::Arc;
+
 use libc::size_t;
 use pki_types::pem::PemObject;
 use pki_types::PrivateKeyDer;
+
 #[cfg(feature = "aws-lc-rs")]
 use rustls::crypto::aws_lc_rs;
 #[cfg(feature = "ring")]
@@ -8,8 +12,6 @@ use rustls::crypto::ring;
 use rustls::crypto::CryptoProvider;
 use rustls::sign::SigningKey;
 use rustls::SupportedCipherSuite;
-use std::slice;
-use std::sync::Arc;
 
 use crate::cipher::rustls_supported_ciphersuite;
 use crate::error::map_error;


### PR DESCRIPTION
The job that the [rustls-pemfile](https://github.com/rustls/pemfile) crate was doing has now been [folded into the pki-types crate](https://github.com/rustls/pki-types/releases/tag/v%2F1.9.0) where we can offer a more integrated experience (and also avoid timing side-channels in base64 decoding of private key material).

This branch replaces rustls-ffi's usage of rustls-pemfile with pki-types >1.10. Happily a lot of extra helper code/imports fall away :rocket: 

Resolves https://github.com/rustls/rustls-ffi/issues/475
See also https://github.com/rustls/rustls/pull/2140