### PR TITLE
rustfmt: style_edition 2024, small CI tweaks

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -7,6 +7,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows-binaries:
     name: Windows (x86_64 MSVC)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -335,9 +335,8 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.73" # Matching MSRV
           components: rustfmt
 
       - name: Install Gersemi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '15 12 * * 3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build+Test (${{ matrix.os }}, ${{ matrix.cc }}, ${{ matrix.rust }}, ${{ matrix.crypto }}${{ matrix.cert_compression == 'on' && ', cert compression' || '' }}${{ matrix.prefer-pq == 'on' && ', prefer-post-quantum' || '' }}${{ matrix.dyn_link == 'on' && ', dynamic linking' || '' }})"

--- a/librustls/src/acceptor.rs
+++ b/librustls/src/acceptor.rs
@@ -1,4 +1,4 @@
-use libc::{c_void, size_t, EINVAL, EIO};
+use libc::{EINVAL, EIO, c_void, size_t};
 use rustls::server::{Accepted, AcceptedAlert, Acceptor};
 
 use crate::connection::rustls_connection;
@@ -7,7 +7,7 @@ use crate::ffi::{
     box_castable, free_box, set_boxed_mut_ptr, to_box, to_boxed_mut_ptr, try_callback,
     try_clone_arc, try_mut_from_ptr, try_mut_from_ptr_ptr, try_ref_from_ptr, try_take,
 };
-use crate::io::{rustls_read_callback, rustls_write_callback, CallbackReader, CallbackWriter};
+use crate::io::{CallbackReader, CallbackWriter, rustls_read_callback, rustls_write_callback};
 use crate::panic::ffi_panic_boundary;
 use crate::rslice::{rustls_slice_bytes, rustls_str};
 use crate::server::rustls_server_config;

--- a/librustls/src/certificate.rs
+++ b/librustls/src/certificate.rs
@@ -4,10 +4,10 @@ use std::ptr::null;
 use std::slice;
 
 use libc::{c_char, size_t};
+use rustls::RootCertStore;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::sign::CertifiedKey;
-use rustls::RootCertStore;
 
 use crate::crypto_provider::{self, rustls_signing_key};
 use crate::error::{map_error, rustls_result};

--- a/librustls/src/client.rs
+++ b/librustls/src/client.rs
@@ -6,15 +6,15 @@ use std::sync::Arc;
 use libc::{c_char, size_t};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::{EchConfig, EchGreaseConfig, EchMode, ResolvesClientCert};
-use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
+use rustls::crypto::{CryptoProvider, verify_tls12_signature, verify_tls13_signature};
 use rustls::pki_types::{CertificateDer, EchConfigListBytes, ServerName, UnixTime};
 use rustls::{
-    sign::CertifiedKey, ClientConfig, ClientConnection, DigitallySignedStruct, Error, KeyLog,
-    KeyLogFile, ProtocolVersion, SignatureScheme, SupportedProtocolVersion,
+    ClientConfig, ClientConnection, DigitallySignedStruct, Error, KeyLog, KeyLogFile,
+    ProtocolVersion, SignatureScheme, SupportedProtocolVersion, sign::CertifiedKey,
 };
 
 use crate::certificate::rustls_certified_key;
-use crate::connection::{rustls_connection, Connection};
+use crate::connection::{Connection, rustls_connection};
 use crate::crypto_provider::{self, rustls_crypto_provider, rustls_hpke};
 use crate::error::{self, map_error, rustls_result};
 use crate::ffi::{
@@ -22,7 +22,7 @@ use crate::ffi::{
     to_boxed_mut_ptr, try_box_from_ptr, try_clone_arc, try_mut_from_ptr, try_mut_from_ptr_ptr,
     try_ref_from_ptr, try_ref_from_ptr_ptr, try_slice,
 };
-use crate::keylog::{rustls_keylog_log_callback, rustls_keylog_will_log_callback, CallbackKeyLog};
+use crate::keylog::{CallbackKeyLog, rustls_keylog_log_callback, rustls_keylog_will_log_callback};
 use crate::panic::ffi_panic_boundary;
 use crate::rslice::NulByte;
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_str};

