### PR TITLE
Cargo: update rustls 0.23.15 -> 0.23.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.15"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "aws-lc-rs",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cert_compression = ["rustls/brotli", "rustls/zlib"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.15", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23.16", default-features = false, features = ["std", "tls12"] }
 pki-types = { package = "rustls-pki-types", version = "1.10", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["std"] }
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::{env, fs, path::PathBuf};
 // because doing so would require a heavy-weight deserialization lib dependency
 // (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
 // by-hand parsing.
-const RUSTLS_CRATE_VERSION: &str = "0.23.15";
+const RUSTLS_CRATE_VERSION: &str = "0.23.16";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());


### PR DESCRIPTION
See https://github.com/rustls/rustls/releases/tag/v%2F0.23.16