### PR TITLE
WIP: opt-in rustls-ffi FIPS support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,6 +99,32 @@ jobs:
       - name: Integration tests
         run: make PROFILE=debug CERT_COMPRESSION=true integration
 
+  fips:
+    name: FIPS
+    runs-on: "${{ matrix.os }}"
+    continue-on-error: true # TODO(@cpu): remove this after debugging MacOS failures.
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install golang for aws-lc-fips-sys on macos
+        if: runner.os == 'MacOS'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.2"
+      - name: Install nightly rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Unit tests
+        run: make FIPS=true test
+      - name: Integration tests
+        run: make FIPS=true integration
+
   test-windows-cmake-debug:
     name: Windows CMake, Debug configuration
     runs-on: windows-latest
@@ -164,6 +190,31 @@ jobs:
         run: cmake --build build --config Release
       - name: Integration test, release configuration, compression
         run: cargo test --features=cert_compression --locked --test client_server client_server_integration -- --ignored --exact
+        env:
+          CLIENT_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\client.exe
+          SERVER_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\server.exe
+
+  test-windows-cmake-fips:
+    name: Windows CMake, FIPS
+    runs-on: windows-latest
+    env:
+      AWS_LC_SYS_PREBUILT_NASM: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install nightly rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install NASM for aws-lc-rs
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        uses: seanmiddleditch/gha-setup-ninja@v5
+      - name: Configure CMake enabling FIPS
+        run: cmake -DFIPS="true" -S . -B build
+      - name: Build, release configuration, FIPS
+        run: cmake --build build --config Release
+      - name: Integration test, release configuration, FIPS
+        run: cargo test --features=fips --locked --test client_server client_server_integration -- --ignored --exact
         env:
           CLIENT_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\client.exe
           SERVER_BINARY: D:\a\rustls-ffi\rustls-ffi\build\tests\Release\server.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ endif ()
 
 set(CERT_COMPRESSION "false" CACHE STRING "Whether to enable brotli and zlib certificate compression support")
 
+set(FIPS "false" CACHE STRING "Whether to enable aws-lc-rs and FIPS support")
+
 set(CARGO_FEATURES --no-default-features)
 if (CRYPTO_PROVIDER STREQUAL "aws-lc-rs")
     list(APPEND CARGO_FEATURES --features=aws-lc-rs)
@@ -19,6 +21,11 @@ endif ()
 
 if (CERT_COMPRESSION STREQUAL "true")
     list(APPEND CARGO_FEATURES --features=cert_compression)
+endif ()
+
+# See https://docs.rs/rustls/latest/rustls/manual/_06_fips/index.html
+if (FIPS STREQUAL "true")
+    list(APPEND CARGO_FEATURES --features=fips)
 endif ()
 
 add_subdirectory(tests)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,11 +33,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf12b67bc9c5168f68655aadb2a12081689a58f1d9b1484705e4d1810ed6e4ac"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "mirai-annotations",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "aws-lc-rs",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cert_compression = ["rustls/brotli", "rustls/zlib"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.13", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23.15", default-features = false, features = ["std", "tls12"] }
 pki-types = { package = "rustls-pki-types", version = "1.10", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["std"] }
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ capi = []
 ring = ["rustls/ring", "webpki/ring"]
 aws-lc-rs = ["rustls/aws-lc-rs", "webpki/aws_lc_rs"]
 cert_compression = ["rustls/brotli", "rustls/zlib"]
