### PR TITLE
librustls: rustls 0.23.28 -> 0.23.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
  "brotli",
@@ -1281,9 +1281,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/librustls/Cargo.toml
+++ b/librustls/Cargo.toml
@@ -29,7 +29,7 @@ prefer-post-quantum = ["aws-lc-rs", "rustls/prefer-post-quantum"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.28", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23.29", default-features = false, features = ["std", "tls12"] }
 webpki  = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/librustls/build.rs
+++ b/librustls/build.rs
@@ -8,7 +8,7 @@ use std::{env, fs, path::PathBuf};
 // because doing so would require a heavy-weight deserialization lib dependency
 // (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
 // by-hand parsing.
-const RUSTLS_CRATE_VERSION: &str = "0.23.28";
+const RUSTLS_CRATE_VERSION: &str = "0.23.29";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/librustls/src/error.rs
+++ b/librustls/src/error.rs
@@ -344,7 +344,7 @@ impl Display for rustls_result {
             CertUnknownIssuer => Error::InvalidCertificate(CertificateError::UnknownIssuer).fmt(f),
             CertBadSignature => Error::InvalidCertificate(CertificateError::BadSignature).fmt(f),
             CertUnsupportedSignatureAlgorithm => {
-                Error::InvalidCertificate(CertificateError::UnsupportedSignatureAlgorithm).fmt(f)
+                write!(f, "unsupported certificate signature algorithm")
             }
             CertNotValidForName => {
                 Error::InvalidCertificate(CertificateError::NotValidForName).fmt(f)
@@ -492,10 +492,9 @@ impl Display for rustls_result {
             CertRevocationListBadSignature => {
                 Error::InvalidCertRevocationList(CertRevocationListError::BadSignature).fmt(f)
             }
-            CertRevocationListUnsupportedSignatureAlgorithm => Error::InvalidCertRevocationList(
-                CertRevocationListError::UnsupportedSignatureAlgorithm,
-            )
-            .fmt(f),
+            CertRevocationListUnsupportedSignatureAlgorithm => {
+                write!(f, "unsupported CRL signature algorithm")
+            }
             CertRevocationListInvalidCrlNumber => {
                 Error::InvalidCertRevocationList(CertRevocationListError::InvalidCrlNumber).fmt(f)
             }
@@ -684,7 +683,7 @@ fn map_crl_error(err: CertRevocationListError) -> rustls_result {
 
     match err {
         CertRevocationListError::BadSignature => CertRevocationListBadSignature,
-        CertRevocationListError::UnsupportedSignatureAlgorithm => {
+        CertRevocationListError::UnsupportedSignatureAlgorithmContext { .. } => {
             CertRevocationListUnsupportedSignatureAlgorithm
         }
         CertRevocationListError::InvalidCrlNumber => CertRevocationListInvalidCrlNumber,
@@ -752,7 +751,9 @@ fn map_invalid_certificate_error(err: CertificateError) -> rustls_result {
         CertificateError::ExpiredRevocationList
         | CertificateError::ExpiredRevocationListContext { .. } => CertExpiredRevocationList,
         CertificateError::BadSignature => CertBadSignature,
-        CertificateError::UnsupportedSignatureAlgorithm => CertUnsupportedSignatureAlgorithm,
+        CertificateError::UnsupportedSignatureAlgorithmContext { .. } => {
+            CertUnsupportedSignatureAlgorithm
+        }
         CertificateError::NotValidForName | CertificateError::NotValidForNameContext { .. } => {
             CertNotValidForName
         }


### PR DESCRIPTION
Updates rustls-ffi from 0.23.28 to [0.23.29](https://github.com/rustls/rustls/releases/tag/v/0.23.29).

Notably this update [marked a couple error enum variants deprecated](https://github.com/rustls/rustls/pull/2531) while introducing richer context variants. We don't have a nice way to expose additional error context at this time and so make the minimum required changes to avoid the deprecation warnings.