--- a/librustls/src/connection.rs
+++ b/librustls/src/connection.rs
@@ -2,9 +2,9 @@ use std::io::{ErrorKind, Read, Write};
 use std::{ffi::c_void, ptr::null};
 use std::{ptr::null_mut, slice};
 
-use libc::{size_t, EINVAL, EIO};
-use rustls::pki_types::CertificateDer;
+use libc::{EINVAL, EIO, size_t};
 use rustls::CipherSuite::TLS_NULL_WITH_NULL_NULL;
+use rustls::pki_types::CertificateDer;
 use rustls::{ClientConnection, ServerConnection};
 
 use crate::certificate::rustls_certificate;
@@ -15,8 +15,8 @@ use crate::ffi::{
     try_slice_mut,
 };
 use crate::io::{
-    rustls_read_callback, rustls_write_callback, rustls_write_vectored_callback, CallbackReader,
-    CallbackWriter, VectoredCallbackWriter,
+    CallbackReader, CallbackWriter, VectoredCallbackWriter, rustls_read_callback,
+    rustls_write_callback, rustls_write_vectored_callback,
 };
 use crate::log::{ensure_log_registered, rustls_log_callback};
 use crate::panic::ffi_panic_boundary;
@@ -556,10 +556,10 @@ impl rustls_connection {
             let n_read = match conn.reader().read(read_buf) {
                 Ok(n) => n,
                 Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
-                    return rustls_result::UnexpectedEof
+                    return rustls_result::UnexpectedEof;
                 }
                 Err(e) if e.kind() == ErrorKind::WouldBlock => {
-                    return rustls_result::PlaintextEmpty
+                    return rustls_result::PlaintextEmpty;
                 }
                 Err(_) => return rustls_result::Io,
             };
@@ -601,10 +601,10 @@ impl rustls_connection {
             let n_read = match conn.reader().read_buf(read_buf.unfilled()) {
                 Ok(()) => read_buf.filled().len(),
                 Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
-                    return rustls_result::UnexpectedEof
+                    return rustls_result::UnexpectedEof;
                 }
                 Err(e) if e.kind() == ErrorKind::WouldBlock => {
-                    return rustls_result::PlaintextEmpty
+                    return rustls_result::PlaintextEmpty;
                 }
                 Err(_) => return rustls_result::Io,
             };

--- a/librustls/src/crypto_provider.rs
+++ b/librustls/src/crypto_provider.rs
@@ -3,15 +3,15 @@ use std::sync::Arc;
 
 use libc::size_t;
 
+use rustls::SupportedCipherSuite;
 #[cfg(feature = "aws-lc-rs")]
 use rustls::crypto::aws_lc_rs;
 #[cfg(feature = "ring")]
 use rustls::crypto::ring;
-use rustls::crypto::{hpke, CryptoProvider};
-use rustls::pki_types::pem::PemObject;
+use rustls::crypto::{CryptoProvider, hpke};
 use rustls::pki_types::PrivateKeyDer;
+use rustls::pki_types::pem::PemObject;
 use rustls::sign::SigningKey;
-use rustls::SupportedCipherSuite;
 
 use crate::cipher::rustls_supported_ciphersuite;
 use crate::error::{map_error, rustls_result};

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -532,7 +532,10 @@ impl Display for rustls_result {
                 write!(f, "an error occurred with the selected HPKE suite")
             }
             BuilderIncompatibleTlsVersions => {
-                write!(f, "the client config builder specifies incompatible TLS versions for the requested feature")
+                write!(
+                    f,
+                    "the client config builder specifies incompatible TLS versions for the requested feature"
+                )
             }
 
             CertEncodingBad => Error::InvalidCertificate(CertificateError::BadEncoding).fmt(f),

--- a/librustls/src/rslice.rs
+++ b/librustls/src/rslice.rs
@@ -97,7 +97,7 @@ pub extern "C" fn rustls_slice_slice_bytes_get(
                     data: null(),
                     len: 0,
                     phantom: PhantomData,
-                }
+                };
             }
         }
     };
