### PR TITLE
ci: cancel in-progress GH runs for same PR || ref

### DIFF
--- a/.github/workflows/pkg-config.yaml
+++ b/.github/workflows/pkg-config.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '15 12 * * 3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build+test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '15 12 * * 3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build+test


### PR DESCRIPTION
If you're pushing new work it's generally not useful to have CI churning on the old work. Cancel it and get cooking on the new stuff ASAP. See [github docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-concurrency-groups) for more information. 

h/t https://github.com/rustls/rustls/pull/2197 & @ctz for the config.