### PR TITLE
Bump macos versions for artifacts

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -169,9 +169,9 @@ jobs:
             artifact: rustls-ffi-x86_64-windows
           - os: ubuntu-latest
             artifact: rustls-ffi-x86_64-linux-gnu
-          - os: macos-14
+          - os: macos-15
             artifact: rustls-ffi-arm64-macos
-          - os: macos-13
+          - os: macos-15-intel
             artifact: rustls-ffi-x86_64-macos
     steps:
       - name: Checkout sources


### PR DESCRIPTION
macos-13 runners are deprecated as of 8th December: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

The Intel runner is moved to macos-15-intel, which is the final Intel macos platform that actions supports.  The arm64 runner is updated to match.