### PR TITLE
ci: adjust powershell steps to stop on error

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -24,12 +24,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-c
+        shell: pwsh
         env:
           LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
           CARGO_C_FILE: cargo-c-windows-msvc.zip
         run: |
+          $ErrorActionPreference = 'Stop'
           curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
-          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+          Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force
 
       - name: Build rustls-ffi
         run: |

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -47,12 +47,14 @@ jobs:
 
       - name: Install cargo-c (Windows)
         if: runner.os == 'Windows'
+        shell: pwsh
         env:
           LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
           CARGO_C_FILE: cargo-c-windows-msvc.zip
         run: |
+          $ErrorActionPreference = 'Stop'
           curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
-          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+          Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force
 
       - name: Setup cmake build
         run: |
@@ -103,12 +105,14 @@ jobs:
 
       - name: Install cargo-c (Windows)
         if: runner.os == 'Windows'
+        shell: pwsh
         env:
           LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
           CARGO_C_FILE: cargo-c-windows-msvc.zip
         run: |
+          $ErrorActionPreference = 'Stop'
           curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
-          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+          Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force
 
       - name: Setup cmake build
         run: |
@@ -164,12 +168,14 @@ jobs:
           unzip cargo-c-macos.zip -d ~/.cargo/bin
       - name: Install cargo-c (Windows)
         if: matrix.os == 'windows-latest'
+        shell: pwsh
         env:
           LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
           CARGO_C_FILE: cargo-c-windows-msvc.zip
         run: |
+          $ErrorActionPreference = 'Stop'
           curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
-          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+          Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force
       - name: Setup cmake build
         run: |
           cmake ${{ 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -248,12 +248,14 @@ jobs:
 
       # Note: must use cargo-c 0.10.7+ for dynamic linking support on Windows.
       - name: Install cargo-c
+        shell: pwsh
         env:
           LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
           CARGO_C_FILE: cargo-c-windows-msvc.zip
         run: |
+          $ErrorActionPreference = 'Stop'
           curl -L "$env:LINK/$env:CARGO_C_FILE" -o cargo-c-windows-msvc.zip
-          powershell -Command "Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force"
+          Expand-Archive -Path cargo-c-windows-msvc.zip -DestinationPath $env:USERPROFILE\\.cargo\\bin -Force
 
       - name: Configure CMake
         run: cmake -DCRYPTO_PROVIDER="${{ matrix.crypto }}" -DCERT_COMPRESSION="${{ matrix.cert_compression }}" -DPREFER_POST_QUANTUM="${{ matrix.prefer-pq }}" -DDYN_LINK="${{ matrix.dyn_link }}" -S librustls -B build


### PR DESCRIPTION
Apparently this isn't the default :-S At the same time, just switch the shell outright to `pwsh` instead of invoking it just for one command.