### PR TITLE
librustls: switch common.c's read_file to binary mode

### DIFF
--- a/librustls/tests/common.c
+++ b/librustls/tests/common.c
@@ -267,7 +267,7 @@ log_cb(void *userdata, const rustls_log_params *params)
 demo_result
 read_file(const char *filename, char *buf, const size_t buflen, size_t *n)
 {
-  FILE *f = fopen(filename, "r");
+  FILE *f = fopen(filename, "rb");
   if(f == NULL) {
     LOG("opening %s: %s", filename, strerror(errno));
     return DEMO_ERROR;


### PR DESCRIPTION
Prior to ECH support all of the consumers of the common `read_file()` helper were loading text data (PEM encoded certs, keys, and CRLs). However, for ECH, we're loading a binary serialized ECH Config List structure.

On Windows specifically if we don't `fopen()` with mode==rb instead of mode==r we open the file in [_text mode_](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170#generic-text-routine-mappings), and certain byte sequences are translated: 

> In text mode, carriage return-line feed (CRLF) combinations are translated into single line feed (LF) characters on input,
> ...
> When a Unicode stream-I/O function operates in text mode (the default), the source or destination stream is assumed to be a sequence of multibyte characters. Therefore, the Unicode stream-input functions convert multibyte characters to wide characters (as if by a call to the mbtowc function).

This in turn breaks ECH config deserialization when the config data happens to have those byte sequences. This manifests as a Windows-only flake of the ECH example unit test in CI, with the error:

> client[8988]: failed to configure ECH with any provided config files

The fix is simple: we can use 'rb' as the mode in `read_file()` and avoid this issue.

Resolves https://github.com/rustls/rustls-ffi/issues/514

