### PR TITLE
Skip push CI for most branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ permissions:
 
 on:
   push:
+    branches: ['main', 'rel-*', 'ci/*']
   pull_request:
   merge_group:
   schedule:


### PR DESCRIPTION
My impression is that the common practice of running CI for both `push` and `pull_request` can be pretty expensive/slow while adding almost no value. Restrict branch CI to `main` and branches prefixed with `rel-` or `ci/`.