@@ -329,7 +329,7 @@ pub extern "C" fn rustls_slice_str_get(input: *const rustls_slice_str, n: size_t
                     data: null(),
                     len: 0,
                     phantom: PhantomData,
-                }
+                };
             }
         }
     };

--- a/librustls/src/server.rs
+++ b/librustls/src/server.rs
@@ -14,19 +14,19 @@ use rustls::sign::CertifiedKey;
 use rustls::{KeyLog, KeyLogFile, ProtocolVersion, SignatureScheme, SupportedProtocolVersion};
 
 use crate::certificate::rustls_certified_key;
-use crate::connection::{rustls_connection, Connection};
+use crate::connection::{Connection, rustls_connection};
 use crate::crypto_provider::{self, rustls_crypto_provider};
 use crate::error::{map_error, rustls_result};
 use crate::ffi::{
-    arc_castable, box_castable, free_arc, free_box, set_arc_mut_ptr, set_boxed_mut_ptr,
-    to_boxed_mut_ptr, try_box_from_ptr, try_clone_arc, try_mut_from_ptr, try_mut_from_ptr_ptr,
-    try_ref_from_ptr, try_ref_from_ptr_ptr, try_slice, Castable, OwnershipRef,
+    Castable, OwnershipRef, arc_castable, box_castable, free_arc, free_box, set_arc_mut_ptr,
+    set_boxed_mut_ptr, to_boxed_mut_ptr, try_box_from_ptr, try_clone_arc, try_mut_from_ptr,
+    try_mut_from_ptr_ptr, try_ref_from_ptr, try_ref_from_ptr_ptr, try_slice,
 };
-use crate::keylog::{rustls_keylog_log_callback, rustls_keylog_will_log_callback, CallbackKeyLog};
+use crate::keylog::{CallbackKeyLog, rustls_keylog_log_callback, rustls_keylog_will_log_callback};
 use crate::panic::ffi_panic_boundary;
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_slice_u16, rustls_str};
 use crate::session::{
-    rustls_session_store_get_callback, rustls_session_store_put_callback, SessionStoreBroker,
+    SessionStoreBroker, rustls_session_store_get_callback, rustls_session_store_put_callback,
 };
 use crate::userdata::userdata_get;
 use crate::verifier::rustls_client_cert_verifier;

--- a/librustls/src/verifier.rs
+++ b/librustls/src/verifier.rs
@@ -2,13 +2,13 @@ use std::slice;
 use std::sync::Arc;
 
 use libc::size_t;
-use rustls::client::danger::ServerCertVerifier;
 use rustls::client::WebPkiServerVerifier;
+use rustls::client::danger::ServerCertVerifier;
 use rustls::crypto::CryptoProvider;
-use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::CertificateRevocationListDer;
-use rustls::server::danger::ClientCertVerifier;
+use rustls::pki_types::pem::PemObject;
 use rustls::server::WebPkiClientVerifier;
+use rustls::server::danger::ClientCertVerifier;
 use rustls::{DistinguishedName, RootCertStore};
 use webpki::{ExpirationPolicy, RevocationCheckDepth, UnknownStatusPolicy};
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2024"


### PR DESCRIPTION
### ci: limit concurrency, auto-cancel stale jobs
This lifts some configuration we've been[ using on the main Rustls repo](https://github.com/rustls/rustls/blob/3ccfcece31d727f57e9ad3806e4652e146ac3eed/.github/workflows/build.yml#L17-L19) for some time now without issue. The primary advantage is having stale workflow runs automatically cancelled when a branch update is pushed.

Historically for this repo I've done that by hand and it's a pain!

### ci: format with latest stable rust

Formatting against MSRV is too restrictive. MSRV is primarily for downstream consumers, and not for developers.

### rustfmt: style_edition 2024

Like https://github.com/rustls/rustls/pull/2348, https://github.com/rustls/webpki/pull/323 and https://github.com/rustls/pki-types/pull/74 we want to adopt 2024 edition style without actually taking 2024 edition (and breaking semver).

Unlike some other repos, `cargo fix --edition` will produce a diff (primarily small changes related to `no_mangle` being marked unsafe, and `unsafe fn` functions not having an automatic function-wide `unsafe` scope). We can't take those until MSRV allows.

