### PR TITLE
Prepare 0.15.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.15.2 (2026-04-15)
+
+This is a minor release with two security fixes. It also updates `rustls` to
+[0.23.38](https://github.com/rustls/rustls/releases/tag/v%2F0.23.38).
+
+### Security
+
+This update addresses
+[RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098.html) and 
+[RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html);
+two security issues affecting name constraint checking with the webpki
+certificate verifiers. Both issues are reachable only after signature
+verification and require misissuance to exploit.
+
+These low-impact vulnerabilities only affect users of the
+`rustls_web_pki_[server|client]_cert_verifier_builder` APIs.
+
+### Added
+
+* `rustls_client_config_builder_set_check_selected_alpn()`
+  * Allows configuring a to-be-built client config to allow skipping a check
+    that the server's selected ALPN was in the list offered by the client. This
+    defaults to true, matching the behavior before the option to skip the check
+    was available.
+
 ## 0.15.1 (2026-03-13)
 
 This is a minor release with one security fix. It updates `rustls` to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-ffi"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "brotli"
@@ -752,9 +752,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -976,9 +976,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1175,9 +1175,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1434,9 +1434,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/librustls/Cargo.toml
+++ b/librustls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustls-ffi"
 # Keep in sync with defines in cbindgen.toml
-version = "0.15.1"
+version = "0.15.2"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "../README-crates.io.md"
 description = "Rustls bindings for non-Rust languages"

--- a/librustls/cbindgen.toml
+++ b/librustls/cbindgen.toml
@@ -5,7 +5,7 @@ after_includes = """
 
 #define RUSTLS_VERSION_MAJOR 0
 #define RUSTLS_VERSION_MINOR 15
-#define RUSTLS_VERSION_PATCH 1
+#define RUSTLS_VERSION_PATCH 2
 
 /**
  * This gives each version part 8 bits, and leaves the 8 least significant bits

--- a/librustls/src/rustls.h
+++ b/librustls/src/rustls.h
@@ -9,7 +9,7 @@
 
 #define RUSTLS_VERSION_MAJOR 0
 #define RUSTLS_VERSION_MINOR 15
-#define RUSTLS_VERSION_PATCH 1
+#define RUSTLS_VERSION_PATCH 2
 
 /**
  * This gives each version part 8 bits, and leaves the 8 least significant bits


### PR DESCRIPTION
This is a minor release with two security fixes. It also updates `rustls` to [0.23.38](https://github.com/rustls/rustls/releases/tag/v%2F0.23.38).

This update addresses [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098.html) and [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099.html); two security issues affecting name constraint checking with the webpki certificate verifiers. Both issues are reachable only after signature verification and require misissuance to exploit.