### PR TITLE
crypto_provider: avoid rand dep for GREASE HPKE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,6 @@ version = "0.15.0"
 dependencies = [
  "libc",
  "log",
- "rand",
  "regex",
  "rustls",
  "rustls-platform-verifier",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ webpki = { package = "rustls-webpki", version = "0.102.0", default-features = fa
 libc = "0.2"
 log = "0.4.22"
 rustls-platform-verifier = "0.5"
-rand = "0.8"
 regex = "1.9.6"
 toml = { version = "0.6.0", default-features = false, features = ["parse"] }
 hickory-resolver = { version = "=0.25.0-alpha.4", features = ["dns-over-https-rustls", "webpki-roots"] }

--- a/librustls/Cargo.toml
+++ b/librustls/Cargo.toml
@@ -33,7 +33,6 @@ webpki  = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 rustls-platform-verifier = { workspace = true }
-rand = { workspace = true }
 
 [lib]
 name = "rustls_ffi"

--- a/librustls/src/client.rs
+++ b/librustls/src/client.rs
@@ -454,7 +454,12 @@ impl rustls_client_config_builder {
             let builder = try_mut_from_ptr!(builder);
             let hpke = try_ref_from_ptr!(hpke);
 
-            let Some((suite, placeholder_pk)) = hpke.grease_public_key() else {
+            let provider = match &builder.provider {
+                Some(provider) => provider,
+                None => return rustls_result::NoDefaultCryptoProvider,
+            };
+
+            let Some((suite, placeholder_pk)) = hpke.grease_public_key(provider) else {
                 return rustls_result::HpkeError;
             };
 


### PR DESCRIPTION
Previously we used the `rand` crate as a convenient way to select a supported HPKE suite at random for ECH when using GREASE. In general it's crummy to take a dep for such a minor need.

Instead, adapt the crypto provider CSRNG to this task by performing a truncated uniform sampling. This should be more than sufficient for the use-case and avoids an extra dep.

Resolves https://github.com/rustls/rustls-ffi/issues/529