### PR TITLE
Add Windows ASAN testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,8 +111,6 @@ jobs:
           persist-credentials: false
       - name: Install nightly rust toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - name: Install NASM for aws-lc-rs
-        uses: ilammy/setup-nasm@v1
       - name: Configure CMake
         run: cmake -DCRYPTO_PROVIDER="${{ matrix.crypto }}" -S . -B build
       - name: Build, debug configuration
@@ -135,8 +133,6 @@ jobs:
           persist-credentials: false
       - name: Install nightly rust toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - name: Install NASM for aws-lc-rs
-        uses: ilammy/setup-nasm@v1
       - name: Configure CMake
         run: cmake -DCRYPTO_PROVIDER="${{ matrix.crypto }}" -S . -B build
       - name: Build, release configuration
@@ -156,8 +152,6 @@ jobs:
           persist-credentials: false
       - name: Install nightly rust toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - name: Install NASM for aws-lc-rs
-        uses: ilammy/setup-nasm@v1
       - name: Configure CMake enabling cert compression
         run: cmake -DCERT_COMPRESSION="true" -S . -B build
       - name: Build, release configuration, compression

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,6 +111,14 @@ jobs:
           persist-credentials: false
       - name: Install nightly rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+      # For Debug builds we use ASAN, which requires a modern MSVC on $PATH
+      # to provide the ASAN clang_rt.asan_*.dll runtime deps or
+      # the built client/server binary will exit immediately with 
+      # exit code -1073741515
+      - name: Setup MSVC
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        with:
+          arch: x64
       - name: Configure CMake
         run: cmake -DCRYPTO_PROVIDER="${{ matrix.crypto }}" -S . -B build
       - name: Build, debug configuration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,10 @@ elseif (CRYPTO_PROVIDER STREQUAL "ring")
     add_compile_definitions(DEFINE_RING)
 endif ()
 
+# Set ASAN sanitizer flags conditionally for Debug builds
+set(sanitizer_flags "$<$<CONFIG:Debug>:-fsanitize=address>")
+add_compile_options(${sanitizer_flags})
+
 add_executable(client client.c common.c)
 add_dependencies(client rustls-ffi)
 target_include_directories(client PUBLIC ${CMAKE_SOURCE_DIR}/src)


### PR DESCRIPTION
## ci: remove NASM install for Windows/aws-lc-rs

Rustls switched `aws-lc-rs` to use the [`prebuilt-nasm` feature](https://github.com/aws/aws-lc-rs/blob/main/aws-lc-rs/README.md#prebuilt-nasm) in Rustls 0.23.16+ This means we no longer need to install NASM in the Windows CI workflows that use aws-lc-rs.

## build Windows debug client/server with ASAN

This commit updates the `tests/CMakeLists.txt` configuration for building the client/server examples on Windows to enable [address sanitizer (ASAN)](https://github.com/google/sanitizers/wiki/AddressSanitizer). We were already doing this for Linux and MacOS builds but were missing Windows coverage.

Notably this requires a modern MSVC configured on the `$PATH` at runtime so that the ASAN DLLs are present. Otherwise the built binaries cryptically exit immediately with no output, just the exit status `-1073741515`. We use the [setup-msvc-dev](https://github.com/TheMrMilchmann/setup-msvc-dev) action in CI to do this for us (but only for the debug profile workflows).

You can confirm that ASAN is being used in the output of a debug build where we see a new warning:
> LINK : warning LNK4300: ignoring '/INCREMENTAL' because input module contains ASAN metadata [D:\a\rustls-ffi\rustls-ffi\build\tests\server.vcxproj]

See [the Microsoft ASAN documentation](https://devblogs.microsoft.com/cppblog/addresssanitizer-asan-for-windows-with-msvc/#compiling-with-asan-from-the-console) for more information.
