### PR TITLE
0.14.1 release preparation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
           - nightly
           # MSRV - keep in sync with what rustls and rustls-platform-verifier
           # consider MSRV
-          - 1.64.0
+          - 1.71.0
         os: [ ubuntu-latest ]
         # but only stable, clang, and aws-lc-rs on macos (slower platform)
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.14.1 (2024-11-22)
+
+This release updates to [Rustls 0.23.18][] and increases the project MSRV from
+1.64 to 1.71, matching the upstream Rustls MSRV.
+
+Notably this brings in a fix for an availability issue for **servers** using
+the `rustls_acceptor` type and associated APIs. See the upstream 0.23.18
+release notes for more information.
+
+[Rustls 0.23.18]: https://github.com/rustls/rustls/releases/tag/v%2F0.23.18
+
 ## 0.14.0 (2024-09-12)
 
 This release updates to [Rustls 0.23.13][] and changes the rustls-ffi API to allow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "libc",
  "log",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rustls/rustls-ffi"
 categories = ["network-programming", "cryptography"]
 edition = "2021"
 links = "rustls_ffi"
-rust-version = "1.64"
+rust-version = "1.71"
 
 [features]
 default = ["aws-lc-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.14.0"
+version = "0.14.1"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README-crates.io.md"
 description = "Rustls bindings for non-Rust languages"
@@ -26,7 +26,7 @@ aws-lc-rs = ["rustls/aws-lc-rs", "webpki/aws_lc_rs"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.13", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23.18", default-features = false, features = ["std", "tls12"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["std"] }
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to provide the cryptographic primitives.
 
 # Build
 
-You'll need to [install the Rust toolchain](https://rustup.rs/) (version 1.64
+You'll need to [install the Rust toolchain](https://rustup.rs/) (version 1.71
 or above) and a C compiler (`gcc` and `clang` should both work).
 
 ## Cryptography provider

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::{env, fs, path::PathBuf};
 // because doing so would require a heavy-weight deserialization lib dependency
 // (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
 // by-hand parsing.
-const RUSTLS_CRATE_VERSION: &str = "0.23.13";
+const RUSTLS_CRATE_VERSION: &str = "0.23.18";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/src/crypto_provider.rs
+++ b/src/crypto_provider.rs
@@ -461,14 +461,9 @@ pub(crate) fn get_default_or_install_from_crate_features() -> Option<Arc<CryptoP
         return Some(provider.clone());
     }
 
-    let provider = match provider_from_crate_features() {
-        Some(provider) => provider,
-        None => return None,
-    };
-
     // Ignore the error resulting from us losing a race to install the default,
     // and accept the outcome.
-    let _ = provider.install_default();
+    let _ = provider_from_crate_features()?.install_default();
 
     // Safety: we can unwrap safely here knowing we've just set the default, or
     // lost a race to something else setting the default.

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -40,7 +40,7 @@ impl Defaultable for rustls_tls_version {}
 
 impl<T> Defaultable for Option<T> {}
 
-impl<'a> Defaultable for rustls_slice_bytes<'a> {}
+impl Defaultable for rustls_slice_bytes<'_> {}
 
 impl<T: Defaultable> PanicOrDefault for T {
     fn value() -> Self {
@@ -66,7 +66,7 @@ impl PanicOrDefault for rustls_result {
     }
 }
 
-impl<'a> PanicOrDefault for rustls_str<'a> {
+impl PanicOrDefault for rustls_str<'_> {
     fn value() -> Self {
         rustls_str::from_str_unchecked("")
     }
@@ -108,7 +108,7 @@ impl NullParameterOrDefault for rustls_io_result {
     }
 }
 
-impl<'a> NullParameterOrDefault for rustls_str<'a> {
+impl NullParameterOrDefault for rustls_str<'_> {
     fn value() -> Self {
         rustls_str::from_str_unchecked("")
     }

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -175,7 +175,7 @@ impl<'a> TryFrom<&'a str> for rustls_str<'a> {
     }
 }
 
-impl<'a> Default for rustls_str<'a> {
+impl Default for rustls_str<'_> {
     fn default() -> rustls_str<'static> {
         Self::from_str_unchecked("")
     }
@@ -186,7 +186,7 @@ impl<'a> Default for rustls_str<'a> {
 /// The string should not have any internal NUL bytes and is not NUL terminated.
 /// C code should not create rustls_str objects, they should only be created in Rust
 /// code.
-impl<'a> rustls_str<'a> {
+impl rustls_str<'_> {
     pub fn from_str_unchecked(s: &'static str) -> rustls_str<'static> {
         rustls_str {
             data: s.as_ptr() as *const _,
@@ -226,7 +226,7 @@ impl<'a> rustls_str<'a> {
 // If the assertion about Rust code being the only creator of rustls_str objects
 // changes, you must change this Debug impl, since the assertion in it no longer
 // holds.
-impl<'a> fmt::Debug for rustls_str<'a> {
+impl fmt::Debug for rustls_str<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let raw = unsafe {
             // Despite the use of "unsafe", we know that this is safe because:

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -257,6 +257,7 @@ impl TestCase {
         });
 
         server.kill().expect("failed to kill server");
+        server.wait().expect("failed to wait on server");
         result
     }
 }


### PR DESCRIPTION
This release updates to [Rustls 0.23.18][] and increases the project MSRV from 1.64 to 1.71, matching the upstream Rustls MSRV.

Notably this brings in a fix for an availability issue for **servers** using the `rustls_acceptor` type and associated APIs. See the upstream 0.23.18 release notes for more information.

This branch targets rel-0.14, created from the 0.14.0 tag.

[Rustls 0.23.18]: https://github.com/rustls/rustls/releases/tag/v%2F0.23.18