### PR TITLE
crypto_provider: fix clippy::question_mark finding

### DIFF
--- a/src/crypto_provider.rs
+++ b/src/crypto_provider.rs
@@ -463,14 +463,9 @@ pub(crate) fn get_default_or_install_from_crate_features() -> Option<Arc<CryptoP
         return Some(provider.clone());
     }
 
-    let provider = match provider_from_crate_features() {
-        Some(provider) => provider,
-        None => return None,
-    };
-
     // Ignore the error resulting from us losing a race to install the default,
     // and accept the outcome.
-    let _ = provider.install_default();
+    let _ = provider_from_crate_features()?.install_default();
 
     // Safety: we can unwrap safely here knowing we've just set the default, or
     // lost a race to something else setting the default.


### PR DESCRIPTION
```
error: this `match` expression can be replaced with `?`
   --> src/crypto_provider.rs:466:20
    |
466 |       let provider = match provider_from_crate_features() {
    |  ____________________^
467 | |         Some(provider) => provider,
468 | |         None => return None,
469 | |     };
    | |_____^ help: try instead: `provider_from_crate_features()?`
```