### PR TITLE
Cargo: rustls .22 -> .25, webpki 0.102.8 -> 0.103, rustls-platform-verifier 0.5 -> 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1203,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "aws-lc-rs",
  "brotli",
@@ -1262,15 +1262,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e012c45844a1790332c9386ed4ca3a06def221092eda277e6f079728f8ea99da"
+checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -1284,7 +1284,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1295,9 +1295,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ resolver = "2"
 
 [workspace.dependencies]
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
-webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = ["std"] }
+webpki = { package = "rustls-webpki", version = "0.103", default-features = false, features = ["std"] }
 libc = "0.2"
 log = "0.4.22"
-rustls-platform-verifier = "0.5"
+rustls-platform-verifier = "0.5.1"
 regex = "1.9.6"
 toml = { version = "0.6.0", default-features = false, features = ["parse"] }
 hickory-resolver = { version = "=0.25.0-alpha.4", features = ["dns-over-https-rustls", "webpki-roots"] }

--- a/librustls/Cargo.toml
+++ b/librustls/Cargo.toml
@@ -22,14 +22,14 @@ no_log_capture = []
 read_buf = ["rustls/read_buf"]
 capi = []
 ring = ["rustls/ring", "webpki/ring"]
-aws-lc-rs = ["rustls/aws-lc-rs", "webpki/aws_lc_rs"]
+aws-lc-rs = ["rustls/aws-lc-rs", "webpki/aws-lc-rs"]
 cert_compression = ["rustls/brotli", "rustls/zlib"]
-fips = ["aws-lc-rs", "rustls/fips"]
+fips = ["rustls/fips", "webpki/aws-lc-rs-fips"]
 prefer-post-quantum = ["aws-lc-rs", "rustls/prefer-post-quantum"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.22", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23.25", default-features = false, features = ["std", "tls12"] }
 webpki  = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/librustls/build.rs
+++ b/librustls/build.rs
@@ -8,7 +8,7 @@ use std::{env, fs, path::PathBuf};
 // because doing so would require a heavy-weight deserialization lib dependency
 // (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
 // by-hand parsing.
-const RUSTLS_CRATE_VERSION: &str = "0.23.22";
+const RUSTLS_CRATE_VERSION: &str = "0.23.25";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -291,7 +291,7 @@ pub(crate) fn cert_result_to_error(result: rustls_result) -> Error {
         CertOtherError => InvalidCertificate(CertificateError::Other(OtherError(Arc::from(
             Box::from(""),
         )))),
-        _ => rustls::Error::General("".into()),
+        _ => Error::General("".into()),
     }
 }
 
