### PR TITLE
`rustls_error`: correct output buffer length handling

### DIFF
--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -235,7 +235,7 @@ impl rustls_result {
                 return;
             }
             let error_str = rustls_result::from(result).to_string();
-            let out_len = min(len - 1, error_str.len());
+            let out_len = min(len, error_str.len());
             unsafe {
                 std::ptr::copy_nonoverlapping(error_str.as_ptr() as *mut c_char, buf, out_len);
                 *out_n = out_len;
@@ -783,6 +783,13 @@ mod tests {
         rustls_result::rustls_error(7101, &mut buf as *mut _, buf.len(), &mut n);
         let output = String::from_utf8(buf[0..n].iter().map(|b| *b as u8).collect()).unwrap();
         assert_eq!(&output, "peer sent no certificates");
+    }
+
+    #[test]
+    fn test_rustls_error_into_empty_buffer() {
+        let mut n = 99;
+        rustls_result::rustls_error(0, &mut [] as *mut _, 0, &mut n);
+        assert_eq!(n, 0);
     }
 
     #[test]

--- a/librustls/src/userdata.rs
+++ b/librustls/src/userdata.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::ffi::c_void;
+use std::ptr;
 
 use crate::log::rustls_log_callback;
 
@@ -75,7 +76,7 @@ impl UserdataGuard {
                     |mut v| {
                         let u = v.pop().ok_or(UserdataError::EmptyStack)?;
                         self.data = None;
-                        if u.userdata == expected_data {
+                        if ptr::eq(u.userdata, expected_data) {
                             Ok(())
                         } else {
                             Err(UserdataError::WrongData)


### PR DESCRIPTION
This function does not need to keep an output buffer byte spare to zero-terminate the string, as it doesn't terminate the output.  So don't do that.

As an effect, this fixes the integer underflow followed by buffer overflow for `rustls_error` with an empty output buffer. `test_rustls_error_into_empty_buffer` is a regression test for that case.

(found while reviewing a use of this function in curl)