### PR TITLE
librustls: update rustls 0.23.29 -> 0.23.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "brotli",

--- a/librustls/Cargo.toml
+++ b/librustls/Cargo.toml
@@ -30,7 +30,7 @@ prefer-post-quantum = ["aws-lc-rs", "rustls/prefer-post-quantum"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.31", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "=0.23.31", default-features = false, features = ["std", "tls12"] }
 webpki  = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/librustls/Cargo.toml
+++ b/librustls/Cargo.toml
@@ -30,7 +30,7 @@ prefer-post-quantum = ["aws-lc-rs", "rustls/prefer-post-quantum"]
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in build.rs
-rustls = { version = "0.23.29", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23.31", default-features = false, features = ["std", "tls12"] }
 webpki  = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/librustls/build.rs
+++ b/librustls/build.rs
@@ -8,7 +8,7 @@ use std::{env, fs, path::PathBuf};
 // because doing so would require a heavy-weight deserialization lib dependency
 // (and it couldn't be a _dev_ dep for use in a build script) or doing brittle
 // by-hand parsing.
-const RUSTLS_CRATE_VERSION: &str = "0.23.29";
+const RUSTLS_CRATE_VERSION: &str = "0.23.31";
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/librustls/tests/rustls_version.rs
+++ b/librustls/tests/rustls_version.rs
@@ -51,7 +51,8 @@ fn rustls_version_match() {
         // Handle the `rustls = "x.y.z"` case
         None => rustls_dep.as_str(),
     }
-    .expect("missing rustls dependency version");
+    .expect("missing rustls dependency version")
+    .trim_start_matches("=");
 
     // Assert that rustls_version() returns a string of the form:
     //   $CRATE_NAME/$CRATE_VERSION/rustls/$RUSTLS_VERSION


### PR DESCRIPTION
There were no upstream changes that motivate API updates in this crate:

* [0.23.31](https://github.com/rustls/rustls/releases/tag/v%2F0.23.31)
* [0.23.30](https://github.com/rustls/rustls/releases/tag/v%2F0.23.30)