### PR TITLE
Two small breaking API changes before next release

### DIFF
--- a/librustls/src/rustls.h
+++ b/librustls/src/rustls.h
@@ -2365,22 +2365,22 @@ rustls_result rustls_server_connection_new(const struct rustls_server_config *co
                                            struct rustls_connection **conn_out);
 
 /**
- * Copy the server name from the server name indication (SNI) extension to `buf`.
+ * Returns a `rustls_str` reference to the server name sent by the client in a server name
+ * indication (SNI) extension.
  *
- * `buf` can hold up  to `count` bytes, and the length of that server name in `out_n`.
+ * The returned `rustls_str` is valid until the next mutating function call affecting the
+ * connection. A mutating function call is one where the first argument has type
+ * `struct rustls_connection *` (as opposed to `const struct rustls_connection *`). The caller
+ * does not need to free the `rustls_str`.
  *
- * The string is stored in UTF-8 with no terminating NUL byte.
+ * Returns a zero-length `rustls_str` if:
  *
- * Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
- *
- * Returns Ok with *out_n == 0 if there is no SNI hostname available on this connection
- * because it hasn't been processed yet, or because the client did not send SNI.
- * <https://docs.rs/rustls/latest/rustls/server/struct.ServerConnection.html#method.server_name>
+ * - the connection is not a server connection.
+ * - the connection is a server connection but the SNI extension in the client hello has not
+ *   been processed during the handshake yet. Check `rustls_connection_is_handshaking`.
+ * - the SNI value contains null bytes.
  */
-rustls_result rustls_server_connection_get_server_name(const struct rustls_connection *conn,
-                                                       uint8_t *buf,
-                                                       size_t count,
-                                                       size_t *out_n);
+struct rustls_str rustls_server_connection_get_server_name(const struct rustls_connection *conn);
 
 /**
  * Register a callback to be invoked when a connection created from this config

--- a/librustls/src/rustls.h
+++ b/librustls/src/rustls.h
@@ -2428,13 +2428,16 @@ rustls_result rustls_client_hello_select_certified_key(const struct rustls_clien
  * keys and values are highly sensitive data, containing enough information
  * to break the security of the connections involved.
  *
+ * If `builder`, `get_cb`, or `put_cb` are NULL, this function will return
+ * immediately without doing anything.
+ *
  * If `userdata` has been set with rustls_connection_set_userdata, it
  * will be passed to the callbacks. Otherwise the userdata param passed to
  * the callbacks will be NULL.
  */
-rustls_result rustls_server_config_builder_set_persistence(struct rustls_server_config_builder *builder,
-                                                           rustls_session_store_get_callback get_cb,
-                                                           rustls_session_store_put_callback put_cb);
+void rustls_server_config_builder_set_persistence(struct rustls_server_config_builder *builder,
+                                                  rustls_session_store_get_callback get_cb,
+                                                  rustls_session_store_put_callback put_cb);
 
 /**
  * Free a `rustls_client_cert_verifier` previously returned from

--- a/librustls/tests/common.c
+++ b/librustls/tests/common.c
@@ -486,6 +486,14 @@ log_connection_info(const rustls_connection *rconn)
   else {
     LOG_SIMPLE("negotiated ALPN protocol: none");
   }
+
+  // We can unconditionally call this function whether we have a server
+  // or client connection, as it will return an empty rustls_str if it was a
+  // client connection.
+  const rustls_str sni = rustls_server_connection_get_server_name(rconn);
+  if(sni.len > 0) {
+    LOG("client SNI: '%.*s'", (int)sni.len, sni.data);
+  }
 }
 
 // TLS 1.2 and TLS 1.3, matching Rustls default.


### PR DESCRIPTION
Knocking out a couple small issues labelled `next-major-release` since we're preparing a 0.15 in `main`. Sure do appreciate having `let .. else` stable in our MSRV :revolving_hearts: 

Resolves #179
Resolves #229 

### server: SNI rustls_connection getter ret rustls_str
The `rustls_server_connection_get_server_name()` API function previously wrote the SNI value to a caller-provided buffer as it predates the `rustls_str` pattern.

This commit updates it to return a `rustls_str`. Invalid parameters or incomplete connection state are returned as empty strs.

The documented lifetime matches that of other `rustls_connection` accessors based on a "set-once" property we assume from upstream.

### server: remove rustls_result from set_persistence

Previously `rustls_server_config_builder_set_persistence()` returned a `rustls_result` just to indicate if a required parameter was `NULL`.

Our API guidelines instead recommend this function do nothing and return void for these circumstances.

