### PR TITLE
0.14.1 backports for main, rustls 0.23.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
           - nightly
           # MSRV - keep in sync with what rustls and rustls-platform-verifier
           # consider MSRV
-          - 1.64.0
+          - 1.71.0
         os: [ ubuntu-latest ]
         # but only stable, clang, and aws-lc-rs on macos (slower platform)
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.14.1 (2024-11-22)
+
+This release updates to [Rustls 0.23.18][] and increases the project MSRV from
+1.64 to 1.71, matching the upstream Rustls MSRV.
+
+Notably this brings in a fix for an availability issue for **servers** using
+the `rustls_acceptor` type and associated APIs. See the upstream 0.23.18
+release notes for more information.
+
+[Rustls 0.23.18]: https://github.com/rustls/rustls/releases/tag/v%2F0.23.18
+
 ## 0.14.0 (2024-09-12)
 
 This release updates to [Rustls 0.23.13][] and changes the rustls-ffi API to allow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "aws-lc-rs",
  "brotli",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "libc",
  "log",
@@ -1001,6 +1001,6 @@ checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zlib-rs"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf919c619da9eaede02291295e9c5ae230fc7b5f2a5f4257ff859b075111faf"
+checksum = "2ca4a9dc6566c9224cc161dedc5577bd81f4a9ee0f9fbe80592756d096b07ee5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rustls/rustls-ffi"
 categories = ["network-programming", "cryptography"]
 edition = "2021"
 links = "rustls_ffi"
-rust-version = "1.64"
+rust-version = "1.71"
 
 [features]
 default = ["aws-lc-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ffi"
-version = "0.14.0"
+version = "0.15.0"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README-crates.io.md"
 description = "Rustls bindings for non-Rust languages"
@@ -27,7 +27,7 @@ cert_compression = ["rustls/brotli", "rustls/zlib"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.16", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23.18", default-features = false, features = ["std", "tls12"] }
 pki-types = { package = "rustls-pki-types", version = "1.10", features = ["std"] }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["std"] }
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to provide the cryptographic primitives.
 
 # Build
 
-You'll need to [install the Rust toolchain](https://rustup.rs/) (version 1.64
+You'll need to [install the Rust toolchain](https://rustup.rs/) (version 1.71
 or above) and a C compiler (`gcc` and `clang` should both work).
 
 ## Cryptography provider

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::{env, fs, path::PathBuf};
 // because doing so would require a heavy-weight deserialization lib dependency
 // (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
 // by-hand parsing.
-const RUSTLS_CRATE_VERSION: &str = "0.23.16";
+const RUSTLS_CRATE_VERSION: &str = "0.23.18";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());


### PR DESCRIPTION
Bringing useful changes from https://github.com/rustls/rustls-ffi/pull/490 to `main`:

### update MSRV 1.64 -> 1.71

This matches upstream rustls. Resolves #489 

### rustls 0.23.18, 0.14.1 changelog update
* Updates main to rustls 0.23.18 for the acceptor API fix, like the rel-0.14 release branch.
* Backports the rel-0.14 release notes for 0.14.1 to the main changelog.
* Sets main's version as 0.15 in preparation for a release in the future when ready.