@@ -467,7 +467,7 @@ impl Display for rustls_result {
 
         match self {
             // These variants are local to this glue layer.
-            rustls_result::Ok => write!(f, "OK"),
+            Ok => write!(f, "OK"),
             Io => write!(f, "I/O error"),
             NullParameter => write!(f, "a parameter was NULL"),
             InvalidDnsNameError => write!(

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -438,7 +438,7 @@ pub(crate) fn map_error(input: Error) -> rustls_result {
     }
 }
 
-pub(crate) fn map_crl_error(err: CertRevocationListError) -> rustls_result {
+fn map_crl_error(err: CertRevocationListError) -> rustls_result {
     use rustls_result::*;
 
     match err {
@@ -463,7 +463,7 @@ pub(crate) fn map_crl_error(err: CertRevocationListError) -> rustls_result {
     }
 }
 
-pub(crate) fn map_ech_error(err: EncryptedClientHelloError) -> rustls_result {
+fn map_ech_error(err: EncryptedClientHelloError) -> rustls_result {
     use rustls_result::*;
 
     match err {

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -295,34 +295,6 @@ pub(crate) fn cert_result_to_error(result: rustls_result) -> Error {
     }
 }
 
-#[test]
-fn test_rustls_error() {
-    let mut buf = [0 as c_char; 512];
-    let mut n = 0;
-    rustls_result::rustls_error(0, &mut buf as *mut _, buf.len(), &mut n);
-    let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
-    assert_eq!(&output, "a parameter had an invalid value");
-
-    rustls_result::rustls_error(7000, &mut buf as *mut _, buf.len(), &mut n);
-    let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
-    assert_eq!(&output, "OK");
-
-    rustls_result::rustls_error(7101, &mut buf as *mut _, buf.len(), &mut n);
-    let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
-    assert_eq!(&output, "peer sent no certificates");
-}
-
-#[test]
-fn test_rustls_result_is_cert_error() {
-    assert!(!rustls_result::rustls_result_is_cert_error(0));
-    assert!(!rustls_result::rustls_result_is_cert_error(7000));
-
-    // Test CertificateError range.
-    for id in 7121..=7131 {
-        assert!(rustls_result::rustls_result_is_cert_error(id));
-    }
-}
-
 pub(crate) fn map_error(input: Error) -> rustls_result {
     use rustls::AlertDescription as alert;
     use rustls_result::*;
@@ -766,6 +738,39 @@ impl Display for rustls_result {
             InvalidEncryptedClientHelloSniRequired => {
                 Error::InvalidEncryptedClientHello(EncryptedClientHelloError::SniRequired).fmt(f)
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rustls_error() {
+        let mut buf = [0 as c_char; 512];
+        let mut n = 0;
+        rustls_result::rustls_error(0, &mut buf as *mut _, buf.len(), &mut n);
+        let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
+        assert_eq!(&output, "a parameter had an invalid value");
+
+        rustls_result::rustls_error(7000, &mut buf as *mut _, buf.len(), &mut n);
+        let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
+        assert_eq!(&output, "OK");
+
+        rustls_result::rustls_error(7101, &mut buf as *mut _, buf.len(), &mut n);
+        let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
+        assert_eq!(&output, "peer sent no certificates");
+    }
+
+    #[test]
+    fn test_rustls_result_is_cert_error() {
+        assert!(!rustls_result::rustls_result_is_cert_error(0));
+        assert!(!rustls_result::rustls_result_is_cert_error(7000));
+
+        // Test CertificateError range.
+        for id in 7121..=7131 {
+            assert!(rustls_result::rustls_result_is_cert_error(id));
         }
     }
 }

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -571,21 +571,7 @@ pub(crate) fn map_error(input: Error) -> rustls_result {
         Error::NoApplicationProtocol => NoApplicationProtocol,
         Error::BadMaxFragmentSize => BadMaxFragmentSize,
 
-        Error::InvalidCertificate(e) => match e {
-            CertificateError::BadEncoding => CertEncodingBad,
-            CertificateError::Expired => CertExpired,
-            CertificateError::NotValidYet => CertNotYetValid,
-            CertificateError::Revoked => CertRevoked,
-            CertificateError::UnhandledCriticalExtension => CertUnhandledCriticalExtension,
-            CertificateError::UnknownIssuer => CertUnknownIssuer,
-            CertificateError::UnknownRevocationStatus => CertUnknownRevocationStatus,
-            CertificateError::ExpiredRevocationList => CertExpiredRevocationList,
-            CertificateError::BadSignature => CertBadSignature,
-            CertificateError::NotValidForName => CertNotValidForName,
-            CertificateError::InvalidPurpose => CertInvalidPurpose,
-            CertificateError::ApplicationVerificationFailure => CertApplicationVerificationFailure,
-            _ => CertOtherError,
-        },
+        Error::InvalidCertificate(e) => map_invalid_certificate_error(e),
 
         Error::General(_) => General,
 
@@ -730,6 +716,26 @@ fn map_invalid_message_error(err: InvalidMessage) -> rustls_result {
         InvalidMessage::UnsupportedCurveType => MessageUnsupportedCurveType,
         InvalidMessage::UnsupportedKeyExchangeAlgorithm(_) => MessageUnsupportedCompression,
         _ => MessageInvalidOther,
+    }
+}
+
+fn map_invalid_certificate_error(err: CertificateError) -> rustls_result {
+    use rustls_result::*;
+
+    match err {
+        CertificateError::BadEncoding => CertEncodingBad,
+        CertificateError::Expired => CertExpired,
+        CertificateError::NotValidYet => CertNotYetValid,
+        CertificateError::Revoked => CertRevoked,
+        CertificateError::UnhandledCriticalExtension => CertUnhandledCriticalExtension,
+        CertificateError::UnknownIssuer => CertUnknownIssuer,
+        CertificateError::UnknownRevocationStatus => CertUnknownRevocationStatus,
+        CertificateError::ExpiredRevocationList => CertExpiredRevocationList,
+        CertificateError::BadSignature => CertBadSignature,
+        CertificateError::NotValidForName => CertNotValidForName,
+        CertificateError::InvalidPurpose => CertInvalidPurpose,
+        CertificateError::ApplicationVerificationFailure => CertApplicationVerificationFailure,
+        _ => CertOtherError,
     }
 }
 

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -562,30 +562,7 @@ pub(crate) fn map_error(input: Error) -> rustls_result {
         Error::UnsupportedNameType => UnsupportedNameType,
         Error::EncryptError => EncryptError,
 
-        Error::InvalidMessage(e) => match e {
-            InvalidMessage::HandshakePayloadTooLarge => MessageHandshakePayloadTooLarge,
-            InvalidMessage::CertificatePayloadTooLarge => MessageCertificatePayloadTooLarge,
-            InvalidMessage::InvalidCcs => MessageInvalidCcs,
-            InvalidMessage::InvalidContentType => MessageInvalidContentType,
-            InvalidMessage::InvalidCertificateStatusType => MessageInvalidCertStatusType,
-            InvalidMessage::InvalidCertRequest => MessageInvalidCertRequest,
-            InvalidMessage::InvalidDhParams => MessageInvalidDhParams,
-            InvalidMessage::InvalidEmptyPayload => MessageInvalidEmptyPayload,
-            InvalidMessage::InvalidKeyUpdate => MessageInvalidKeyUpdate,
-            InvalidMessage::InvalidServerName => MessageInvalidServerName,
-            InvalidMessage::MessageTooLarge => MessageTooLarge,
-            InvalidMessage::MessageTooShort => MessageTooShort,
-            InvalidMessage::MissingData(_) => MessageMissingData,
-            InvalidMessage::MissingKeyExchange => MessageMissingKeyExchange,
-            InvalidMessage::NoSignatureSchemes => MessageNoSignatureSchemes,
-            InvalidMessage::TrailingData(_) => MessageTrailingData,
-            InvalidMessage::UnexpectedMessage(_) => MessageUnexpectedMessage,
-            InvalidMessage::UnknownProtocolVersion => MessageUnknownProtocolVersion,
-            InvalidMessage::UnsupportedCompression => MessageUnsupportedCompression,
-            InvalidMessage::UnsupportedCurveType => MessageUnsupportedCurveType,
-            InvalidMessage::UnsupportedKeyExchangeAlgorithm(_) => MessageUnsupportedCompression,
-            _ => MessageInvalidOther,
-        },
+        Error::InvalidMessage(e) => map_invalid_message_error(e),
 
         Error::FailedToGetCurrentTime => FailedToGetCurrentTime,
         Error::FailedToGetRandomBytes => FailedToGetRandomBytes,
@@ -724,6 +701,35 @@ fn map_crl_error(err: CertRevocationListError) -> rustls_result {
             CertRevocationListUnsupportedRevocationReason
         }
         _ => CertRevocationListOtherError,
+    }
+}
+
+fn map_invalid_message_error(err: InvalidMessage) -> rustls_result {
+    use rustls_result::*;
+
+    match err {
+        InvalidMessage::HandshakePayloadTooLarge => MessageHandshakePayloadTooLarge,
+        InvalidMessage::CertificatePayloadTooLarge => MessageCertificatePayloadTooLarge,
+        InvalidMessage::InvalidCcs => MessageInvalidCcs,
+        InvalidMessage::InvalidContentType => MessageInvalidContentType,
+        InvalidMessage::InvalidCertificateStatusType => MessageInvalidCertStatusType,
+        InvalidMessage::InvalidCertRequest => MessageInvalidCertRequest,
+        InvalidMessage::InvalidDhParams => MessageInvalidDhParams,
+        InvalidMessage::InvalidEmptyPayload => MessageInvalidEmptyPayload,
+        InvalidMessage::InvalidKeyUpdate => MessageInvalidKeyUpdate,
+        InvalidMessage::InvalidServerName => MessageInvalidServerName,
+        InvalidMessage::MessageTooLarge => MessageTooLarge,
+        InvalidMessage::MessageTooShort => MessageTooShort,
+        InvalidMessage::MissingData(_) => MessageMissingData,
+        InvalidMessage::MissingKeyExchange => MessageMissingKeyExchange,
+        InvalidMessage::NoSignatureSchemes => MessageNoSignatureSchemes,
+        InvalidMessage::TrailingData(_) => MessageTrailingData,
+        InvalidMessage::UnexpectedMessage(_) => MessageUnexpectedMessage,
+        InvalidMessage::UnknownProtocolVersion => MessageUnknownProtocolVersion,
+        InvalidMessage::UnsupportedCompression => MessageUnsupportedCompression,
+        InvalidMessage::UnsupportedCurveType => MessageUnsupportedCurveType,
+        InvalidMessage::UnsupportedKeyExchangeAlgorithm(_) => MessageUnsupportedCompression,
+        _ => MessageInvalidOther,
     }
 }
 

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -729,15 +729,20 @@ fn map_invalid_certificate_error(err: CertificateError) -> rustls_result {
 
     match err {
         CertificateError::BadEncoding => CertEncodingBad,
-        CertificateError::Expired => CertExpired,
-        CertificateError::NotValidYet => CertNotYetValid,
+        CertificateError::Expired | CertificateError::ExpiredContext { .. } => CertExpired,
+        CertificateError::NotValidYet | CertificateError::NotValidYetContext { .. } => {
+            CertNotYetValid
+        }
         CertificateError::Revoked => CertRevoked,
         CertificateError::UnhandledCriticalExtension => CertUnhandledCriticalExtension,
         CertificateError::UnknownIssuer => CertUnknownIssuer,
         CertificateError::UnknownRevocationStatus => CertUnknownRevocationStatus,
-        CertificateError::ExpiredRevocationList => CertExpiredRevocationList,
+        CertificateError::ExpiredRevocationList
+        | CertificateError::ExpiredRevocationListContext { .. } => CertExpiredRevocationList,
         CertificateError::BadSignature => CertBadSignature,
-        CertificateError::NotValidForName => CertNotValidForName,
+        CertificateError::NotValidForName | CertificateError::NotValidForNameContext { .. } => {
+            CertNotValidForName
+        }
         CertificateError::InvalidPurpose => CertInvalidPurpose,
         CertificateError::ApplicationVerificationFailure => CertApplicationVerificationFailure,
         _ => CertOtherError,

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use libc::{c_char, c_uint, size_t};
 use rustls::server::VerifierBuilderError;
 use rustls::{
-    CertRevocationListError, CertificateError, EncryptedClientHelloError, Error, InconsistentKeys,
-    InvalidMessage,
+    AlertDescription, CertRevocationListError, CertificateError, EncryptedClientHelloError, Error,
+    InconsistentKeys, InvalidMessage,
 };
 
 use crate::panic::ffi_panic_boundary;
@@ -548,7 +548,6 @@ impl Display for rustls_result {
 }
 
 pub(crate) fn map_error(input: Error) -> rustls_result {
-    use rustls::AlertDescription as alert;
     use rustls_result::*;
 
     match input {
@@ -575,44 +574,7 @@ pub(crate) fn map_error(input: Error) -> rustls_result {
 
         Error::General(_) => General,
 
-        Error::AlertReceived(e) => match e {
-            alert::CloseNotify => AlertCloseNotify,
-            alert::UnexpectedMessage => AlertUnexpectedMessage,
-            alert::BadRecordMac => AlertBadRecordMac,
-            alert::DecryptionFailed => AlertDecryptionFailed,
-            alert::RecordOverflow => AlertRecordOverflow,
-            alert::DecompressionFailure => AlertDecompressionFailure,
-            alert::HandshakeFailure => AlertHandshakeFailure,
-            alert::NoCertificate => AlertNoCertificate,
-            alert::BadCertificate => AlertBadCertificate,
-            alert::UnsupportedCertificate => AlertUnsupportedCertificate,
-            alert::CertificateRevoked => AlertCertificateRevoked,
-            alert::CertificateExpired => AlertCertificateExpired,
-            alert::CertificateUnknown => AlertCertificateUnknown,
-            alert::IllegalParameter => AlertIllegalParameter,
-            alert::UnknownCA => AlertUnknownCA,
-            alert::AccessDenied => AlertAccessDenied,
-            alert::DecodeError => AlertDecodeError,
-            alert::DecryptError => AlertDecryptError,
-            alert::ExportRestriction => AlertExportRestriction,
-            alert::ProtocolVersion => AlertProtocolVersion,
-            alert::InsufficientSecurity => AlertInsufficientSecurity,
-            alert::InternalError => AlertInternalError,
-            alert::InappropriateFallback => AlertInappropriateFallback,
-            alert::UserCanceled => AlertUserCanceled,
-            alert::NoRenegotiation => AlertNoRenegotiation,
-            alert::MissingExtension => AlertMissingExtension,
-            alert::UnsupportedExtension => AlertUnsupportedExtension,
-            alert::CertificateUnobtainable => AlertCertificateUnobtainable,
-            alert::UnrecognisedName => AlertUnrecognisedName,
-            alert::BadCertificateStatusResponse => AlertBadCertificateStatusResponse,
-            alert::BadCertificateHashValue => AlertBadCertificateHashValue,
-            alert::UnknownPSKIdentity => AlertUnknownPSKIdentity,
-            alert::CertificateRequired => AlertCertificateRequired,
-            alert::NoApplicationProtocol => AlertNoApplicationProtocol,
-            alert::Unknown(_) => AlertUnknown,
-            _ => AlertUnknown,
-        },
+        Error::AlertReceived(e) => map_alert_error(e),
 
         Error::InvalidCertRevocationList(e) => map_crl_error(e),
 
@@ -662,6 +624,49 @@ pub(crate) fn map_verifier_builder_error(err: VerifierBuilderError) -> rustls_re
         }
         VerifierBuilderError::InvalidCrl(crl_err) => map_crl_error(crl_err),
         _ => rustls_result::General,
+    }
+}
+
+fn map_alert_error(alert: AlertDescription) -> rustls_result {
+    use rustls_result::*;
+
+    match alert {
+        AlertDescription::CloseNotify => AlertCloseNotify,
+        AlertDescription::UnexpectedMessage => AlertUnexpectedMessage,
+        AlertDescription::BadRecordMac => AlertBadRecordMac,
+        AlertDescription::DecryptionFailed => AlertDecryptionFailed,
+        AlertDescription::RecordOverflow => AlertRecordOverflow,
+        AlertDescription::DecompressionFailure => AlertDecompressionFailure,
+        AlertDescription::HandshakeFailure => AlertHandshakeFailure,
+        AlertDescription::NoCertificate => AlertNoCertificate,
+        AlertDescription::BadCertificate => AlertBadCertificate,
+        AlertDescription::UnsupportedCertificate => AlertUnsupportedCertificate,
+        AlertDescription::CertificateRevoked => AlertCertificateRevoked,
+        AlertDescription::CertificateExpired => AlertCertificateExpired,
+        AlertDescription::CertificateUnknown => AlertCertificateUnknown,
+        AlertDescription::IllegalParameter => AlertIllegalParameter,
+        AlertDescription::UnknownCA => AlertUnknownCA,
+        AlertDescription::AccessDenied => AlertAccessDenied,
+        AlertDescription::DecodeError => AlertDecodeError,
+        AlertDescription::DecryptError => AlertDecryptError,
+        AlertDescription::ExportRestriction => AlertExportRestriction,
+        AlertDescription::ProtocolVersion => AlertProtocolVersion,
+        AlertDescription::InsufficientSecurity => AlertInsufficientSecurity,
+        AlertDescription::InternalError => AlertInternalError,
+        AlertDescription::InappropriateFallback => AlertInappropriateFallback,
+        AlertDescription::UserCanceled => AlertUserCanceled,
+        AlertDescription::NoRenegotiation => AlertNoRenegotiation,
+        AlertDescription::MissingExtension => AlertMissingExtension,
+        AlertDescription::UnsupportedExtension => AlertUnsupportedExtension,
+        AlertDescription::CertificateUnobtainable => AlertCertificateUnobtainable,
+        AlertDescription::UnrecognisedName => AlertUnrecognisedName,
+        AlertDescription::BadCertificateStatusResponse => AlertBadCertificateStatusResponse,
+        AlertDescription::BadCertificateHashValue => AlertBadCertificateHashValue,
+        AlertDescription::UnknownPSKIdentity => AlertUnknownPSKIdentity,
+        AlertDescription::CertificateRequired => AlertCertificateRequired,
+        AlertDescription::NoApplicationProtocol => AlertNoApplicationProtocol,
+        AlertDescription::Unknown(_) => AlertUnknown,
+        _ => AlertUnknown,
     }
 }
 


### PR DESCRIPTION
Updates rustls to 0.23.25, webpki 0.102.8 to 0.103, and rustls-platform-verifier to 0.5.1 (for compat w/ the updated rustls/webpki deps).

Alongside this update, we tidy our features slightly:

* The webpki "aws_lc_rs" feature is replaced with "aws-lc-rs". The underscore variant was an early mistake we undid with 0.103.
* The rustls-ffi "fips" feature now activates "rustls/fips" and "webpki/aws-lc-rs-fips". This avoids having both aws-lc-sys and aws-lc-fips-sys in FIPS builds.

These updates introduce a few new `rustls::CertificateError::*` variants (with more context) that we take care to map to our existing `rustls_error` variants for the respective underlying cause. Some various `error.rs` tidying comes along for the ride.

Resolves https://github.com/rustls/rustls-ffi/issues/528