### PR TITLE
librustls: fix typo in server cert verifier builder docs

### DIFF
--- a/librustls/src/rustls.h
+++ b/librustls/src/rustls.h
@@ -2689,7 +2689,7 @@ void rustls_web_pki_client_cert_verifier_builder_free(struct rustls_web_pki_clie
 
 /**
  * Create a `rustls_web_pki_server_cert_verifier_builder` using the process-wide default
- * crypto provider. Caller owns the memory and may free it with
+ * crypto provider.
  *
  * Caller owns the memory and may free it with `rustls_web_pki_server_cert_verifier_builder_free`,
  * regardless of whether `rustls_web_pki_server_cert_verifier_builder_build` was called.

--- a/librustls/src/verifier.rs
+++ b/librustls/src/verifier.rs
@@ -409,7 +409,7 @@ pub(crate) struct ServerCertVerifierBuilder {
 
 impl ServerCertVerifierBuilder {
     /// Create a `rustls_web_pki_server_cert_verifier_builder` using the process-wide default
-    /// crypto provider. Caller owns the memory and may free it with
+    /// crypto provider.
     ///
     /// Caller owns the memory and may free it with `rustls_web_pki_server_cert_verifier_builder_free`,
     /// regardless of whether `rustls_web_pki_server_cert_verifier_builder_build` was called.


### PR DESCRIPTION
Small typo fix I noticed checking the docs for something. The removed sentence fragment is incomplete, and is covered by the next paragraph.