+fips = ["aws-lc-rs", "rustls/fips"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CFLAGS := -Werror -Wall -Wextra -Wpedantic -g -I src/
 PROFILE := release
 CRYPTO_PROVIDER := aws-lc-rs
 COMPRESSION := false
+FIPS := false
 DESTDIR=/usr/local
 
 ifeq ($(PROFILE), debug)
@@ -39,6 +40,11 @@ endif
 ifeq ($(COMPRESSION), true)
 	CARGOFLAGS += --features cert_compression
 	LDFLAGS += -lm
+endif
+
+# See https://docs.rs/rustls/latest/rustls/manual/_06_fips/index.html
+ifeq ($(FIPS), true)
+	CARGOFLAGS += --features fips
 endif
 
 default: target/$(PROFILE)/librustls_ffi.a

--- a/Makefile.pkg-config
+++ b/Makefile.pkg-config
@@ -15,6 +15,7 @@ CFLAGS := -Werror -Wall -Wextra -Wpedantic -g -I src/
 PROFILE := release
 CRYPTO_PROVIDER := aws-lc-rs
 CERT_COMPRESSION := false
+FIPS := false
 PREFIX=/usr/local
 
 ifeq ($(PROFILE), debug)
@@ -37,6 +38,11 @@ endif
 
 ifeq ($(CERT_COMPRESSION), true)
 	CARGOFLAGS += --features cert_compression
+endif
+
+# See https://docs.rs/rustls/latest/rustls/manual/_06_fips/index.html
+ifeq ($(FIPS), true)
+	CARGOFLAGS += --features fips
 endif
 
 all: target/client target/server

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::{env, fs, path::PathBuf};
 // because doing so would require a heavy-weight deserialization lib dependency
 // (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
 // by-hand parsing.
-const RUSTLS_CRATE_VERSION: &str = "0.23.13";
+const RUSTLS_CRATE_VERSION: &str = "0.23.15";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -14,7 +14,8 @@ include = ["rustls_tls_version"]
 "feature = read_buf" = "DEFINE_READ_BUF"
 "feature = aws-lc-rs" = "DEFINE_AWS_LC_RS"
 "feature = ring" = "DEFINE_RING"
+"feature = fips" = "DEFINE_FIPS"
 
 [parse.expand]
 crates = ["rustls-ffi"]
-features = ["read_buf", "aws-lc-rs", "ring"]
+features = ["read_buf", "aws-lc-rs", "ring", "fips"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -582,6 +582,19 @@ impl rustls_client_config_builder {
 }
 
 impl rustls_client_config {
+    /// Returns true if a `rustls_connection` created from the `rustls_client_config` will
+    /// operate in FIPS mode.
+    ///
+    /// This is different from `rustls_crypto_provider_fips` which is concerned
+    /// only with cryptography, whereas this also covers TLS-level configuration that NIST
+    /// recommends, as well as ECH HPKE suites if applicable.
+    #[no_mangle]
+    pub extern "C" fn rustls_client_config_fips(config: *const rustls_client_config) -> bool {
+        ffi_panic_boundary! {
+            try_ref_from_ptr!(config).fips()
+        }
+    }
+
     /// "Free" a `rustls_client_config` previously returned from
     /// `rustls_client_config_builder_build`.
     ///

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -613,6 +613,24 @@ impl rustls_connection {
         }
     }
 
+    /// Returns true if the `rustls_connection` was made with a `rustls_client_config`
+    /// that is FIPS compatible.
+    ///
+    /// This is different from `rustls_crypto_provider_fips` which is concerned
+    /// only with cryptography, whereas this also covers TLS-level configuration that NIST
+    /// recommends, as well as ECH HPKE suites if applicable.
+    #[no_mangle]
+    pub extern "C" fn rustls_connection_fips(conn: *const rustls_connection) -> bool {
+        ffi_panic_boundary! {
+            let conn = try_ref_from_ptr!(conn);
+            match &conn.conn {
+                rustls::Connection::Client(c) => c.fips(),
+                // TODO(XXX): investigate why there isn't a ServerConnection::fips().
+                _ => false,
+            }
+        }
+    }
+
     /// Free a rustls_connection. Calling with NULL is fine.
     /// Must not be called twice with the same value.
     #[no_mangle]

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1759,6 +1759,16 @@ rustls_result rustls_client_config_builder_build(struct rustls_client_config_bui
 void rustls_client_config_builder_free(struct rustls_client_config_builder *config);
 
 /**
+ * Returns true if a `rustls_connection` created from the `rustls_client_config` will
+ * operate in FIPS mode.
+ *
+ * This is different from `rustls_crypto_provider_fips` which is concerned
+ * only with cryptography, whereas this also covers TLS-level configuration that NIST
+ * recommends, as well as ECH HPKE suites if applicable.
+ */
+bool rustls_client_config_fips(const struct rustls_client_config *config);
+
+/**
  * "Free" a `rustls_client_config` previously returned from
  * `rustls_client_config_builder_build`.
  *
@@ -2048,6 +2058,16 @@ rustls_result rustls_connection_read_2(struct rustls_connection *conn,
 #endif
 
 /**
+ * Returns true if the `rustls_connection` was made with a `rustls_client_config`
+ * that is FIPS compatible.
+ *
+ * This is different from `rustls_crypto_provider_fips` which is concerned
+ * only with cryptography, whereas this also covers TLS-level configuration that NIST
+ * recommends, as well as ECH HPKE suites if applicable.
+ */
+bool rustls_connection_fips(const struct rustls_connection *conn);
+
+/**
  * Free a rustls_connection. Calling with NULL is fine.
  * Must not be called twice with the same value.
  */
@@ -2172,6 +2192,23 @@ const struct rustls_crypto_provider *rustls_ring_crypto_provider(void);
 const struct rustls_crypto_provider *rustls_aws_lc_rs_crypto_provider(void);
 #endif
 
+#if defined(DEFINE_FIPS)
+/**
+ * Return a `rustls_crypto_provider` that uses FIPS140-3 approved cryptography.
+ *
+ * Using this function expresses in your code that you require FIPS-approved cryptography,
+ * and will not compile if you make a mistake with cargo features.
+ *
+ * See the upstream [rustls FIPS documentation][FIPS] for more information.
+ *
+ * The caller owns the returned `rustls_crypto_provider` and must free it using
+ * `rustls_crypto_provider_free`.
+ *
+ * [FIPS]: https://docs.rs/rustls/latest/rustls/manual/_06_fips/index.html
+ */
+const struct rustls_crypto_provider *rustls_default_fips_provider(void);
+#endif
+
 /**
  * Retrieve a pointer to the process default `rustls_crypto_provider`.
  *
@@ -2232,6 +2269,16 @@ rustls_result rustls_crypto_provider_load_key(const struct rustls_crypto_provide
 rustls_result rustls_crypto_provider_random(const struct rustls_crypto_provider *provider,
                                             uint8_t *buff,
                                             size_t len);
+
+/**
+ * Returns true if the `rustls_crypto_provider` is operating in FIPS mode.
+ *
+ * This covers only the cryptographic parts of FIPS approval. There are also
+ * TLS protocol-level recommendations made by NIST. You should prefer to call
+ * `rustls_client_config_fips` or `rustls_server_config_fips` which take these
+ * into account.
+ */
+bool rustls_crypto_provider_fips(const struct rustls_crypto_provider *provider);
 
 /**
  * Frees the `rustls_crypto_provider`.
@@ -2496,6 +2543,16 @@ rustls_result rustls_server_config_builder_set_certified_keys(struct rustls_serv
  */
 rustls_result rustls_server_config_builder_build(struct rustls_server_config_builder *builder,
                                                  const struct rustls_server_config **config_out);
+
+/**
+ * Returns true if a `rustls_connection` created from the `rustls_server_config` will
+ * operate in FIPS mode.
+ *
+ * This is different from `rustls_crypto_provider_fips` which is concerned
+ * only with cryptography, whereas this also covers TLS-level configuration that NIST
+ * recommends, as well as ECH HPKE suites if applicable.
+ */
+bool rustls_server_config_fips(const struct rustls_server_config *config);
 
 /**
  * "Free" a rustls_server_config previously returned from

--- a/src/server.rs
+++ b/src/server.rs
@@ -377,6 +377,19 @@ impl rustls_server_config_builder {
 }
 
 impl rustls_server_config {
+    /// Returns true if a `rustls_connection` created from the `rustls_server_config` will
+    /// operate in FIPS mode.
+    ///
+    /// This is different from `rustls_crypto_provider_fips` which is concerned
+    /// only with cryptography, whereas this also covers TLS-level configuration that NIST
+    /// recommends, as well as ECH HPKE suites if applicable.
+    #[no_mangle]
+    pub extern "C" fn rustls_server_config_fips(config: *const rustls_server_config) -> bool {
+        ffi_panic_boundary! {
+            try_ref_from_ptr!(config).fips()
+        }
+    }
+
     /// "Free" a rustls_server_config previously returned from
     /// rustls_server_config_builder_build.
     ///

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -110,11 +110,17 @@ fn client_server_integration() {
         ],
     };
 
+    // CHACHA20 is not FIPS approved :)
+    #[cfg(not(feature = "fips"))]
+    let custom_ciphersuite = "TLS13_CHACHA20_POLY1305_SHA256";
+    #[cfg(feature = "fips")]
+    let custom_ciphersuite = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+
     let custom_ciphersuites = TestCase {
         name: "client/server with limited ciphersuites",
         server_opts: ServerOptions {
             valgrind: valgrind.clone(),
-            env: vec![("RUSTLS_CIPHERSUITE", "TLS13_CHACHA20_POLY1305_SHA256")],
+            env: vec![("RUSTLS_CIPHERSUITE", custom_ciphersuite)],
         },
         client_tests: vec![
             ClientTest {
@@ -122,7 +128,7 @@ fn client_server_integration() {
                 valgrind: valgrind.clone(),
                 env: vec![
                     ("NO_CHECK_CERTIFICATE", "1"),
-                    ("RUSTLS_CIPHERSUITE", "TLS13_CHACHA20_POLY1305_SHA256"),
+                    ("RUSTLS_CIPHERSUITE", custom_ciphersuite),
                 ],
                 expect_error: false,
             },


### PR DESCRIPTION
## FIPS feature

Using `make FIPS=true` with the Makefiles, or `cmake -DFIPS="true" -S . -B build` with the Windows cmake build will activate the `aws-lc-rs` feature of `rustls-ffi`, and the `rustls/fips` feature of Rustls.

On MacOS and Windows this requires some additional build tooling (Golang and Ninja). See [the rustls manual](https://docs.rs/rustls/latest/rustls/manual/_06_fips/index.html) and the [aws-lc-rs-fips-sys crate](https://crates.io/crates/aws-lc-fips-sys) for more information.

## API additions

* Ability to instantiate the FIPS default `crypto_provider` using a new function `rustls_default_fips_provider()`, available only when the fips feature is activated.

* Ability to determine if a given `crypto_provider` is in FIPS mode using a new function `rustls_crypto_provider_fips()`.

* Ability to determine if a given `rustls_client_config` would create connections that are FIPS compatible with a new function
  `rustls_client_config_fips()`. 
  
* Ability to determine if a given `rustls_server_config` would create connections that are FIPS compatible with a new function
  `rustls_server_config_fips()`.

* Ability to determine if a given `rustls_connection` was created from a `rustls_client_config` that was FIPS enabled with a new function `rustls_connection_fips()`. Doing equivalent for a server connection is not presently supported upstream (see https://github.com/rustls/rustls/pull/2174).

## TODO

* [ ] presently the Mac and Windows FIPS-enabled builds fail with unresolved symbol errors when building the client/server examples
* [ ] there's no FIPS specific integration tests.