### PR TITLE
ci: separate out a daily-tests workflow

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -1,0 +1,132 @@
+name: daily-tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    # We run these tests on a daily basis (at a time slightly offset from the
+    # top of the hour), as their runtime is either too long for the usual per-PR
+    # CI, or because they rely on external 3rd party services that can be flaky.
+    - cron: '15 18 * * *'
+
+jobs:
+  verifier:
+    name: "Platform Verifier (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-c (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
+        run: |
+          curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
+
+      - name: Install cargo-c (macOS)
+        if: matrix.os == 'macos-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-macos.zip
+        run: |
+          curl -L $LINK/$CARGO_C_FILE -o cargo-c-macos.zip
+          unzip cargo-c-macos.zip -d ~/.cargo/bin
+
+      - name: Install cargo-c (Windows)
+        if: matrix.os == 'windows-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-windows-msvc.zip
+        run: |
+          curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
+          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+
+      - name: Setup cmake build
+        run: |
+          cmake ${{ 
+            matrix.os != 'windows-latest' && '-DCMAKE_BUILD_TYPE=Release \' || '' 
+          }} ${{ 
+            matrix.os == 'macos-latest' && '-DCMAKE_OSX_DEPLOYMENT_TARGET=14.5' || '' 
+          }} -S librustls -B build
+
+      - name: Run platform-verifier connect test
+        run: |
+          cmake --build build --target connect-test ${{ 
+            matrix.os == 'windows-latest' && '--config Release' || '' 
+          }}
+
+  ech:
+    name: "ECH (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-c (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
+        run: |
+          curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
+
+      - name: Install cargo-c (macOS)
+        if: matrix.os == 'macos-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-macos.zip
+        run: |
+          curl -L $LINK/$CARGO_C_FILE -o cargo-c-macos.zip
+          unzip cargo-c-macos.zip -d ~/.cargo/bin
+
+      - name: Install cargo-c (Windows)
+        if: matrix.os == 'windows-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          CARGO_C_FILE: cargo-c-windows-msvc.zip
+        run: |
+          curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
+          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+
+      - name: Setup cmake build
+        run: |
+          cmake ${{ 
+            matrix.os != 'windows-latest' && '-DCMAKE_BUILD_TYPE=Release \' || '' 
+          }} ${{ 
+            matrix.os == 'macos-latest' && '-DCMAKE_OSX_DEPLOYMENT_TARGET=14.5' || '' 
+          }} -S librustls -B build
+
+      - name: Run ECH test
+        # NOTE: uses bash as the shell to allow for easy no-powershell tee/grep pipeline.
+        shell: bash
+        run: |
+          cmake --build build --target ech-test ${{ 
+            matrix.os == 'windows-latest' && '--config Release' || '' 
+          }} | tee ech-test.log
+
+      - name: Verify ECH status
+        shell: bash
+        run: |
+          grep 'sni=encrypted' ech-test.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,9 +105,6 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      - name: Platform verifier connect test
-        run: cmake --build build --target connect-test
-
       - name: Integration tests
         run: cmake --build build --target integration-test
 
@@ -128,12 +125,6 @@ jobs:
         run: |
           ! nm build/tests/client | grep '__asan_init' 
           ! nm build/tests/server | grep '__asan_init'
-
-      - name: Run ECH connect test
-        if: matrix.crypto == 'aws-lc-rs' # No HPKE in ring
-        run: |
-          cmake --build build --target ech-test > ech-test.log
-          grep 'sni=encrypted' ech-test.log
 
       # Our integration tests rely on a built-in provider being enabled.
       # Double-check the library/unit tests work without any providers to
@@ -249,12 +240,6 @@ jobs:
 
       - name: Integration test
         run: cmake --build build --config "${{matrix.config}}" --target integration-test
-
-      - name: Run ECH connect test
-        if: matrix.crypto == 'aws-lc-rs' # No HPKE in ring
-        run: |
-          cmake --build build --target ech-test > ech-test.log
-          grep 'sni=encrypted' ech-test.log
 
   ensure-header-updated:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously we were running both the `connect-test` (for checking platform-verifier works against `example.com`) and the `ech-test` (for checking ECH works against cloudflare's test server) as part of normal CI.

In practice relying on remote servers as a blocking condition for a pass on a required CI task is crummy. Flakes outside of our control can cause build failures that later resolve themselves.

Instead, follow the main rustls repo practice of running a separate CI job on a daily schedule. This makes flakes less onerous while still maintaining the test coverage. The workflow can also be manually invoked in the GitHub UI via the manual dispatch trigger.

Updates https://github.com/rustls/rustls-ffi/issues/514