### PR TITLE
ci: build binary artifacts for pushes/PRs

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -70,6 +70,33 @@ jobs:
           name: rustls-ffi-x86_64-linux-gnu
           path: dist
 
+  linux-deb:
+    name: Linux (x86-64 GNU Deb)
+    runs-on: ubuntu-20.04 # x86_64. Using older Ubuntu for greater GLIBC compat.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-c
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
+        run: |
+          curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
+
+      - name: Build deb
+        run: ./debian/build.sh
+
+      - name: Upload deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: librustls_0.15.0_amd64.deb
+          path: librustls_0.15.0_amd64.deb
+
   macos-binaries:
     name: MacOS (Arm64 and x86_64)
     runs-on: macos-14 # arm64.

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -146,3 +146,122 @@ jobs:
         with:
           name: rustls-ffi-x86_64-macos
           path: x86-dist
+
+  test-archives:
+    name: "Test (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    needs: [ windows-binaries, linux-binaries, macos-binaries ]
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            artifact: rustls-ffi-x86_64-windows
+          - os: ubuntu-latest
+            artifact: rustls-ffi-x86_64-linux-gnu
+          - os: macos-14
+            artifact: rustls-ffi-arm64-macos
+          - os: macos-13
+            artifact: rustls-ffi-x86_64-macos
+    steps:
+      - name: Checkout rustls-ffi-test sources
+        uses: actions/checkout@v4
+        with:
+          repository: 'cpu/rustls-ffi-test'
+      - name: Download rustls-ffi artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+      # .pc files aren't relocatable. We need to update the prefix to point to
+      # the correct location that we extracted the archive. This seems more reliable
+      # than using `--define-prefix` - it seems to tack an extra 'lib/' subcomponent
+      # onto the include path that breaks the build.
+      - name: Fix pkg-config prefix
+        # We use bash shell explicitly to avoid PowerShell on Windows and to ensure we have 'sed'.
+        shell: bash
+        # For further fun, sed isn't consistent between macOS and Linux.
+        run: |
+          case "${{ runner.os }}" in
+            "macOS")
+              sed -i '' "s|prefix=.*|prefix=${{ matrix.artifact }}|" ${{ matrix.artifact }}/lib/pkgconfig/rustls.pc
+              ;;
+            *)
+              sed -i "s|prefix=.*|prefix=${{ matrix.artifact }}|" ${{ matrix.artifact }}/lib/pkgconfig/rustls.pc
+              ;;
+          esac
+      # Dump out what pkg-config says about the rustls package.
+      - name: Debug pkg-config
+        run: |
+          pkg-config --cflags rustls
+          pkg-config --libs rustls
+        env:
+          PKG_CONFIG_PATH: ${{ matrix.artifact }}/lib/pkgconfig
+      # Set up the cmake build, overriding PKG_CONFIG_PATH to
+      # point to the extracted rustls-ffi archive.
+      - name: Setup cmake build (UNIX)
+        if: matrix.os != 'windows-latest'
+        env:
+          PKG_CONFIG_PATH: ${{ matrix.artifact }}/lib/pkgconfig
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      # Set up the cmake build, overriding PKG_CONFIG_PATH to
+      # point to the extracted rustls-ffi archive.
+      #
+      # For Windows cmake needs some help finding the strawberry perl pkg-config
+      # that's installed in the runner's PATH.
+      - name: Setup cmake build (Windows)
+        if: matrix.os == 'windows-latest'
+        env:
+          PKG_CONFIG_PATH: ${{ matrix.artifact }}/lib/pkgconfig
+        run: cmake -DPKG_CONFIG_EXECUTABLE=C:\Strawberry\perl\bin\pkg-config.bat -S . -B build
+      # Build the rustls-ffi-test binary.
+      - name: Build rustls-ffi-test (UNIX)
+        if: matrix.os != 'windows-latest'
+        run: cmake --build build -v
+      # Build the rustls-ffi-test binary.
+      # On Windows we need to specify a configuration to avoid a warning about using the default
+      # debug MSCRT runtime with a lib built with the release MSCRT runtime.
+      - name: Build rustls-ffi-test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: cmake --build build --config Release -v
+      # Run the rustls-ffi-test binary.
+      - name: Run rustls-ffi-test (UNIX)
+        if: matrix.os != 'windows-latest'
+        run: ./build/rustls-ffi-test
+      # Run the rustls-ffi-test binary.
+      # On Windows it's in a different output location under build.
+      - name: Run rustls-ffi-test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: ./build/Release/rustls-ffi-test.exe
+
+  test-deb:
+    name: "Test Linux Deb (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    needs: [ linux-deb ]
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, ubuntu-20.04 ]
+    steps:
+      - name: Checkout rustls-ffi-test sources
+        uses: actions/checkout@v4
+        with:
+          repository: 'cpu/rustls-ffi-test'
+      - name: Download rustls-ffi deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: librustls_0.15.0_amd64.deb
+      - name: Install deb
+        run: sudo dpkg --install ./librustls_0.15.0_amd64.deb
+      # Dump out what pkg-config says about the rustls package.
+      - name: Debug pkg-config
+        run: |
+          pkg-config --cflags rustls
+          pkg-config --libs rustls
+      # Set up the cmake build, no pkg-config ENV overrides needed.
+      - name: Setup cmake build
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      # Build the rustls-ffi-test binary.
+      - name: Build rustls-ffi-test
+        run: cmake --build build -v
+      # Run the rustls-ffi-test binary.
+      - name: Run rustls-ffi-test
+        run: ./build/rustls-ffi-test

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -1,0 +1,121 @@
+name: binary artifacts
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  windows-binaries:
+    name: Windows (x86_64 MSVC)
+    runs-on: windows-2022 # x86_64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-c
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-windows-msvc.zip
+        run: |
+          curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
+          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+
+      - name: Build rusts-ffi
+        run: |
+          cargo cinstall --locked --target x86_64-pc-windows-msvc --features cert_compression --release --prefix dist 
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustls-ffi-x86_64-windows
+          path: dist
+
+  linux-binaries:
+    name: Linux (x86_64 GNU)
+    runs-on: ubuntu-20.04 # x86_64. Using older Ubuntu for greater GLIBC compat.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-c
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
+        run: |
+          curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
+
+      - name: Build rusts-ffi
+        # The Ubuntu 20.04 GCC is too old to build aws-lc.
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
+        env:
+          CC: clang
+          CXX: clang
+        run: |
+          cargo cinstall --locked --target x86_64-unknown-linux-gnu --features cert_compression --release --prefix dist
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustls-ffi-x86_64-linux-gnu
+          path: dist
+
+  macos-binaries:
+    name: MacOS (Arm64 and x86_64)
+    runs-on: macos-14 # arm64.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Install both the arm64 and x86_64 targets.
+          targets: aarch64-apple-darwin, x86_64-apple-darwin
+
+      - name: Install cargo-c
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-macos.zip
+        run: |
+          curl -L $LINK/$CARGO_C_FILE -o cargo-c-macos.zip
+          unzip cargo-c-macos.zip -d ~/.cargo/bin
+
+      - name: Build rusts-ffi (arm64)
+        run: |
+          cargo cinstall --target aarch64-apple-darwin --locked --features cert_compression --release --prefix arm64-dist
+
+      - name: Fix rpath (arm64)
+        run: |
+          install_name_tool -id @rpath/librustls.dylib arm64-dist/lib/librustls.dylib
+
+      - name: Upload binaries (arm64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustls-ffi-arm64-macos
+          path: arm64-dist
+
+      - name: Build rusts-ffi (x86_64)
+        run: |
+          cargo cinstall --target x86_64-apple-darwin --locked --features cert_compression --release --prefix x86-dist
+
+      - name: Fix rpath (x86_64)
+        run: |
+          install_name_tool -id @rpath/librustls.dylib x86-dist/lib/librustls.dylib
+
+      - name: Upload binaries (x86_64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustls-ffi-x86_64-macos
+          path: x86-dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ librustls/cmake-build*
 .idea
 .venv
 .vs
+debian/usr
+debian/DEBIAN

--- a/debian/build.sh
+++ b/debian/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -eu
+set -x
+
+cd "$(dirname "$0")"
+
+VERSION=$(sed -n 's/^version = "\(.*\)"$/\1/p' ../librustls/Cargo.toml)
+if [ -z "$VERSION" ]; then
+    echo "Failed to extract version from Cargo.toml" >&2
+    exit 1
+fi
+
+PACKAGE="librustls"
+ARCH="amd64"
+DIST_DIR="/tmp/dist"
+DEB_ROOT="/tmp/deb"
+
+CC=clang CXX=clang cargo cinstall --locked --features cert_compression --release --prefix "${DIST_DIR}"
+
+mkdir -p "${DEB_ROOT}/usr/"{lib,include}
+mkdir -p "${DEB_ROOT}/DEBIAN"
+
+cp -r "${DIST_DIR}/lib/"* "${DEB_ROOT}/usr/lib/"
+cp -r "${DIST_DIR}/include/"* "${DEB_ROOT}/usr/include/"
+
+sed -i "s|prefix=.*|prefix=/usr|" "${DEB_ROOT}/usr/lib/x86_64-linux-gnu/pkgconfig/rustls.pc"
+
+cat > "${DEB_ROOT}/DEBIAN/control" << EOF
+Package: ${PACKAGE}
+Version: ${VERSION}
+Architecture: ${ARCH}
+Maintainer: Daniel McCarney <daniel@binaryparadox.net>
+Description: FFI bindings for the Rustls TLS library
+Section: libs
+Depends: libc6
+Priority: optional
+EOF
+
+cat > "${DEB_ROOT}/DEBIAN/postinst" << EOF
+#!/bin/sh
+set -e
+ldconfig
+EOF
+chmod 755 "${DEB_ROOT}/DEBIAN/postinst"
+
+cd ..
+dpkg-deb --build ${DEB_ROOT} "${PACKAGE}_${VERSION}_${ARCH}.deb"


### PR DESCRIPTION
This branch adds a CI job for all pushes & PRs that builds binary artifacts for `rustls-ffi` for:

* Windows (x86_64 MSVC)
* Debian .deb (x86_64 GNU)
* Linux (x86_64 GNU)
* Apple (ARM64 and x86_64)

Binary artifacts are built in release mode using stable rust, with the default crypto provider (aws-lc-rs) and cert compression enabled.

Linux binaries are built on ubuntu-20.04 for greatest compatibility. Users will need glibc 2.31 or greater. For now I've opted not to include a statically linked musl build.

For FIPS, no cert-compression, the ring crypto provider, debug builds, or other customization you will need to build from source.

Users of the `.pc` files from the bare archive will need to override the `prefix` to wherever they extract the archive, or use `cargo cinstall` from src. Package config files in an archive aren't relocatable. The `.deb` for Debian/Ubuntu has the correct `.pc` prefix already.

The build library zips are automatically added to the CI run as artifacts. This has the advantage that we don't need any special write permissions and can manually attach binary artifacts to the releases we publish as appropriate. For now I'd like to avoid automating the release process. Artifact links associated with a branch are valid for ~90d.

You can see the artifacts produced for this PR [here](https://github.com/rustls/rustls-ffi/actions/runs/12509008035), under the annotations.

![artifacts_000](https://github.com/user-attachments/assets/bce62e57-7c42-47dd-886c-6d7709fc9679)

See an example of a simple C test application built using `cmake` and `pkg-config` from the distributed binary releases here: https://github.com/cpu/rustls-ffi-test  It's used by testing CI stages that run after the packaging step for each OS/output.

Unpacking the archives gives structure like:

```
# Linux
.
├── include
│   └── rustls.h
├── lib
│  ├── librustls.a
│  ├── librustls.so
│  ├── librustls.so.0.15.0
│  └── pkgconfig
│      └── rustls.pc
```

```
# MacOS
.
├── include
│   └── rustls.h
├── lib
│   ├── librustls.0.15.0.dylib
│   ├── librustls.a
│   ├── librustls.dylib
│   └── pkgconfig
│       └── rustls.pc
```

```
# Windows
.
├── bin
│   ├── rustls.dll
│   └── rustls.pdb
├── include
│   └── rustls.h
├── lib
│   ├── pkgconfig
│   │   └── rustls.pc
│   ├── rustls.def
│   ├── rustls.dll.lib
│   └── rustls.lib
```

The `.deb` displays the following:

```
$ dpkg-deb --info librustls_0.15.0_amd64.deb
 new Debian package, version 2.0.
 size 8759588 bytes: control archive=420 bytes.
     211 bytes,     8 lines      control
      26 bytes,     3 lines   *  postinst             #!/bin/sh
 Package: librustls
 Version: 0.15.0
 Architecture: amd64
 Maintainer: Daniel McCarney <daniel@binaryparadox.net>
 Description: FFI bindings for the Rustls TLS library
 Section: libs
 Depends: libc6
 Priority: optional
 
$ dpkg-deb --contents librustls_0.15.0_amd64.deb
drwxr-xr-x runner/docker     0 2024-12-22 20:09 ./
drwxr-xr-x runner/docker     0 2024-12-22 20:09 ./usr/
drwxr-xr-x runner/docker     0 2024-12-22 20:09 ./usr/include/
-rw-r--r-- runner/docker 122289 2024-12-22 20:09 ./usr/include/rustls.h
drwxr-xr-x runner/docker      0 2024-12-22 20:09 ./usr/lib/
drwxr-xr-x runner/docker      0 2024-12-22 20:09 ./usr/lib/x86_64-linux-gnu/
-rw-r--r-- runner/docker 38767436 2024-12-22 20:09 ./usr/lib/x86_64-linux-gnu/librustls.a
-rwxr-xr-x runner/docker  6082776 2024-12-22 20:09 ./usr/lib/x86_64-linux-gnu/librustls.so.0.15.0
drwxr-xr-x runner/docker        0 2024-12-22 20:09 ./usr/lib/x86_64-linux-gnu/pkgconfig/
-rw-r--r-- runner/docker      286 2024-12-22 20:09 ./usr/lib/x86_64-linux-gnu/pkgconfig/rustls.pc
lrwxrwxrwx runner/docker        0 2024-12-22 20:09 ./usr/lib/x86_64-linux-gnu/librustls.so -> librustls.so.0.15.0
```

Resolves https://github.com/rustls/rustls-ffi/issues/218