### PR TITLE
Build artifacts on ubuntu-22

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -31,7 +31,7 @@ jobs:
           curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
           powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
 
-      - name: Build rusts-ffi
+      - name: Build rustls-ffi
         run: |
           cargo cinstall --locked --target x86_64-pc-windows-msvc --features cert_compression --release --prefix dist
 
@@ -62,7 +62,7 @@ jobs:
         run: |
           curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
 
-      - name: Build rusts-ffi
+      - name: Build rustls-ffi
         # The Ubuntu 20.04 GCC is too old to build aws-lc.
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
         env:
@@ -129,7 +129,7 @@ jobs:
           curl -L $LINK/$CARGO_C_FILE -o cargo-c-macos.zip
           unzip cargo-c-macos.zip -d ~/.cargo/bin
 
-      - name: Build rusts-ffi (arm64)
+      - name: Build rustls-ffi (arm64)
         run: |
           cargo cinstall --target aarch64-apple-darwin --locked --features cert_compression --release --prefix arm64-dist
 
@@ -146,7 +146,7 @@ jobs:
           name: rustls-ffi-arm64-macos
           path: arm64-dist
 
-      - name: Build rusts-ffi (x86_64)
+      - name: Build rustls-ffi (x86_64)
         run: |
           cargo cinstall --target x86_64-apple-darwin --locked --features cert_compression --release --prefix x86-dist
 

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -46,7 +46,7 @@ jobs:
 
   linux-binaries:
     name: Linux (x86_64 GNU)
-    runs-on: ubuntu-20.04 # x86_64. Using older Ubuntu for greater GLIBC compat.
+    runs-on: ubuntu-22.04 # x86_64.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,11 +63,6 @@ jobs:
           curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
 
       - name: Build rustls-ffi
-        # The Ubuntu 20.04 GCC is too old to build aws-lc.
-        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
-        env:
-          CC: clang
-          CXX: clang
         run: |
           cargo cinstall --locked --target x86_64-unknown-linux-gnu --features cert_compression --release --prefix dist
 
@@ -82,7 +77,7 @@ jobs:
 
   linux-deb:
     name: Linux (x86-64 GNU Deb)
-    runs-on: ubuntu-20.04 # x86_64. Using older Ubuntu for greater GLIBC compat.
+    runs-on: ubuntu-22.04 # x86_64.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -275,7 +270,7 @@ jobs:
     needs: [ linux-deb ]
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-20.04 ]
+        os: [ ubuntu-latest, ubuntu-22.04 ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
There are comments here motivating the choice of 20.04 as being
an older (= more compatible) glibc.  It is unclear whether that
is a current or vestigial requirement. (Thoughts @cpu ?)

If it's a current requirement, we can instead continue to build on ubuntu-20.04
by using docker hosted on ubuntu-latest.