### PR TITLE
ci: include LICENSE files in artifact zips/deb

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -29,7 +29,10 @@ jobs:
 
       - name: Build rusts-ffi
         run: |
-          cargo cinstall --locked --target x86_64-pc-windows-msvc --features cert_compression --release --prefix dist 
+          cargo cinstall --locked --target x86_64-pc-windows-msvc --features cert_compression --release --prefix dist
+
+      - name: Copy in LICENSE files
+        run: cp LICENSE* dist
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4
@@ -63,6 +66,9 @@ jobs:
           CXX: clang
         run: |
           cargo cinstall --locked --target x86_64-unknown-linux-gnu --features cert_compression --release --prefix dist
+
+      - name: Copy in LICENSE files
+        run: cp LICENSE* dist
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4
@@ -127,6 +133,9 @@ jobs:
         run: |
           install_name_tool -id @rpath/librustls.dylib arm64-dist/lib/librustls.dylib
 
+      - name: Copy in LICENSE files (arm64)
+        run: cp LICENSE* arm64-dist
+
       - name: Upload binaries (arm64)
         uses: actions/upload-artifact@v4
         with:
@@ -140,6 +149,9 @@ jobs:
       - name: Fix rpath (x86_64)
         run: |
           install_name_tool -id @rpath/librustls.dylib x86-dist/lib/librustls.dylib
+
+      - name: Copy in LICENSE files (x86_64)
+        run: cp LICENSE* x86-dist
 
       - name: Upload binaries (x86_64)
         uses: actions/upload-artifact@v4
@@ -172,6 +184,12 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
+      - name: Verify license files are present
+        run: |
+          test -f ${{ matrix.artifact }}/LICENSE
+          test -f ${{ matrix.artifact }}/LICENSE-APACHE
+          test -f ${{ matrix.artifact }}/LICENSE-ISC
+          test -f ${{ matrix.artifact }}/LICENSE-MIT
       # .pc files aren't relocatable. We need to update the prefix to point to
       # the correct location that we extracted the archive. This seems more reliable
       # than using `--define-prefix` - it seems to tack an extra 'lib/' subcomponent
@@ -251,6 +269,8 @@ jobs:
           name: librustls_0.15.0_amd64.deb
       - name: Install deb
         run: sudo dpkg --install ./librustls_0.15.0_amd64.deb
+      - name: Check copyright exists
+        run: test -f /usr/share/doc/librustls/COPYRIGHT
       # Dump out what pkg-config says about the rustls package.
       - name: Debug pkg-config
         run: |

--- a/debian/build.sh
+++ b/debian/build.sh
@@ -17,11 +17,12 @@ DEB_ROOT="/tmp/deb"
 
 CC=clang CXX=clang cargo cinstall --locked --features cert_compression --release --prefix "${DIST_DIR}"
 
-mkdir -p "${DEB_ROOT}/usr/"{lib,include}
+mkdir -p "${DEB_ROOT}/usr/"{lib,include,share/doc/${PACKAGE}}
 mkdir -p "${DEB_ROOT}/DEBIAN"
 
 cp -r "${DIST_DIR}/lib/"* "${DEB_ROOT}/usr/lib/"
 cp -r "${DIST_DIR}/include/"* "${DEB_ROOT}/usr/include/"
+cat ../LICENSE* > "${DEB_ROOT}/usr/share/doc/${PACKAGE}/COPYRIGHT"
 
 sed -i "s|prefix=.*|prefix=/usr|" "${DEB_ROOT}/usr/lib/x86_64-linux-gnu/pkgconfig/rustls.pc"
 


### PR DESCRIPTION
Also check for their presence in the artifact testing stage.

This was an oversight in https://github.com/rustls/rustls-ffi/pull/506