### PR TITLE
Add a compatibility Makefile stub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ hickory-resolver = { version = "=0.25.0-alpha.4", features = ["dns-over-https-ru
 tokio = { version = "1.43.0", features = ["io-util", "macros", "net", "rt"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tree-sitter = "0.23" # TODO(@cpu): handle breaking API changes for 0.24
+# TODO(@cpu): handle breaking API changes for tree-sitter 0.24.
+#   This is blocked on a tree-sitter-md release for the tree-sitter 0.24 update
+#   presently unreleased on upstream main.
+tree-sitter = "0.23" 
 tree-sitter-c = "0.23"
 tree-sitter-md = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# This Makefile exists exclusively as a convenience for users previously relying on the
+# rustls-ffi Makefile for Linux/MacOS builds.
+#
+# GNU make is **not** required to build librustls and in most circumstances you are better off
+# using cargo-c directly. See the README.md for more information.
+
+CARGO ?= cargo
+DESTDIR ?= /usr/local
+
+all: install
+
+check-cargo-c:
+	@if ! ${CARGO} capi --version >/dev/null 2>&1; then \
+		printf "%s" "Error: cargo-c is not installed. Install it with 'cargo install cargo-c' " && \
+		printf "%s\n" "or download a binary release from https://github.com/lu-zero/cargo-c/releases/"; \
+		exit 1; \
+	fi
+
+# NOTE: If you wish to customize library features, or build in debug mode, you should use cargo-c directly.
+install: check-cargo-c
+	${CARGO} capi install --release --libdir lib --prefix=${DESTDIR}
+
+.PHONY: all install check-cargo-c


### PR DESCRIPTION
Adds a tiny Makefile that defers to `cargo capi install`.

Previously rustls-ffi offered a GNU `Makefile` for building the library on Linux/MacOS. Because of the inherent limitations of this build system and a desire to have uniformity across all supported operating systems we've replaced this with usage of `cargo-c`.

While the README documents the finer details of using `cargo-c` it's likely some users just want to keep doing what they were doing before: running `make install` with a custom `DESTDIR`.

This commit provides a shortcut to do just that, backed by `cargo-c`. I have explicitly not restored the ability to:

* build/run the client/server tests: this is handled by `cmake` now.
* handle developer tasks like formatting/linting. Also handled by `cmake` now.
* customize the build (e.g. debug build, alt crypto providers, fips mode, etc). Use `cargo-c` directly for this per the README instructions.

Resolves https://github.com/rustls/rustls-ffi/issues/525