### PR TITLE
tests: support multiple HTTPS RRs for ECH configs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -385,7 +385,8 @@ impl rustls_client_config_builder {
     ///
     /// The provided `ech_config_list_bytes` and `rustls_hpke` must not be NULL or an
     /// error will be returned. The caller maintains ownership of the ECH config list TLS bytes
-    /// and `rustls_hpke` instance.
+    /// and `rustls_hpke` instance. This function does not retain any reference to
+    /// `ech_config_list_bytes`.
     ///
     /// A `RUSTLS_RESULT_BUILDER_INCOMPATIBLE_TLS_VERSIONS` error is returned if the builder's
     /// TLS versions have been customized via `rustls_client_config_builder_new_custom()`

--- a/src/rustls.h
+++ b/src/rustls.h
@@ -1768,7 +1768,8 @@ rustls_result rustls_client_config_builder_set_key_log(struct rustls_client_conf
  *
  * The provided `ech_config_list_bytes` and `rustls_hpke` must not be NULL or an
  * error will be returned. The caller maintains ownership of the ECH config list TLS bytes
- * and `rustls_hpke` instance.
+ * and `rustls_hpke` instance. This function does not retain any reference to
+ * `ech_config_list_bytes`.
  *
  * A `RUSTLS_RESULT_BUILDER_INCOMPATIBLE_TLS_VERSIONS` error is returned if the builder's
  * TLS versions have been customized via `rustls_client_config_builder_new_custom()`

--- a/tests/common.h
+++ b/tests/common.h
@@ -23,6 +23,12 @@ const char *ws_strerror(int err);
 #endif /* !STDOUT_FILENO */
 #endif /* _WIN32 */
 
+#if defined(_MSC_VER)
+#define STRTOK_R strtok_s
+#else
+#define STRTOK_R strtok_r
+#endif
+
 enum demo_result
 {
   DEMO_OK,


### PR DESCRIPTION
Similar to a change in the [upstream Rustls ech-client.rs demo](https://github.com/rustls/rustls/pull/2278) we want to be able to process _multiple_ HTTPS records for a given domain, and look at each ECH config list from each record for a potential compatible config. Follow-up to https://github.com/rustls/rustls-ffi/pull/485.

Mechanically this means:

1. Updating the `test/ech_fetch.rs` helper to support writing multiple `.bin` files when there are multiple HTTPS records w/ ECH configs. The tool now outputs to stdout a comma separated list of the files it writes to make it easier to use with the `client.c` example.

2. Updating the `tests/client.c` example to treat the `RUSTLS_ECH_CONFIG_LIST` env var as a comma separated list of ECH config lists. We now loop through each and only fail if all of the provided files are unable to be used to configure the client config with a compatible ECH config. 

Doing string manipulation with C remains "a delight". For Windows compat we achieve tokenizing the string by the comma delim with a define to call either [`strtok_r`](https://linux.die.net/man/3/strtok_r) with GCC/clang, or [`strtok_s`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/strtok-s-strtok-s-l-wcstok-s-wcstok-s-l-mbstok-s-mbstok-s-l?view=msvc-170) with MSCV.

You can test this update with:

```
ECH_CONFIG_LISTS=$(cargo test --test ech_fetch -- curves1-ng.test.defo.ie /tmp/curves1-ng.test.defo.ie)
RUSTLS_PLATFORM_VERIFIER=1 RUSTLS_ECH_CONFIG_LIST="$ECH_CONFIG_LISTS" ./cmake-build-debug/tests/client curves1-ng.test.defo.ie 443 /echstat.php?format=json
```

If you're unlucky and the first HTTPS record served is the one with invalid configs you should see output like the following showing the client skipping over the `.1` config list and using the `.2` one instead:

```
client[188911]: no compatible/valid ECH configs found in '/tmp/curves1-ng.test.defo.ie.1'
client[188911]: using ECH with config list from '/tmp/curves1-ng.test.defo.ie.2'
```

This logic will also need to be ported into #497. I'll do that shortly but expect we can land this PR first against the pre-existing `client.c` and then catch 497 up afterwards.

Resolves https://github.com/rustls/rustls-ffi/issues/503